### PR TITLE
Rolling daily cap with carry-over and actual daily average

### DIFF
--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -50,7 +50,13 @@
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Daily avg</td>
+            <td class="py-1.5 pr-2 text-gray-500">Daily avg (actual)</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center py-1.5 px-2 font-mono">
+              {{ r.stats.dailyAverageActual }} km
+            </td>
+          </tr>
+          <tr>
+            <td class="py-1.5 pr-2 text-gray-500">Daily avg (capped)</td>
             <td v-for="r in rankedRiders" :key="r.id" class="text-center py-1.5 px-2 font-mono">
               {{ r.stats.dailyAverageCapped }} km
             </td>

--- a/processing/rider_stats.py
+++ b/processing/rider_stats.py
@@ -67,8 +67,20 @@ def calculate_stats(daily_log, rider_config):
         # Days below 3km
         days_below_three = sum(1 for d in daily_dists if d < 3)
 
-        # --- Stats using CAPPED daily distances (max daily_cap per day) ---
-        capped_dists = [min(d, daily_cap) for d in daily_dists]
+        # --- Daily average using ACTUAL distances ---
+        daily_avg_actual = statistics.mean(daily_dists) if daily_dists else 0
+
+        # --- Stats using CAPPED daily distances with carry-over ---
+        # Cap is 2km/day, but unused cap rolls to the next day.
+        # E.g., ride 1km on day 1 -> day 2 cap is 3km (2 + 1 unused)
+        capped_dists = []
+        carry = 0.0
+        for d in daily_dists:
+            available = daily_cap + carry
+            credited = min(d, available)
+            capped_dists.append(credited)
+            carry = available - credited
+
         total_capped = sum(capped_dists)
         daily_avg_capped = statistics.mean(capped_dists) if capped_dists else 0
         distance_remaining = max(0, total_distance - total_capped)
@@ -82,6 +94,7 @@ def calculate_stats(daily_log, rider_config):
 
         result["riders"][rider_id] = {
             "totalDistanceCapped": round(total_capped, 1),
+            "dailyAverageActual": round(daily_avg_actual, 2),
             "dailyAverageCapped": round(daily_avg_capped, 2),
             "longestDay": round(longest_day, 1),
             "shortestDay": round(shortest_day, 1),


### PR DESCRIPTION
## Summary

- **Rolling cap (#34):** Unused daily cap now carries over. If a rider does 1km on day 1 (cap 2km), day 2 cap is 3km (2 + 1 unused). Previously each day was capped independently.
- **Actual daily average (#37):** Added `dailyAverageActual` stat using raw distances. Dashboard now shows both actual and capped averages.

## Example of rolling cap

```
Day 1: rides 1km, cap=2.0, credited=1.0, carry=1.0
Day 2: rides 4km, cap=3.0, credited=3.0, carry=0.0
Day 3: rides 0.5km, cap=2.0, credited=0.5, carry=1.5
```

## Test plan

- [ ] Run `processing/.venv/bin/python processing/rider_stats.py` and verify stats.json has `dailyAverageActual`
- [ ] Add multi-day test data to daily-log.json and verify carry-over works
- [ ] Check dashboard shows both "Daily avg (actual)" and "Daily avg (capped)" rows

Closes #34, closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)