### PR TITLE
Fix town and climb marker positions on map

### DIFF
--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -33,7 +33,8 @@ import 'leaflet/dist/leaflet.css'
 const props = defineProps({
   segment: { type: Number, required: true },
   segments: { type: Array, default: () => [] },
-  routeCoords: { type: Array, default: () => [] }
+  routeCoords: { type: Array, default: () => [] },
+  townCoords: { type: Object, default: () => ({}) }
 })
 
 const mapContainer = ref(null)
@@ -121,37 +122,49 @@ async function initMap(el) {
     opacity: 0.4
   })
 
-  // Towns and climbs markers overlay
+  // Towns and climbs markers overlay using real coordinates
   const poiGroup = L.layerGroup()
-  const allSegments = props.segments
-  for (const seg of allSegments) {
-    // Town markers
+  const townCoordsData = props.townCoords || {}
+  const placed = new Set()
+
+  for (const seg of props.segments) {
     if (seg.towns?.length) {
-      const midLat = (seg.start_lat + seg.end_lat) / 2
-      const midLng = (seg.start_lng + seg.end_lng) / 2
-      const townIcon = L.divIcon({
-        html: '<div style="width:8px;height:8px;background:#2563eb;border-radius:50%;border:1px solid white;box-shadow:0 1px 2px rgba(0,0,0,0.3)"></div>',
-        className: '',
-        iconSize: [10, 10],
-        iconAnchor: [5, 5]
-      })
-      L.marker([midLat, midLng], { icon: townIcon })
-        .bindPopup(`<b>${seg.towns.join(', ')}</b><br>Segment ${seg.segment}`)
-        .addTo(poiGroup)
+      for (const town of seg.towns) {
+        if (placed.has(town)) continue
+        placed.add(town)
+        const coords = townCoordsData[town]
+        const lat = coords?.lat || (seg.start_lat + seg.end_lat) / 2
+        const lng = coords?.lng || (seg.start_lng + seg.end_lng) / 2
+        const townIcon = L.divIcon({
+          html: '<div style="font-size:22px;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.4))">🏘️</div>',
+          className: '',
+          iconSize: [26, 26],
+          iconAnchor: [13, 13]
+        })
+        L.marker([lat, lng], { icon: townIcon })
+          .bindTooltip(town, { direction: 'top', offset: [0, -10] })
+          .bindPopup(`<b>${town}</b><br>Segment ${seg.segment}`)
+          .addTo(poiGroup)
+      }
     }
-    // Climb markers
     if (seg.climbs?.length) {
-      const midLat = (seg.start_lat + seg.end_lat) / 2
-      const midLng = (seg.start_lng + seg.end_lng) / 2
-      const climbIcon = L.divIcon({
-        html: '<div style="width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-bottom:10px solid #dc2626;filter:drop-shadow(0 1px 1px rgba(0,0,0,0.3))"></div>',
-        className: '',
-        iconSize: [12, 10],
-        iconAnchor: [6, 10]
-      })
-      L.marker([midLat, midLng], { icon: climbIcon })
-        .bindPopup(`<b>${seg.climbs.join(', ')}</b><br>Segment ${seg.segment}`)
-        .addTo(poiGroup)
+      for (const climb of seg.climbs) {
+        if (placed.has(climb)) continue
+        placed.add(climb)
+        const coords = townCoordsData[climb]
+        const lat = coords?.lat || (seg.start_lat + seg.end_lat) / 2
+        const lng = coords?.lng || (seg.start_lng + seg.end_lng) / 2
+        const climbIcon = L.divIcon({
+          html: '<div style="font-size:22px;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.4))">⛰️</div>',
+          className: '',
+          iconSize: [26, 26],
+          iconAnchor: [13, 13]
+        })
+        L.marker([lat, lng], { icon: climbIcon })
+          .bindTooltip(climb, { direction: 'top', offset: [0, -10] })
+          .bindPopup(`<b>${climb}</b><br>Segment ${seg.segment}`)
+          .addTo(poiGroup)
+      }
     }
   }
 

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -1,0 +1,107 @@
+{
+  "Malemort": {
+    "type": "town",
+    "lat": 45.1752984,
+    "lng": 1.574502
+  },
+  "Brive-la-Gaillarde": {
+    "type": "town",
+    "lat": 45.1584982,
+    "lng": 1.5332389
+  },
+  "Turenne": {
+    "type": "town",
+    "lat": 45.053482,
+    "lng": 1.5814221
+  },
+  "Collonges-la-Rouge": {
+    "type": "town",
+    "lat": 45.0604597,
+    "lng": 1.6551231
+  },
+  "Beynat": {
+    "type": "town",
+    "lat": 45.124713,
+    "lng": 1.7218235
+  },
+  "Tulle": {
+    "type": "town",
+    "lat": 45.2678347,
+    "lng": 1.7706797
+  },
+  "Naves": {
+    "type": "town",
+    "lat": 45.312319,
+    "lng": 1.7666474
+  },
+  "Chaumeil": {
+    "type": "town",
+    "lat": 45.4555541,
+    "lng": 1.8808583
+  },
+  "Treignac": {
+    "type": "town",
+    "lat": 45.5365916,
+    "lng": 1.7935339
+  },
+  "Bugeat": {
+    "type": "town",
+    "lat": 45.5975774,
+    "lng": 1.9281816
+  },
+  "Meymac": {
+    "type": "town",
+    "lat": 45.5366795,
+    "lng": 2.1464895
+  },
+  "Ussel": {
+    "type": "town",
+    "lat": 45.5456877,
+    "lng": 2.3118583
+  },
+  "Puy Boubou": {
+    "type": "climb",
+    "lat": 45.0677317,
+    "lng": 1.640618
+  },
+  "Côte de Lagleygeolle": {
+    "type": "climb",
+    "lat": 45.0782793,
+    "lng": 1.6965828
+  },
+  "Côte de Miel": {
+    "type": "climb",
+    "lat": 45.1363007,
+    "lng": 1.7651832
+  },
+  "Côte des Naves": {
+    "type": "climb",
+    "lat": 45.312319,
+    "lng": 1.7666474
+  },
+  "Puy de Lachaud": {
+    "type": "climb",
+    "lat": 45.336,
+    "lng": 1.784
+  },
+  "Suc au May": {
+    "type": "climb",
+    "lat": 45.4713728,
+    "lng": 1.8424529
+  },
+  "Côte de la Croix de Pey": {
+    "type": "climb",
+    "lat": 45.5192072,
+    "lng": 1.8741342
+  },
+  "Mont Bessou": {
+    "type": "climb",
+    "lat": 45.5701029,
+    "lng": 2.1231273
+  },
+  "Côte des Gardes": {
+    "type": "climb",
+    "lat": 45.527,
+    "lng": 2.174
+  }
+}

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -13,6 +13,7 @@
       :segment="page.segment"
       :segments="segments"
       :route-coords="routeCoords"
+      :town-coords="townCoords"
       class="mb-8"
     />
 
@@ -52,6 +53,7 @@
 
 <script setup>
 import segmentsJson from '~/data/segments.json'
+import townCoordsJson from '~/data/town-coords.json'
 
 const route = useRoute()
 const { data: page } = await useAsyncData(`entry-${route.path}`, () =>
@@ -83,6 +85,7 @@ const { data: next } = await useAsyncData(`next-${route.path}`, () =>
 )
 
 const segments = segmentsJson
+const townCoords = townCoordsJson
 
 // Load route coordinates
 const routeCoords = ref([])

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,6 +22,7 @@
             :segment="0"
             :segments="segments"
             :route-coords="routeCoords"
+            :town-coords="townCoords"
           />
           <p class="text-xs text-gray-400 mt-2">
             Full 185km route. Use layer controls for topo, cycling, and satellite views.
@@ -63,11 +64,13 @@
 
 <script setup>
 import segmentsJson from '~/data/segments.json'
+import townCoordsJson from '~/data/town-coords.json'
 
 const isDev = process.dev
 const today = new Date().toISOString().split('T')[0]
 
 const segments = segmentsJson
+const townCoords = townCoordsJson
 
 const overviewElevation = ref(null)
 try {

--- a/processing/geocode_towns.py
+++ b/processing/geocode_towns.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Geocode towns and climbs to get accurate coordinates using OpenStreetMap Nominatim."""
+
+import json
+import os
+import time
+import urllib.request
+import urllib.parse
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+USER_AGENT = "CorrezeTravelogue/1.0 (cycling travelogue project)"
+
+# Known towns with search hints for disambiguation
+TOWN_SEARCH = {
+    "Malemort": "Malemort-sur-Corrèze, Corrèze, France",
+    "Brive-la-Gaillarde": "Brive-la-Gaillarde, Corrèze, France",
+    "Turenne": "Turenne, Corrèze, France",
+    "Collonges-la-Rouge": "Collonges-la-Rouge, Corrèze, France",
+    "Beynat": "Beynat, Corrèze, France",
+    "Tulle": "Tulle, Corrèze, France",
+    "Naves": "Naves, Corrèze, France",
+    "Chaumeil": "Chaumeil, Corrèze, France",
+    "Treignac": "Treignac, Corrèze, France",
+    "Bugeat": "Bugeat, Corrèze, France",
+    "Meymac": "Meymac, Corrèze, France",
+    "Ussel": "Ussel, Corrèze, France",
+}
+
+# Known climbs with search hints
+CLIMB_SEARCH = {
+    "Puy Boubou": "Puy Boubou, Corrèze, France",
+    "Côte de Lagleygeolle": "Lagleygeolle, Corrèze, France",
+    "Côte de Miel": "Miel, Corrèze, France",
+    "Côte des Naves": "Naves, Corrèze, France",
+    "Puy de Lachaud": "Lachaud, Corrèze, France",
+    "Suc au May": "Suc au May, Corrèze, France",
+    "Côte de la Croix de Pey": "Croix de Pey, Corrèze, France",
+    "Mont Bessou": "Mont Bessou, Corrèze, France",
+    "Côte des Gardes": "Les Gardes, Corrèze, France",
+}
+
+
+def geocode(query):
+    """Look up coordinates for a place name using Nominatim."""
+    params = {
+        "q": query,
+        "format": "json",
+        "limit": "1",
+        "countrycodes": "fr",
+    }
+    url = f"{NOMINATIM_URL}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            if data:
+                return {
+                    "lat": float(data[0]["lat"]),
+                    "lng": float(data[0]["lon"]),
+                    "display_name": data[0].get("display_name", ""),
+                }
+    except Exception as e:
+        print(f"    Warning: geocode failed for '{query}': {e}")
+    return None
+
+
+def main():
+    output_path = "data/town-coords.json"
+    coords = {}
+
+    print("Geocoding towns...")
+    for name, query in TOWN_SEARCH.items():
+        result = geocode(query)
+        if result:
+            coords[name] = {
+                "type": "town",
+                "lat": result["lat"],
+                "lng": result["lng"],
+            }
+            print(f"  {name}: {result['lat']:.5f}, {result['lng']:.5f}")
+        else:
+            print(f"  {name}: NOT FOUND")
+        time.sleep(1)  # Nominatim rate limit: 1 req/sec
+
+    print("\nGeocoding climbs...")
+    for name, query in CLIMB_SEARCH.items():
+        result = geocode(query)
+        if result:
+            coords[name] = {
+                "type": "climb",
+                "lat": result["lat"],
+                "lng": result["lng"],
+            }
+            print(f"  {name}: {result['lat']:.5f}, {result['lng']:.5f}")
+        else:
+            print(f"  {name}: NOT FOUND")
+        time.sleep(1)
+
+    with open(output_path, "w") as f:
+        json.dump(coords, f, indent=2, ensure_ascii=False)
+
+    print(f"\nWrote {len(coords)} coordinates to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New `processing/geocode_towns.py` script queries OpenStreetMap Nominatim for real coordinates
- `data/town-coords.json` with accurate lat/lng for all 12 towns and 9 climbs
- 2 outlier climbs manually corrected (Nominatim returned wrong locations)
- SegmentMap uses real coordinates instead of segment midpoints
- Markers deduplicated (same town appearing in multiple segments only shows once)
- Falls back to segment midpoint if coordinates unavailable

## Test plan

- [ ] Toggle "Towns & Climbs" layer on the map
- [ ] Verify town markers align with actual town locations on OpenStreetMap
- [ ] Verify climb markers are in sensible positions along the route
- [ ] Check both homepage overview and entry page maps

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)