### PR TITLE
Add admin entry publish controls

### DIFF
--- a/pages/admin/entries.vue
+++ b/pages/admin/entries.vue
@@ -1,0 +1,116 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">Entry Publish Controls</h1>
+
+    <div class="bg-white rounded-lg shadow-sm p-6">
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="text-left py-2 pr-2 text-gray-500 font-medium w-10">#</th>
+              <th class="text-left py-2 pr-2 text-gray-500 font-medium">Title</th>
+              <th class="text-center py-2 px-2 text-gray-500 font-medium w-32">Publish Date</th>
+              <th class="text-center py-2 px-2 text-gray-500 font-medium w-24">Status</th>
+              <th class="text-center py-2 px-2 text-gray-500 font-medium w-20">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            <tr v-for="entry in entries" :key="entry.filename" :class="entry.draft ? 'opacity-60' : ''">
+              <td class="py-2 pr-2 font-mono text-gray-400">{{ entry.segment }}</td>
+              <td class="py-2 pr-2">
+                <span class="text-gray-800">{{ entry.title }}</span>
+                <span class="text-xs text-gray-400 ml-2">{{ entry.filename }}</span>
+              </td>
+              <td class="text-center py-2 px-2">
+                <input
+                  :value="entry.publishDate"
+                  @change="updateDate(entry, $event)"
+                  type="date"
+                  class="border border-gray-300 rounded px-2 py-1 text-xs w-full"
+                />
+              </td>
+              <td class="text-center py-2 px-2">
+                <span
+                  class="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
+                  :class="entry.draft ? 'bg-yellow-100 text-yellow-700' : 'bg-green-100 text-green-700'"
+                >
+                  {{ entry.draft ? 'Draft' : 'Published' }}
+                </span>
+              </td>
+              <td class="text-center py-2 px-2">
+                <button
+                  @click="toggleDraft(entry)"
+                  class="text-xs hover:underline"
+                  :class="entry.draft ? 'text-green-600' : 'text-yellow-600'"
+                >
+                  {{ entry.draft ? 'Publish' : 'Unpublish' }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="mt-4 flex gap-4">
+      <button @click="setAllDraft(true)" class="text-sm text-yellow-600 hover:underline">
+        Set all to draft
+      </button>
+      <button @click="setAllDraft(false)" class="text-sm text-green-600 hover:underline">
+        Publish all
+      </button>
+    </div>
+
+    <span v-if="saveMessage" class="block mt-2 text-sm" :class="saveError ? 'text-red-600' : 'text-green-600'">
+      {{ saveMessage }}
+    </span>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ layout: 'admin' })
+
+const entries = ref([])
+const saveMessage = ref('')
+const saveError = ref(false)
+
+async function loadEntries() {
+  const data = await $fetch('/api/entries')
+  entries.value = data.entries
+}
+
+async function updateEntry(entry, updates) {
+  saveMessage.value = ''
+  saveError.value = false
+  try {
+    await $fetch('/api/entry-status', {
+      method: 'POST',
+      body: { filename: entry.filename, ...updates }
+    })
+    Object.assign(entry, updates)
+    saveMessage.value = `Updated ${entry.filename}`
+  } catch {
+    saveMessage.value = `Error updating ${entry.filename}`
+    saveError.value = true
+  }
+}
+
+function toggleDraft(entry) {
+  updateEntry(entry, { draft: !entry.draft })
+}
+
+function updateDate(entry, event) {
+  updateEntry(entry, { publishDate: event.target.value })
+}
+
+async function setAllDraft(draft) {
+  for (const entry of entries.value) {
+    if (entry.draft !== draft) {
+      await updateEntry(entry, { draft })
+    }
+  }
+  saveMessage.value = draft ? 'All entries set to draft' : 'All entries published'
+}
+
+onMounted(() => loadEntries())
+</script>

--- a/server/api/entries.get.ts
+++ b/server/api/entries.get.ts
@@ -1,0 +1,36 @@
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+export default defineEventHandler(() => {
+  const entriesDir = resolve('content/entries')
+  const files = readdirSync(entriesDir).filter(f => f.endsWith('.md')).sort()
+
+  const entries = files.map(filename => {
+    const content = readFileSync(join(entriesDir, filename), 'utf8')
+    const frontmatter: Record<string, any> = {}
+
+    const match = content.match(/^---\n([\s\S]*?)\n---/)
+    if (match) {
+      for (const line of match[1].split('\n')) {
+        const colonIdx = line.indexOf(':')
+        if (colonIdx > 0) {
+          const key = line.slice(0, colonIdx).trim()
+          let value: any = line.slice(colonIdx + 1).trim()
+          if (value === 'true') value = true
+          else if (value === 'false') value = false
+          else if (value === 'null') value = null
+          else if (/^\d+(\.\d+)?$/.test(value)) value = parseFloat(value)
+          else if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1)
+          frontmatter[key] = value
+        }
+      }
+    }
+
+    return {
+      filename,
+      ...frontmatter
+    }
+  })
+
+  return { entries }
+})

--- a/server/api/entry-status.post.ts
+++ b/server/api/entry-status.post.ts
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve, join } from 'path'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { filename, draft, publishDate } = body
+
+  if (!filename) {
+    throw createError({ statusCode: 400, message: 'Missing filename' })
+  }
+
+  const filePath = join(resolve('content/entries'), filename)
+  let content = readFileSync(filePath, 'utf8')
+
+  if (draft !== undefined) {
+    content = content.replace(
+      /^draft:\s*(true|false)$/m,
+      `draft: ${draft}`
+    )
+  }
+
+  if (publishDate) {
+    content = content.replace(
+      /^publishDate:\s*\S+$/m,
+      `publishDate: ${publishDate}`
+    )
+  }
+
+  writeFileSync(filePath, content)
+
+  return { success: true, filename }
+})


### PR DESCRIPTION
## Summary

- Entry list at `/admin/entries` showing all 27 entries
- Toggle draft/published status per entry
- Inline date picker to change publish dates
- Bulk actions: set all to draft, publish all
- Server API: GET `/api/entries`, POST `/api/entry-status`
- Changes written directly to markdown frontmatter

## Test plan

- [ ] Navigate to http://localhost:3000/admin/entries
- [ ] See all entries with segment number, title, date, and status
- [ ] Click "Publish" on a draft entry - verify status changes
- [ ] Change a publish date - verify frontmatter updated
- [ ] Test bulk "Set all to draft" action

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)