### PR TITLE
Add admin publish dashboard with one-click deploy

### DIFF
--- a/pages/admin/publish.vue
+++ b/pages/admin/publish.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">Publish</h1>
+
+    <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+      <h2 class="text-lg font-semibold text-gray-700 mb-4">Build and Deploy</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        Regenerates rider stats, builds the static site, and optionally deploys to the production server.
+      </p>
+
+      <div class="flex items-center gap-4 mb-4">
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="skipDeploy" type="checkbox" class="rounded" />
+          Skip deploy
+        </label>
+        <label class="flex items-center gap-2 text-sm">
+          <input v-model="dryRun" type="checkbox" class="rounded" />
+          Dry run
+        </label>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <button
+          @click="runPublish"
+          :disabled="running"
+          class="bg-gray-900 text-white px-6 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+        >
+          {{ running ? 'Running...' : 'Publish' }}
+        </button>
+        <span v-if="running" class="text-sm text-gray-500">This may take a minute...</span>
+      </div>
+    </div>
+
+    <div v-if="logs.length" class="bg-gray-900 rounded-lg shadow-sm p-6">
+      <h2 class="text-sm font-semibold text-gray-400 mb-3">Output</h2>
+      <pre class="text-sm font-mono text-green-400 whitespace-pre-wrap max-h-[500px] overflow-auto">{{ logs.join('\n') }}</pre>
+      <div class="mt-4 pt-3 border-t border-gray-700">
+        <span class="text-sm" :class="success ? 'text-green-400' : 'text-red-400'">
+          {{ success ? '✓ Publish complete' : '✗ Publish failed' }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ layout: 'admin' })
+
+const skipDeploy = ref(true)
+const dryRun = ref(false)
+const running = ref(false)
+const logs = ref([])
+const success = ref(false)
+
+async function runPublish() {
+  running.value = true
+  logs.value = ['Starting publish pipeline...']
+  success.value = false
+
+  try {
+    const result = await $fetch('/api/publish', {
+      method: 'POST',
+      body: {
+        skipDeploy: skipDeploy.value,
+        dryRun: dryRun.value
+      }
+    })
+    logs.value = result.logs
+    success.value = true
+  } catch (err) {
+    if (err.data?.data?.logs) {
+      logs.value = err.data.data.logs
+    } else {
+      logs.value.push(`Error: ${err.data?.message || err.message}`)
+    }
+    success.value = false
+  } finally {
+    running.value = false
+  }
+}
+</script>

--- a/server/api/publish.post.ts
+++ b/server/api/publish.post.ts
@@ -1,0 +1,50 @@
+import { execSync } from 'child_process'
+import { resolve } from 'path'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { skipDeploy = true, dryRun = false } = body
+
+  const projectDir = resolve('.')
+  const venvPython = resolve('processing/.venv/bin/python')
+  const logs: string[] = []
+
+  function run(label: string, cmd: string) {
+    logs.push(`--- ${label} ---`)
+    try {
+      const output = execSync(cmd, {
+        cwd: projectDir,
+        timeout: 120000,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: process.env.PATH }
+      })
+      logs.push(output.trim())
+      logs.push(`✓ ${label} complete`)
+    } catch (err: any) {
+      logs.push(`✗ ${label} failed: ${err.message}`)
+      throw createError({ statusCode: 500, message: `${label} failed`, data: { logs } })
+    }
+  }
+
+  // Step 1: Rider stats
+  run('Rider Stats', `${venvPython} processing/rider_stats.py --daily-log data/riders/daily-log.json --rider-config data/riders/rider-config.json --output data/riders/stats.json`)
+
+  // Step 2: Build
+  run('Build Site', 'npx nuxt generate')
+
+  // Step 3: Deploy
+  if (skipDeploy || dryRun) {
+    logs.push('--- Deploy ---')
+    logs.push(dryRun ? '(dry run - skipped)' : '(skip deploy - skipped)')
+  } else {
+    const target = process.env.DEPLOY_TARGET
+    if (target) {
+      run('Deploy', `scp -r .output/public/* ${target}`)
+    } else {
+      logs.push('--- Deploy ---')
+      logs.push('No DEPLOY_TARGET set, skipped')
+    }
+  }
+
+  return { success: true, logs }
+})


### PR DESCRIPTION
## Summary

- Publish dashboard at `/admin/publish`
- One-click button runs the full pipeline: rider stats -> nuxt generate -> deploy
- Options: "Skip deploy" checkbox (default on), "Dry run" checkbox
- Dark terminal-style output log showing each step's progress
- Success/failure indicator at the bottom
- Server API: POST `/api/publish` with configurable options

## Test plan

- [ ] Navigate to http://localhost:3000/admin/publish
- [ ] Click Publish with "Skip deploy" checked
- [ ] Verify output shows rider stats and build steps
- [ ] Verify success indicator appears
- [ ] .output/public/ is regenerated

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)