### PR TITLE
Add rider_stats.py - calculate rider stats from daily log

### DIFF
--- a/data/riders/stats.json
+++ b/data/riders/stats.json
@@ -1,0 +1,62 @@
+{
+  "asOf": "2026-04-03",
+  "entryNumber": 1,
+  "riders": {
+    "justin": {
+      "totalDistanceCapped": 0,
+      "dailyAverageCapped": 0,
+      "longestDay": 0,
+      "shortestDay": 0,
+      "daysBelowThreeKm": 1,
+      "consistencyStdev": 0,
+      "bestThreeDayCombo": 0,
+      "recentFiveDayAverage": 0,
+      "distanceRemaining": 185,
+      "estimatedDaysToFinish": null,
+      "estimatedFinishDate": null,
+      "place": 1
+    },
+    "marian": {
+      "totalDistanceCapped": 0,
+      "dailyAverageCapped": 0,
+      "longestDay": 0,
+      "shortestDay": 0,
+      "daysBelowThreeKm": 1,
+      "consistencyStdev": 0,
+      "bestThreeDayCombo": 0,
+      "recentFiveDayAverage": 0,
+      "distanceRemaining": 185,
+      "estimatedDaysToFinish": null,
+      "estimatedFinishDate": null,
+      "place": 2
+    },
+    "nan": {
+      "totalDistanceCapped": 0,
+      "dailyAverageCapped": 0,
+      "longestDay": 0,
+      "shortestDay": 0,
+      "daysBelowThreeKm": 1,
+      "consistencyStdev": 0,
+      "bestThreeDayCombo": 0,
+      "recentFiveDayAverage": 0,
+      "distanceRemaining": 185,
+      "estimatedDaysToFinish": null,
+      "estimatedFinishDate": null,
+      "place": 3
+    },
+    "wally": {
+      "totalDistanceCapped": 0,
+      "dailyAverageCapped": 0,
+      "longestDay": 0,
+      "shortestDay": 0,
+      "daysBelowThreeKm": 1,
+      "consistencyStdev": 0,
+      "bestThreeDayCombo": 0,
+      "recentFiveDayAverage": 0,
+      "distanceRemaining": 185,
+      "estimatedDaysToFinish": null,
+      "estimatedFinishDate": null,
+      "place": 4
+    }
+  }
+}

--- a/processing/rider_stats.py
+++ b/processing/rider_stats.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Calculate rider stats from daily-log.json and output stats.json."""
+
+import argparse
+import json
+import os
+import statistics
+from datetime import datetime, timedelta
+
+
+def load_json(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def calculate_stats(daily_log, rider_config):
+    """Calculate all stats for all riders."""
+    riders = {r["id"]: r for r in rider_config["riders"]}
+    total_distance = rider_config["totalDistance"]
+    daily_cap = rider_config["dailyCap"]
+    entries = daily_log["entries"]
+
+    if not entries:
+        return {"asOf": datetime.now().strftime("%Y-%m-%d"), "entryNumber": 0, "riders": {}}
+
+    # Sort entries by date
+    entries = sorted(entries, key=lambda e: e["date"])
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    result = {
+        "asOf": today,
+        "entryNumber": len(entries),
+        "riders": {},
+    }
+
+    for rider_id in riders:
+        daily_dists = []
+        for entry in entries:
+            dist = entry.get("distances", {}).get(rider_id, 0)
+            daily_dists.append(dist)
+
+        if not daily_dists:
+            continue
+
+        # --- Stats using ACTUAL daily distances (uncapped) ---
+        nonzero_dists = [d for d in daily_dists if d > 0]
+
+        longest_day = max(daily_dists) if daily_dists else 0
+        shortest_day = min(nonzero_dists) if nonzero_dists else 0
+
+        # Best 3-day combo
+        best_three_day = 0
+        if len(daily_dists) >= 3:
+            for i in range(len(daily_dists) - 2):
+                combo = sum(daily_dists[i:i + 3])
+                best_three_day = max(best_three_day, combo)
+        else:
+            best_three_day = sum(daily_dists)
+
+        # Most recent 5-day average
+        recent_five = daily_dists[-5:] if len(daily_dists) >= 5 else daily_dists
+        recent_five_avg = statistics.mean(recent_five) if recent_five else 0
+
+        # Consistency (std dev of daily distances)
+        consistency_stdev = statistics.stdev(daily_dists) if len(daily_dists) >= 2 else 0
+
+        # Days below 3km
+        days_below_three = sum(1 for d in daily_dists if d < 3)
+
+        # --- Stats using CAPPED daily distances (max daily_cap per day) ---
+        capped_dists = [min(d, daily_cap) for d in daily_dists]
+        total_capped = sum(capped_dists)
+        daily_avg_capped = statistics.mean(capped_dists) if capped_dists else 0
+        distance_remaining = max(0, total_distance - total_capped)
+
+        if daily_avg_capped > 0:
+            est_days_to_finish = distance_remaining / daily_avg_capped
+            est_finish_date = (datetime.now() + timedelta(days=est_days_to_finish)).strftime("%Y-%m-%d")
+        else:
+            est_days_to_finish = None
+            est_finish_date = None
+
+        result["riders"][rider_id] = {
+            "totalDistanceCapped": round(total_capped, 1),
+            "dailyAverageCapped": round(daily_avg_capped, 2),
+            "longestDay": round(longest_day, 1),
+            "shortestDay": round(shortest_day, 1),
+            "daysBelowThreeKm": days_below_three,
+            "consistencyStdev": round(consistency_stdev, 2),
+            "bestThreeDayCombo": round(best_three_day, 1),
+            "recentFiveDayAverage": round(recent_five_avg, 2),
+            "distanceRemaining": round(distance_remaining, 1),
+            "estimatedDaysToFinish": round(est_days_to_finish) if est_days_to_finish else None,
+            "estimatedFinishDate": est_finish_date,
+        }
+
+    # Calculate rankings by total capped distance
+    ranked = sorted(
+        result["riders"].items(),
+        key=lambda x: x[1]["totalDistanceCapped"],
+        reverse=True,
+    )
+    for place, (rider_id, stats) in enumerate(ranked, 1):
+        stats["place"] = place
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate rider stats")
+    parser.add_argument("--daily-log", default="data/riders/daily-log.json")
+    parser.add_argument("--rider-config", default="data/riders/rider-config.json")
+    parser.add_argument("--output", default="data/riders/stats.json")
+    args = parser.parse_args()
+
+    daily_log = load_json(args.daily_log)
+    rider_config = load_json(args.rider_config)
+
+    stats = calculate_stats(daily_log, rider_config)
+
+    with open(args.output, "w") as f:
+        json.dump(stats, f, indent=2)
+
+    print(f"Stats calculated as of {stats['asOf']} ({stats['entryNumber']} log entries)")
+    print()
+
+    for rider_id, s in stats["riders"].items():
+        rider_name = next(r["name"] for r in rider_config["riders"] if r["id"] == rider_id)
+        print(f"  #{s['place']} {rider_name}:")
+        print(f"    Total (capped): {s['totalDistanceCapped']} km / {rider_config['totalDistance']} km")
+        print(f"    Remaining: {s['distanceRemaining']} km")
+        print(f"    Longest day: {s['longestDay']} km | Best 3-day: {s['bestThreeDayCombo']} km")
+        if s['estimatedFinishDate']:
+            print(f"    Est. finish: {s['estimatedFinishDate']} (~{s['estimatedDaysToFinish']} days)")
+        print()
+
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `processing/rider_stats.py` which calculates all rider statistics from the daily log
- **Uncapped stats:** longest/shortest day, best 3-day combo, recent 5-day average, consistency (stdev), days below 3km
- **Capped stats (2km/day max):** total distance, daily average, distance remaining, estimated days to finish, estimated finish date
- Rankings by total capped distance
- Outputs `data/riders/stats.json`
- Currently shows zeros since daily-log.json has no real data yet

## Test plan

- [ ] Run `processing/.venv/bin/python processing/rider_stats.py` and verify it completes
- [ ] Check `data/riders/stats.json` has entries for all 4 riders
- [ ] Add some test data to `data/riders/daily-log.json` and re-run to verify calculations

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)