### PR TITLE
Add admin layout, dashboard, and rider daily distance entry

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="min-h-screen bg-gray-100">
+    <header class="bg-gray-900 text-white">
+      <nav class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="flex items-center gap-6">
+          <NuxtLink to="/admin" class="text-lg font-bold hover:text-yellow-300 transition-colors">
+            Admin
+          </NuxtLink>
+          <div class="hidden md:flex items-center gap-4 text-sm">
+            <NuxtLink to="/admin/riders" class="text-gray-300 hover:text-white">Riders</NuxtLink>
+            <NuxtLink to="/admin/entries" class="text-gray-300 hover:text-white">Entries</NuxtLink>
+            <NuxtLink to="/admin/images" class="text-gray-300 hover:text-white">Images</NuxtLink>
+            <NuxtLink to="/admin/weather" class="text-gray-300 hover:text-white">Weather</NuxtLink>
+            <NuxtLink to="/admin/schedule" class="text-gray-300 hover:text-white">Schedule</NuxtLink>
+            <NuxtLink to="/admin/publish" class="text-gray-300 hover:text-white">Publish</NuxtLink>
+            <NuxtLink to="/admin/settings" class="text-gray-300 hover:text-white">Settings</NuxtLink>
+          </div>
+        </div>
+        <NuxtLink to="/" class="text-sm text-gray-400 hover:text-white">
+          View Site &rarr;
+        </NuxtLink>
+      </nav>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 py-8">
+      <slot />
+    </main>
+  </div>
+</template>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">Admin Dashboard</h1>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <NuxtLink to="/admin/riders" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Riders</h2>
+        <p class="text-sm text-gray-500 mt-1">Enter daily distances, view standings</p>
+      </NuxtLink>
+      <NuxtLink to="/admin/entries" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Entries</h2>
+        <p class="text-sm text-gray-500 mt-1">Edit content, toggle draft/publish</p>
+      </NuxtLink>
+      <NuxtLink to="/admin/images" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Images</h2>
+        <p class="text-sm text-gray-500 mt-1">Select CC images per segment</p>
+      </NuxtLink>
+      <NuxtLink to="/admin/weather" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Weather</h2>
+        <p class="text-sm text-gray-500 mt-1">Fetch and inject weather data</p>
+      </NuxtLink>
+      <NuxtLink to="/admin/schedule" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Schedule</h2>
+        <p class="text-sm text-gray-500 mt-1">Configure publish dates</p>
+      </NuxtLink>
+      <NuxtLink to="/admin/publish" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
+        <h2 class="text-lg font-semibold text-gray-800">Publish</h2>
+        <p class="text-sm text-gray-500 mt-1">Build and deploy the site</p>
+      </NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ layout: 'admin' })
+</script>

--- a/pages/admin/riders.vue
+++ b/pages/admin/riders.vue
@@ -1,0 +1,165 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">Rider Daily Distances</h1>
+
+    <!-- Entry form -->
+    <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
+      <h2 class="text-lg font-semibold text-gray-700 mb-4">Add / Edit Entry</h2>
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-gray-600 mb-1">Date</label>
+        <input
+          v-model="entryDate"
+          type="date"
+          class="border border-gray-300 rounded px-3 py-2 text-sm w-48"
+        />
+      </div>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+        <div v-for="rider in riders" :key="rider.id">
+          <label class="block text-sm font-medium mb-1" :style="{ color: displayColor(rider.color) }">
+            {{ rider.name }} (km)
+          </label>
+          <input
+            v-model.number="entryDistances[rider.id]"
+            type="number"
+            step="0.1"
+            min="0"
+            class="border border-gray-300 rounded px-3 py-2 text-sm w-full"
+            placeholder="0"
+          />
+        </div>
+      </div>
+      <div class="flex items-center gap-4">
+        <button
+          @click="submitEntry"
+          :disabled="submitting"
+          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+        >
+          {{ submitting ? 'Saving...' : 'Save Entry' }}
+        </button>
+        <span v-if="saveMessage" class="text-sm" :class="saveError ? 'text-red-600' : 'text-green-600'">
+          {{ saveMessage }}
+        </span>
+      </div>
+    </div>
+
+    <!-- History table -->
+    <div class="bg-white rounded-lg shadow-sm p-6">
+      <h2 class="text-lg font-semibold text-gray-700 mb-4">History</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left py-2 pr-4 text-gray-500 font-medium">Date</th>
+              <th
+                v-for="rider in riders"
+                :key="rider.id"
+                class="text-center py-2 px-2 font-medium"
+                :style="{ color: displayColor(rider.color) }"
+              >
+                {{ rider.name }}
+              </th>
+              <th class="text-center py-2 px-2 text-gray-500 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="entry in reversedEntries" :key="entry.date">
+              <td class="py-2 pr-4 font-mono text-gray-600">{{ entry.date }}</td>
+              <td v-for="rider in riders" :key="rider.id" class="text-center py-2 px-2 font-mono">
+                {{ entry.distances[rider.id] || 0 }}
+              </td>
+              <td class="text-center py-2 px-2">
+                <button @click="editEntry(entry)" class="text-blue-600 hover:underline text-xs">
+                  edit
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p v-if="!entries.length" class="text-gray-400 italic text-sm">No entries yet.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ layout: 'admin' })
+
+const riders = ref([])
+const entries = ref([])
+const entryDate = ref('')
+const entryDistances = ref({})
+const submitting = ref(false)
+const saveMessage = ref('')
+const saveError = ref(false)
+
+const reversedEntries = computed(() => [...entries.value].reverse())
+
+async function loadData() {
+  const data = await $fetch('/api/riders')
+  riders.value = data.config.riders
+  entries.value = data.log.entries
+
+  // Default date: day after last entry
+  if (data.log.entries.length) {
+    const lastDate = data.log.entries[data.log.entries.length - 1].date
+    const next = new Date(lastDate + 'T00:00:00')
+    next.setDate(next.getDate() + 1)
+    entryDate.value = next.toISOString().split('T')[0]
+  } else {
+    entryDate.value = new Date().toISOString().split('T')[0]
+  }
+
+  // Init distances to 0
+  for (const r of data.config.riders) {
+    if (!(r.id in entryDistances.value)) {
+      entryDistances.value[r.id] = 0
+    }
+  }
+}
+
+function editEntry(entry) {
+  entryDate.value = entry.date
+  entryDistances.value = { ...entry.distances }
+}
+
+async function submitEntry() {
+  submitting.value = true
+  saveMessage.value = ''
+  saveError.value = false
+
+  try {
+    const result = await $fetch('/api/riders', {
+      method: 'POST',
+      body: {
+        date: entryDate.value,
+        distances: { ...entryDistances.value }
+      }
+    })
+    saveMessage.value = 'Saved! Stats updated.'
+    await loadData()
+
+    // Reset distances and advance date
+    for (const r of riders.value) {
+      entryDistances.value[r.id] = 0
+    }
+  } catch (err) {
+    saveMessage.value = 'Error saving entry.'
+    saveError.value = true
+  } finally {
+    submitting.value = false
+  }
+}
+
+function displayColor(hex) {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  if (luminance > 0.85) {
+    return `rgb(${Math.round(r * 0.5)}, ${Math.round(g * 0.5)}, ${Math.round(b * 0.5)})`
+  }
+  return hex
+}
+
+onMounted(() => loadData())
+</script>

--- a/server/api/riders.get.ts
+++ b/server/api/riders.get.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+export default defineEventHandler(() => {
+  const logPath = resolve('data/riders/daily-log.json')
+  const configPath = resolve('data/riders/rider-config.json')
+  const statsPath = resolve('data/riders/stats.json')
+
+  const log = JSON.parse(readFileSync(logPath, 'utf8'))
+  const config = JSON.parse(readFileSync(configPath, 'utf8'))
+
+  let stats = { riders: {} }
+  try {
+    stats = JSON.parse(readFileSync(statsPath, 'utf8'))
+  } catch {}
+
+  return { log, config, stats }
+})

--- a/server/api/riders.post.ts
+++ b/server/api/riders.post.ts
@@ -1,0 +1,42 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { execSync } from 'child_process'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { date, distances } = body
+
+  if (!date || !distances) {
+    throw createError({ statusCode: 400, message: 'Missing date or distances' })
+  }
+
+  const logPath = resolve('data/riders/daily-log.json')
+  const configPath = resolve('data/riders/rider-config.json')
+  const statsPath = resolve('data/riders/stats.json')
+
+  // Read current log
+  const log = JSON.parse(readFileSync(logPath, 'utf8'))
+
+  // Remove existing entry for this date if it exists
+  log.entries = log.entries.filter((e: any) => e.date !== date)
+
+  // Add new entry
+  log.entries.push({ date, distances })
+  log.entries.sort((a: any, b: any) => a.date.localeCompare(b.date))
+
+  // Write updated log
+  writeFileSync(logPath, JSON.stringify(log, null, 2))
+
+  // Regenerate stats
+  try {
+    const venvPython = resolve('processing/.venv/bin/python')
+    const statsScript = resolve('processing/rider_stats.py')
+    execSync(`${venvPython} ${statsScript} --daily-log ${logPath} --rider-config ${configPath} --output ${statsPath}`)
+  } catch (err: any) {
+    console.error('Stats regeneration failed:', err.message)
+  }
+
+  // Read and return updated stats
+  const stats = JSON.parse(readFileSync(statsPath, 'utf8'))
+  return { success: true, stats }
+})


### PR DESCRIPTION
## Summary

Foundation for the admin interface plus the first admin page:

- **Admin layout** (`layouts/admin.vue`): dark nav bar with links to all admin sections, "View Site" link
- **Admin dashboard** (`pages/admin/index.vue`): card grid linking to each admin section
- **Rider entry page** (`pages/admin/riders.vue`): 
  - Date picker defaulting to next unlogged date
  - Distance input per rider with colour coding
  - Save triggers stats regeneration automatically
  - History table showing all logged entries
  - Edit button loads entry back into the form
- **Server API**: GET/POST `/api/riders` for loading and saving rider data

## Test plan

- [ ] Navigate to http://localhost:3000/admin
- [ ] Click "Riders" card to open rider entry page
- [ ] Enter distances and click Save - verify data saved and stats updated
- [ ] Check history table shows the entry
- [ ] Click "edit" on a history row - verify form populates
- [ ] Verify admin pages don't appear in static build

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)