### PR TITLE
Fix CI: seed rider data from example files if missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,11 @@ jobs:
           python -m venv processing/.venv
           processing/.venv/bin/pip install -r processing/requirements.txt
 
+      - name: Seed rider data if missing
+        run: |
+          [ -f data/riders/daily-log.json ] || cp data/riders/daily-log.example.json data/riders/daily-log.json
+          [ -f data/riders/stats.json ] || cp data/riders/stats.example.json data/riders/stats.json
+
       - name: Regenerate rider stats
         run: |
           processing/.venv/bin/python processing/rider_stats.py \


### PR DESCRIPTION
## Summary

The deploy workflow fails because `daily-log.json` and `stats.json` are gitignored (rider data kept out of git per #83). Added a step to copy from `.example.json` files if the real ones are missing.

## Test plan

- [ ] Merge to dev, then merge dev to main
- [ ] GitHub Actions deploy should pass the rider stats step

🤖 Generated with [Claude Code](https://claude.com/claude-code)