### PR TITLE
Homepage with full route map, latest entries, rider standings

### DIFF
--- a/components/RouteOverviewMap.vue
+++ b/components/RouteOverviewMap.vue
@@ -1,0 +1,120 @@
+<template>
+  <ClientOnly>
+    <div
+      ref="mapContainer"
+      style="width:100%;height:500px"
+      class="rounded-lg overflow-hidden shadow-sm"
+    />
+    <template #fallback>
+      <div class="w-full h-[500px] rounded-lg bg-gray-200 flex items-center justify-center text-gray-500">
+        Loading map...
+      </div>
+    </template>
+  </ClientOnly>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import 'leaflet/dist/leaflet.css'
+
+const props = defineProps({
+  segments: { type: Array, default: () => [] },
+  routeCoords: { type: Array, default: () => [] },
+  publishedSegments: { type: Array, default: () => [] }
+})
+
+const mapContainer = ref(null)
+let mapInitialized = false
+
+watch(mapContainer, async (el) => {
+  if (!el || mapInitialized) return
+  mapInitialized = true
+
+  const leafletModule = await import('leaflet')
+  const L = leafletModule.default || leafletModule
+
+  const map = L.map(el, { scrollWheelZoom: false }).setView([45.35, 1.85], 10)
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    maxZoom: 18
+  }).addTo(map)
+
+  if (props.routeCoords.length < 2) return
+
+  // Draw each segment, colored by published status
+  const publishedSet = new Set(props.publishedSegments)
+  let cumDist = 0
+  let segIdx = 0
+  let segCoords = []
+  const segBounds = []
+
+  for (let i = 0; i < props.routeCoords.length; i++) {
+    if (i > 0) {
+      const [lng1, lat1] = [props.routeCoords[i - 1][0], props.routeCoords[i - 1][1]]
+      const [lng2, lat2] = [props.routeCoords[i][0], props.routeCoords[i][1]]
+      cumDist += haversine(lat1, lng1, lat2, lng2)
+    }
+
+    const seg = props.segments[segIdx]
+    if (!seg) break
+
+    const kmDist = cumDist / 1000
+    segCoords.push([props.routeCoords[i][1], props.routeCoords[i][0]])
+
+    if (kmDist >= seg.km_end || i === props.routeCoords.length - 1) {
+      const isPublished = publishedSet.has(seg.segment)
+      const line = L.polyline(segCoords, {
+        color: isPublished ? '#8B2500' : '#d1d5db',
+        weight: isPublished ? 4 : 3,
+        opacity: isPublished ? 0.9 : 0.5
+      }).addTo(map)
+
+      if (isPublished) {
+        const title = seg.towns?.length ? seg.towns[0] : `Segment ${seg.segment}`
+        line.bindPopup(`<b>Segment ${seg.segment}</b><br>${title}<br>Km ${seg.km_start}-${seg.km_end}`)
+      }
+
+      segBounds.push(...segCoords)
+      segCoords = [segCoords[segCoords.length - 1]]
+      segIdx++
+    }
+  }
+
+  // Fit to route bounds
+  if (segBounds.length > 1) {
+    map.fitBounds(L.latLngBounds(segBounds), { padding: [20, 20] })
+  }
+
+  // Start and end markers
+  const first = props.segments[0]
+  const last = props.segments[props.segments.length - 1]
+  if (first && last) {
+    L.marker([first.start_lat, first.start_lng], {
+      icon: L.divIcon({
+        html: '<div style="background:#16a34a;color:white;font-size:10px;font-weight:bold;padding:2px 6px;border-radius:4px;white-space:nowrap;box-shadow:0 1px 3px rgba(0,0,0,0.3)">Malemort</div>',
+        className: '',
+        iconAnchor: [0, 12]
+      })
+    }).addTo(map)
+
+    L.marker([last.end_lat, last.end_lng], {
+      icon: L.divIcon({
+        html: '<div style="background:#dc2626;color:white;font-size:10px;font-weight:bold;padding:2px 6px;border-radius:4px;white-space:nowrap;box-shadow:0 1px 3px rgba(0,0,0,0.3)">Ussel</div>',
+        className: '',
+        iconAnchor: [0, 12]
+      })
+    }).addTo(map)
+  }
+})
+
+function haversine(lat1, lon1, lat2, lon2) {
+  const R = 6371000
+  const toRad = d => d * Math.PI / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,55 +6,84 @@
       </h1>
       <p class="text-xl text-gray-600 font-serif leading-relaxed">
         A cycling travelogue following the 185km route of Stage 9 of the 2026 Tour de France,
-        through the hills, valleys, and villages of Corrèze.
+        through the hills, valleys, and villages of Correze.
       </p>
-      <p class="mt-4 text-gray-500">
-        26 entries, published twice weekly from April to July 2026.
+      <p class="mt-2 text-gray-500">
+        26 entries published twice weekly, Sunday and Wednesday mornings.
         The peloton rides this road on Sunday, July 12.
       </p>
     </section>
 
     <section class="mb-12">
-      <h2 class="text-2xl font-serif font-bold text-gray-800 mb-6">Latest Entries</h2>
-      <div v-if="entries && entries.length" class="space-y-6">
-        <article v-for="entry in entries" :key="entry._path" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-          <NuxtLink :to="entry._path" class="block">
-            <span class="text-sm text-correze-red font-semibold">
-              Segment {{ entry.segment }} — Km {{ entry.kmStart }}–{{ entry.kmEnd }}
-            </span>
-            <h3 class="text-xl font-serif font-bold text-gray-900 mt-1">{{ entry.title }}</h3>
-            <p v-if="entry.subtitle" class="text-gray-600 mt-1">{{ entry.subtitle }}</p>
-            <time class="text-sm text-gray-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
-          </NuxtLink>
-        </article>
-      </div>
-      <p v-else class="text-gray-500 italic">No entries published yet.</p>
+      <h2 class="text-2xl font-serif font-bold text-gray-800 mb-4">The Route</h2>
+      <RouteOverviewMap
+        :segments="segments"
+        :route-coords="routeCoords"
+        :published-segments="publishedSegmentNumbers"
+      />
+      <p class="text-xs text-gray-400 mt-2">
+        Published segments shown in red. Click for details.
+      </p>
     </section>
 
-    <section>
-      <h2 class="text-2xl font-serif font-bold text-gray-800 mb-4">The Route</h2>
-      <div class="bg-white rounded-lg shadow-sm p-6">
-        <p class="text-gray-600">
-          185 kilometers from Malemort-sur-Corrèze to Ussel, crossing the Corrèze department
-          from southwest to northeast. Through the medieval villages of Turenne and Collonges-la-Rouge,
-          over the departmental capital of Tulle, up the fierce Suc au May in the Monédières,
-          across the wild Plateau de Millevaches, past the highest point in Corrèze at Mont Bessou,
-          and down to the finish at Place Voltaire in Ussel.
-        </p>
-      </div>
-    </section>
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
+      <section class="lg:col-span-2">
+        <h2 class="text-2xl font-serif font-bold text-gray-800 mb-6">Latest Entries</h2>
+        <div v-if="entries && entries.length" class="space-y-6">
+          <article v-for="entry in entries" :key="entry._path" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+            <NuxtLink :to="entry._path" class="block">
+              <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+                Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+              </span>
+              <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+              <h3 class="text-xl font-serif font-bold text-gray-900 mt-1">{{ entry.title }}</h3>
+              <p v-if="entry.subtitle" class="text-gray-600 mt-1">{{ entry.subtitle }}</p>
+              <time class="text-sm text-gray-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+            </NuxtLink>
+          </article>
+        </div>
+        <p v-else class="text-gray-500 italic">No entries published yet.</p>
+      </section>
+
+      <aside>
+        <RiderDashboard />
+
+        <div class="mt-8">
+          <PublishSchedule />
+        </div>
+      </aside>
+    </div>
   </div>
 </template>
 
 <script setup>
+import segmentsJson from '~/data/segments.json'
+
 const today = new Date().toISOString().split('T')[0]
+
+const segments = segmentsJson
+
+const routeCoords = ref([])
+try {
+  const routeData = await import('~/data/route.json')
+  const data = routeData.default || routeData
+  routeCoords.value = data.features?.[0]?.geometry?.coordinates || []
+} catch {
+  routeCoords.value = []
+}
 
 const { data: entries } = await useAsyncData('entries', () =>
   queryContent('entries')
     .where({ draft: false, publishDate: { $lte: today } })
-    .sort({ segment: -1 })
+    .sort({ publishDate: -1 })
     .limit(5)
     .find()
+)
+
+const publishedSegmentNumbers = computed(() =>
+  (entries.value || [])
+    .filter(e => e.segment > 0)
+    .map(e => e.segment)
 )
 
 function formatDate(dateStr) {


### PR DESCRIPTION
## Summary

Complete homepage rebuild with all planned sections:

- **Route overview map** (RouteOverviewMap.vue): full 185km route, published segments in red with clickable popups, unpublished in gray, Malemort/Ussel labels
- **Latest entries**: up to 5 most recent published entries with links
- **Rider dashboard**: standings sidebar (reuses existing component)
- **Publish schedule**: timeline sidebar (reuses existing component)
- Responsive 3-column grid (entries left, sidebar right) collapsing to single column on mobile

## Test plan

- [ ] Homepage shows the full route map with Malemort and Ussel labels
- [ ] Published entries appear in the latest entries section
- [ ] Published segments show in red on the map, unpublished in gray
- [ ] Rider standings visible in sidebar
- [ ] Publish schedule visible in sidebar
- [ ] Layout responsive on mobile

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)