### PR TITLE
Migrate to Nuxt Content v3 query API

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -1,0 +1,23 @@
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+
+export default defineContentConfig({
+  collections: {
+    entries: defineCollection({
+      type: 'page',
+      source: 'entries/**',
+      schema: z.object({
+        segment: z.number(),
+        title: z.string(),
+        subtitle: z.string().optional(),
+        publishDate: z.string(),
+        kmStart: z.number(),
+        kmEnd: z.number(),
+        gpxFile: z.string().optional().nullable(),
+        elevationData: z.string().optional().nullable(),
+        images: z.array(z.any()).optional(),
+        weather: z.any().optional().nullable(),
+        draft: z.boolean().default(true)
+      })
+    })
+  }
+})

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -54,26 +54,33 @@
 import segmentsJson from '~/data/segments.json'
 
 const route = useRoute()
+const slug = route.path.replace(/^\//, '')
 const { data: page } = await useAsyncData(`entry-${route.path}`, () =>
-  queryContent(route.path).findOne()
+  queryCollection('entries')
+    .path(slug)
+    .first()
 )
 
 const today = new Date().toISOString().split('T')[0]
 
 const { data: prev } = await useAsyncData(`prev-${route.path}`, () =>
-  queryContent('entries')
-    .where({ segment: { $lt: page.value?.segment }, draft: false, publishDate: { $lte: today } })
-    .sort({ segment: -1 })
+  queryCollection('entries')
+    .where('segment', '<', page.value?.segment)
+    .where('draft', '=', false)
+    .where('publishDate', '<=', today)
+    .order('segment', 'DESC')
     .limit(1)
-    .findOne()
+    .first()
 )
 
 const { data: next } = await useAsyncData(`next-${route.path}`, () =>
-  queryContent('entries')
-    .where({ segment: { $gt: page.value?.segment }, draft: false, publishDate: { $lte: today } })
-    .sort({ segment: 1 })
+  queryCollection('entries')
+    .where('segment', '>', page.value?.segment)
+    .where('draft', '=', false)
+    .where('publishDate', '<=', today)
+    .order('segment', 'ASC')
     .limit(1)
-    .findOne()
+    .first()
 )
 
 const segments = segmentsJson

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -76,11 +76,12 @@ try {
 }
 
 const { data: entries } = await useAsyncData('entries', () =>
-  queryContent('entries')
-    .where({ draft: false, publishDate: { $lte: today } })
-    .sort({ publishDate: -1 })
+  queryCollection('entries')
+    .where('draft', '=', false)
+    .where('publishDate', '<=', today)
+    .order('publishDate', 'DESC')
     .limit(5)
-    .find()
+    .all()
 )
 
 function formatDate(dateStr) {


### PR DESCRIPTION
## Summary

Dependabot upgraded @nuxt/content from v2 to v3, which broke all content queries. This PR fixes:

- `queryContent()` -> `queryCollection()`
- `.find()` -> `.all()`, `.findOne()` -> `.first()`
- `.sort({ field: -1 })` -> `.order('field', 'DESC')`
- `.where({ field: value })` -> `.where('field', '=', value)`
- Add `content.config.ts` with entries collection schema (Content v3 requires schema for SQLite columns)

## Test plan

- [ ] Homepage shows published entries
- [ ] Entry pages load and render content
- [ ] Previous/next navigation works
- [ ] Draft entries hidden from homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)