### PR TITLE
Add admin visual image selector per segment

### DIFF
--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -1,0 +1,181 @@
+<template>
+  <div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-6">Image Selector</h1>
+
+    <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
+      <div class="flex items-center gap-4">
+        <label class="text-sm font-medium text-gray-600">Segment</label>
+        <select v-model.number="selectedSegment" class="border border-gray-300 rounded px-3 py-2 text-sm">
+          <option v-for="n in 26" :key="n" :value="n">{{ n }} - {{ segmentTitle(n) }}</option>
+        </select>
+        <button
+          @click="loadImages"
+          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700"
+        >
+          Load
+        </button>
+        <button
+          @click="fetchSuggestions"
+          :disabled="fetching"
+          class="text-sm text-blue-600 hover:underline disabled:opacity-50"
+        >
+          {{ fetching ? 'Fetching...' : 'Fetch from Wikimedia' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Selected images -->
+    <div v-if="selected.length" class="bg-white rounded-lg shadow-sm p-6 mb-6">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-gray-700">Selected ({{ selected.length }})</h2>
+        <button
+          @click="saveSelection"
+          :disabled="saving"
+          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+        >
+          {{ saving ? 'Saving...' : 'Save to Entry' }}
+        </button>
+      </div>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div v-for="(img, idx) in selected" :key="idx" class="relative group">
+          <img :src="img.src" :alt="img.alt" class="w-full h-32 object-cover rounded border-2 border-green-500" />
+          <button
+            @click="removeSelected(idx)"
+            class="absolute top-1 right-1 bg-red-600 text-white w-5 h-5 rounded-full text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            x
+          </button>
+          <p class="text-xs text-gray-500 mt-1 truncate">{{ img.alt }}</p>
+        </div>
+      </div>
+      <span v-if="saveMessage" class="block mt-3 text-sm" :class="saveError ? 'text-red-600' : 'text-green-600'">
+        {{ saveMessage }}
+      </span>
+    </div>
+
+    <!-- Suggestions grid -->
+    <div v-if="suggestions.length" class="bg-white rounded-lg shadow-sm p-6">
+      <h2 class="text-lg font-semibold text-gray-700 mb-4">
+        Suggestions ({{ suggestions.length }})
+      </h2>
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div
+          v-for="(img, idx) in suggestions"
+          :key="idx"
+          class="cursor-pointer group"
+          @click="selectImage(img)"
+        >
+          <div class="relative overflow-hidden rounded border border-gray-200 hover:border-blue-400 transition-colors">
+            <img
+              :src="img.url"
+              :alt="img.description || img.title"
+              class="w-full h-36 object-cover"
+              loading="lazy"
+            />
+            <div class="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
+              <span class="text-white text-xs bg-blue-600 px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity">
+                Select
+              </span>
+            </div>
+          </div>
+          <p class="text-xs text-gray-600 mt-1 truncate">{{ img.title }}</p>
+          <p class="text-xs text-gray-400 truncate">{{ img.license }} - {{ img.width }}x{{ img.height }}</p>
+        </div>
+      </div>
+    </div>
+
+    <p v-else-if="loaded && !fetching" class="text-gray-400 italic text-sm">
+      No suggestions found. Click "Fetch from Wikimedia" to search.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import segmentsJson from '~/data/segments.json'
+
+definePageMeta({ layout: 'admin' })
+
+const selectedSegment = ref(1)
+const suggestions = ref([])
+const selected = ref([])
+const entryFilename = ref('')
+const loaded = ref(false)
+const fetching = ref(false)
+const saving = ref(false)
+const saveMessage = ref('')
+const saveError = ref(false)
+
+function segmentTitle(n) {
+  const seg = segmentsJson.find(s => s.segment === n)
+  if (!seg) return ''
+  if (seg.towns?.length) return seg.towns[0]
+  if (seg.climbs?.length) return seg.climbs[0]
+  return `Segment ${n}`
+}
+
+async function loadImages() {
+  loaded.value = false
+  saveMessage.value = ''
+  const data = await $fetch('/api/images', { params: { segment: selectedSegment.value } })
+  suggestions.value = data.suggestions
+  selected.value = data.entryImages || []
+  entryFilename.value = data.entryFilename
+  loaded.value = true
+}
+
+async function fetchSuggestions() {
+  fetching.value = true
+  try {
+    await $fetch('/api/images-suggest', {
+      method: 'POST',
+      body: { segment: selectedSegment.value }
+    })
+    await loadImages()
+  } catch (err) {
+    saveMessage.value = 'Error fetching suggestions'
+    saveError.value = true
+  } finally {
+    fetching.value = false
+  }
+}
+
+function selectImage(img) {
+  // Check if already selected
+  if (selected.value.some(s => s.src === img.url)) return
+
+  selected.value.push({
+    src: img.url,
+    alt: img.description || img.title || '',
+    attribution: `${img.artist}, ${img.license}, Wikimedia Commons`
+  })
+}
+
+function removeSelected(idx) {
+  selected.value.splice(idx, 1)
+}
+
+async function saveSelection() {
+  if (!entryFilename.value) return
+  saving.value = true
+  saveMessage.value = ''
+  saveError.value = false
+
+  try {
+    await $fetch('/api/images', {
+      method: 'POST',
+      body: {
+        filename: entryFilename.value,
+        images: selected.value
+      }
+    })
+    saveMessage.value = `Saved ${selected.value.length} images to ${entryFilename.value}`
+  } catch {
+    saveMessage.value = 'Error saving images'
+    saveError.value = true
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => loadImages())
+</script>

--- a/server/api/images-suggest.post.ts
+++ b/server/api/images-suggest.post.ts
@@ -1,0 +1,26 @@
+import { execSync } from 'child_process'
+import { resolve } from 'path'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { segment } = body
+
+  if (!segment && segment !== 0) {
+    throw createError({ statusCode: 400, message: 'Missing segment number' })
+  }
+
+  const venvPython = resolve('processing/.venv/bin/python')
+  const script = resolve('processing/suggest_images.py')
+  const segmentsJson = resolve('data/segments.json')
+  const outputDir = resolve('data/image-suggestions')
+
+  try {
+    execSync(
+      `${venvPython} ${script} --segments-json ${segmentsJson} --output-dir ${outputDir} --segment ${segment}`,
+      { timeout: 30000, encoding: 'utf8' }
+    )
+    return { success: true }
+  } catch (err: any) {
+    throw createError({ statusCode: 500, message: `Suggestion fetch failed: ${err.message}` })
+  }
+})

--- a/server/api/images.get.ts
+++ b/server/api/images.get.ts
@@ -1,0 +1,45 @@
+import { readFileSync, existsSync } from 'fs'
+import { resolve, join } from 'path'
+
+export default defineEventHandler((event) => {
+  const query = getQuery(event)
+  const segment = parseInt(query.segment as string)
+
+  if (isNaN(segment)) {
+    throw createError({ statusCode: 400, message: 'Missing segment number' })
+  }
+
+  const segStr = String(segment).padStart(2, '0')
+
+  // Load suggestions if they exist
+  const suggestionsPath = join(resolve('data/image-suggestions'), `segment-${segStr}.json`)
+  let suggestions = []
+  if (existsSync(suggestionsPath)) {
+    const data = JSON.parse(readFileSync(suggestionsPath, 'utf8'))
+    suggestions = data.images || []
+  }
+
+  // Load current entry images from frontmatter
+  const entriesDir = resolve('content/entries')
+  const { readdirSync } = require('fs')
+  const files = readdirSync(entriesDir).filter((f: string) => f.endsWith('.md'))
+  let entryImages = []
+  let entryFilename = ''
+
+  for (const filename of files) {
+    const content = readFileSync(join(entriesDir, filename), 'utf8')
+    const segMatch = content.match(/^segment:\s*(\d+)/m)
+    if (segMatch && parseInt(segMatch[1]) === segment) {
+      entryFilename = filename
+      const imagesMatch = content.match(/^images:\s*(\[[\s\S]*?\])\s*$/m)
+      if (imagesMatch) {
+        try {
+          entryImages = JSON.parse(imagesMatch[1])
+        } catch {}
+      }
+      break
+    }
+  }
+
+  return { segment, suggestions, entryImages, entryFilename }
+})

--- a/server/api/images.post.ts
+++ b/server/api/images.post.ts
@@ -1,0 +1,24 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve, join } from 'path'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { filename, images } = body
+
+  if (!filename || !Array.isArray(images)) {
+    throw createError({ statusCode: 400, message: 'Missing filename or images array' })
+  }
+
+  const filePath = join(resolve('content/entries'), filename)
+  let content = readFileSync(filePath, 'utf8')
+
+  const imagesJson = JSON.stringify(images)
+  content = content.replace(
+    /^images:.*$/m,
+    `images: ${imagesJson}`
+  )
+
+  writeFileSync(filePath, content)
+
+  return { success: true, filename, count: images.length }
+})


### PR DESCRIPTION
## Summary

- Image selector at `/admin/images`
- Dropdown to pick segment (1-26)
- "Fetch from Wikimedia" button runs suggest_images.py for that segment
- Thumbnail grid showing all CC-licensed suggestions with title, license, dimensions
- Click a suggestion to select it (added to selected list with green border)
- Remove selected images with hover X button
- "Save to Entry" writes the images array to entry frontmatter
- Three server APIs: load images/suggestions, save selection, trigger Wikimedia fetch

## Test plan

- [ ] Navigate to http://localhost:3000/admin/images
- [ ] Select segment 4 (Collonges-la-Rouge, has existing suggestions) and click Load
- [ ] See thumbnail grid of CC images
- [ ] Click images to select them - verify they appear in "Selected" section
- [ ] Click Save - verify entry frontmatter updated
- [ ] Try "Fetch from Wikimedia" on a segment without suggestions

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)