### PR TITLE
Replace publish schedule with stage details on production site

### DIFF
--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="bg-white rounded-lg shadow-sm p-6">
+    <h3 class="text-lg font-semibold text-gray-700 mb-4">Stage Details</h3>
+
+    <div class="mb-5">
+      <h4 class="text-sm font-semibold text-gray-500 mb-2">Towns</h4>
+      <div class="space-y-1">
+        <div v-for="town in towns" :key="town.name" class="flex justify-between text-sm">
+          <span class="text-gray-700">{{ town.name }}</span>
+          <span class="font-mono text-gray-400">km {{ town.km }} &middot; {{ town.elevation }}m</span>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <h4 class="text-sm font-semibold text-gray-500 mb-2">Climbs</h4>
+      <div class="space-y-1">
+        <div v-for="climb in climbs" :key="climb.name" class="flex justify-between text-sm">
+          <span class="text-gray-700">{{ climb.name }}</span>
+          <span class="font-mono text-gray-400">km {{ climb.km }} &middot; {{ climb.gradient }}%</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-4 pt-3 border-t border-gray-100 text-xs text-gray-400">
+      185 km &middot; 9 climbs &middot; +3,390m elevation
+    </div>
+  </div>
+</template>
+
+<script setup>
+import segmentsJson from '~/data/segments.json'
+
+// Known climb details from CLAUDE.md
+const climbData = {
+  'Puy Boubou': { length: 2.8, gradient: 4.1 },
+  'Côte de Lagleygeolle': { length: 5.2, gradient: 3.9 },
+  'Côte de Miel': { length: 6.6, gradient: 3.9 },
+  'Côte des Naves': { length: 2.8, gradient: 6.7 },
+  'Puy de Lachaud': { length: 3.6, gradient: 5.3 },
+  'Suc au May': { length: 3.8, gradient: 7.7 },
+  'Côte de la Croix de Pey': { length: 7.0, gradient: 4.9 },
+  'Mont Bessou': { length: 5.0, gradient: 3.5 },
+  'Côte des Gardes': { length: 2.2, gradient: 4.8 },
+}
+
+// Extract towns with their approximate km and elevation
+const townSet = new Map()
+for (const seg of segmentsJson) {
+  if (seg.towns?.length) {
+    for (const town of seg.towns) {
+      if (!townSet.has(town)) {
+        townSet.set(town, {
+          name: town,
+          km: seg.km_start.toFixed(0),
+          elevation: seg.min_elevation
+        })
+      }
+    }
+  }
+}
+const towns = Array.from(townSet.values())
+
+// Extract climbs with first appearance km
+const climbSet = new Map()
+for (const seg of segmentsJson) {
+  if (seg.climbs?.length) {
+    for (const climb of seg.climbs) {
+      if (!climbSet.has(climb)) {
+        const data = climbData[climb] || {}
+        climbSet.set(climb, {
+          name: climb,
+          km: seg.km_start.toFixed(0),
+          gradient: data.gradient || '?',
+          length: data.length || '?'
+        })
+      }
+    }
+  }
+}
+const climbs = Array.from(climbSet.values())
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -50,7 +50,8 @@
       <aside>
         <RiderDashboard />
         <div class="mt-6">
-          <PublishSchedule />
+          <PublishSchedule v-if="isDev" />
+          <StageDetails v-else />
         </div>
       </aside>
     </div>
@@ -60,6 +61,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 
+const isDev = process.dev
 const today = new Date().toISOString().split('T')[0]
 
 const segments = segmentsJson


### PR DESCRIPTION
## Summary

- New `StageDetails.vue`: lists 12 towns and 9 categorized climbs with km from start, elevation/gradient
- Homepage shows PublishSchedule in dev mode, StageDetails in production builds
- Data sourced from segments.json and known climb details from CLAUDE.md

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)