### PR TITLE
Fix editor toolbar, add marked and typography plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "dependencies": {
         "@nuxt/content": "^2.13.0",
         "@nuxtjs/tailwindcss": "^6.12.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "chart.js": "^4.4.0",
         "leaflet": "^1.9.4",
+        "marked": "^17.0.5",
         "nuxt": "^3.16.0",
         "vue-chartjs": "^5.3.0"
       },
@@ -3923,6 +3925,31 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5596,12 +5623,14 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -8448,6 +8477,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -12475,6 +12516,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tagged-tag": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "nuxt": "^3.16.0",
     "@nuxt/content": "^2.13.0",
     "@nuxtjs/tailwindcss": "^6.12.0",
-    "leaflet": "^1.9.4",
+    "@tailwindcss/typography": "^0.5.19",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "chart.js": "^4.4.0",
+    "leaflet": "^1.9.4",
+    "marked": "^17.0.5",
+    "nuxt": "^3.16.0",
     "vue-chartjs": "^5.3.0"
   },
   "devDependencies": {

--- a/pages/admin/edit/[filename].vue
+++ b/pages/admin/edit/[filename].vue
@@ -19,31 +19,52 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <!-- Editor -->
-      <div>
-        <div class="bg-white rounded-lg shadow-sm p-4 mb-4">
+    <div class="flex gap-2" style="height: calc(100vh - 180px)">
+      <!-- Editor pane -->
+      <div class="flex flex-col overflow-hidden" :style="{ width: editorWidth + '%' }">
+        <div class="bg-white rounded-lg shadow-sm p-4 mb-4 flex-shrink-0">
           <h2 class="text-sm font-semibold text-gray-600 mb-2">Frontmatter</h2>
           <textarea
             v-model="frontmatter"
             class="w-full font-mono text-xs border border-gray-300 rounded p-3 bg-gray-50"
-            rows="8"
+            rows="6"
             spellcheck="false"
           />
         </div>
-        <div class="bg-white rounded-lg shadow-sm p-4">
+        <div class="bg-white rounded-lg shadow-sm p-4 flex-1 flex flex-col overflow-hidden">
           <h2 class="text-sm font-semibold text-gray-600 mb-2">Content (Markdown)</h2>
+          <!-- Toolbar -->
+          <div class="flex gap-1 mb-2 flex-shrink-0">
+            <button @click="insertLinePrefix('# ')" class="toolbar-btn font-bold" title="Heading 1">H1</button>
+            <button @click="insertLinePrefix('## ')" class="toolbar-btn font-bold" title="Heading 2">H2</button>
+            <button @click="insertLinePrefix('### ')" class="toolbar-btn font-bold" title="Heading 3">H3</button>
+            <span class="w-px bg-gray-300 mx-1"></span>
+            <button @click="wrapMd('**', '**')" class="toolbar-btn font-bold" title="Bold">B</button>
+            <button @click="wrapMd('*', '*')" class="toolbar-btn italic" title="Italic">I</button>
+            <span class="w-px bg-gray-300 mx-1"></span>
+            <button @click="insertLinePrefix('> ')" class="toolbar-btn" title="Quote">&ldquo;</button>
+            <button @click="wrapMd('[', '](url)')" class="toolbar-btn" title="Link">Link</button>
+          </div>
           <textarea
+            ref="editorRef"
             v-model="body"
-            class="w-full font-mono text-sm border border-gray-300 rounded p-3 min-h-[500px]"
+            class="w-full font-mono text-sm border border-gray-300 rounded p-3 flex-1 resize-none"
             spellcheck="true"
           />
         </div>
       </div>
 
-      <!-- Preview -->
-      <div>
-        <div class="bg-white rounded-lg shadow-sm p-6">
+      <!-- Resize handle -->
+      <div
+        class="w-2 cursor-col-resize flex-shrink-0 flex items-center justify-center hover:bg-gray-300 rounded"
+        @mousedown="startResize"
+      >
+        <div class="w-0.5 h-8 bg-gray-400 rounded"></div>
+      </div>
+
+      <!-- Preview pane -->
+      <div class="flex-1 overflow-auto">
+        <div class="bg-white rounded-lg shadow-sm p-6 h-full overflow-auto">
           <h2 class="text-sm font-semibold text-gray-600 mb-4">Preview</h2>
           <div class="prose prose-lg max-w-none font-serif" v-html="renderedPreview" />
         </div>
@@ -56,7 +77,7 @@
 definePageMeta({ layout: 'admin' })
 
 const route = useRoute()
-const filename = route.params.filename as string
+const filename = String(route.params.filename)
 
 const frontmatter = ref('')
 const body = ref('')
@@ -64,27 +85,101 @@ const entryTitle = ref('')
 const saving = ref(false)
 const saveMessage = ref('')
 const saveError = ref(false)
+const editorRef = ref(null)
+const editorWidth = ref(50)
 
-// Simple markdown to HTML for preview
-function markdownToHtml(md: string): string {
-  return md
-    // Headers
-    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
-    // Bold and italic
-    .replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>')
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\*(.+?)\*/g, '<em>$1</em>')
-    // Links
-    .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
-    // Paragraphs
-    .replace(/\n\n/g, '</p><p>')
-    .replace(/^/, '<p>')
-    .replace(/$/, '</p>')
+// --- Resize ---
+function startResize(e) {
+  e.preventDefault()
+  const startX = e.clientX
+  const startWidth = editorWidth.value
+  const containerWidth = e.target.parentElement.offsetWidth
+
+  function onMove(e) {
+    const delta = e.clientX - startX
+    const pct = (delta / containerWidth) * 100
+    editorWidth.value = Math.min(80, Math.max(20, startWidth + pct))
+  }
+  function onUp() {
+    document.removeEventListener('mousemove', onMove)
+    document.removeEventListener('mouseup', onUp)
+  }
+  document.addEventListener('mousemove', onMove)
+  document.addEventListener('mouseup', onUp)
 }
 
-const renderedPreview = computed(() => markdownToHtml(body.value))
+// --- Toolbar ---
+function insertLinePrefix(prefix) {
+  const el = editorRef.value
+  if (!el) return
+  const start = el.selectionStart
+  const end = el.selectionEnd
+
+  // Find the start of the current line
+  const lineStart = body.value.lastIndexOf('\n', start - 1) + 1
+  const lineContent = body.value.slice(lineStart, end)
+
+  // Check if already has this prefix — toggle off
+  if (lineContent.startsWith(prefix)) {
+    body.value = body.value.slice(0, lineStart) + lineContent.slice(prefix.length) + body.value.slice(end)
+    nextTick(() => {
+      el.selectionStart = Math.max(lineStart, start - prefix.length)
+      el.selectionEnd = Math.max(lineStart, end - prefix.length)
+      el.focus()
+    })
+    return
+  }
+
+  // Strip any existing heading/quote prefix before adding new one
+  const stripped = lineContent.replace(/^#{1,3} |^> /, '')
+  body.value = body.value.slice(0, lineStart) + prefix + stripped + body.value.slice(end)
+  const offset = prefix.length + stripped.length - lineContent.length
+  nextTick(() => {
+    el.selectionStart = start + offset
+    el.selectionEnd = end + offset
+    el.focus()
+  })
+}
+
+function wrapMd(before, after) {
+  const el = editorRef.value
+  if (!el) return
+  const start = el.selectionStart
+  const end = el.selectionEnd
+  const selected = body.value.slice(start, end) || 'text'
+
+  // Check if already wrapped — if so, unwrap
+  const prefixStart = start - before.length
+  const suffixEnd = end + after.length
+  if (
+    prefixStart >= 0 &&
+    suffixEnd <= body.value.length &&
+    body.value.slice(prefixStart, start) === before &&
+    body.value.slice(end, suffixEnd) === after
+  ) {
+    // Unwrap
+    body.value = body.value.slice(0, prefixStart) + selected + body.value.slice(suffixEnd)
+    nextTick(() => {
+      el.selectionStart = prefixStart
+      el.selectionEnd = prefixStart + selected.length
+      el.focus()
+    })
+    return
+  }
+
+  // Wrap
+  body.value = body.value.slice(0, start) + before + selected + after + body.value.slice(end)
+  nextTick(() => {
+    el.selectionStart = start + before.length
+    el.selectionEnd = start + before.length + selected.length
+    el.focus()
+  })
+}
+
+// --- Markdown preview ---
+import { marked } from 'marked'
+
+const renderedPreview = computed(() => marked(body.value || ''))
 
 async function loadEntry() {
   const data = await $fetch('/api/entry-content', {
@@ -93,7 +188,6 @@ async function loadEntry() {
   frontmatter.value = data.frontmatter
   body.value = data.body
 
-  // Extract title from frontmatter
   const titleMatch = data.frontmatter.match(/^title:\s*"?(.+?)"?\s*$/m)
   if (titleMatch) entryTitle.value = titleMatch[1]
 }
@@ -124,3 +218,9 @@ async function saveEntry() {
 
 onMounted(() => loadEntry())
 </script>
+
+<style scoped>
+.toolbar-btn {
+  @apply px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-100 text-gray-700 cursor-pointer;
+}
+</style>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,9 @@
 import type { Config } from 'tailwindcss'
+import typography from '@tailwindcss/typography'
 
 export default {
   content: [],
+  plugins: [typography],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

Follow-up fixes for the entry editor:

- **marked library**: replaces homebrew regex markdown renderer with proper parser
- **@tailwindcss/typography**: adds prose styles so headings, blockquotes, lists render correctly across the whole site
- **Toolbar fixes**: H1/H2/H3/Quote now use `insertLinePrefix` - works at any cursor position, toggles off on second press, switches between heading levels
- **Bold/Italic toggle**: pressing again removes the formatting
- **Resizable columns**: drag handle between editor and preview
- **TypeScript fix**: removed type annotations from `<script setup>` (was causing build errors)

## Test plan

- [ ] Type `# Hello` in editor - appears as H1 in preview
- [ ] Click H2 button - adds `## ` prefix to current line
- [ ] Click H2 again - removes prefix
- [ ] Bold button toggles on/off
- [ ] Drag resize handle between editor and preview
- [ ] Check entry pages on public site also render headings correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)