### PR TITLE
Add rider progress layer to map

### DIFF
--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -34,7 +34,9 @@ const props = defineProps({
   segment: { type: Number, required: true },
   segments: { type: Array, default: () => [] },
   routeCoords: { type: Array, default: () => [] },
-  townCoords: { type: Object, default: () => ({}) }
+  townCoords: { type: Object, default: () => ({}) },
+  riderStats: { type: Object, default: null },
+  riderConfig: { type: Object, default: null }
 })
 
 const mapContainer = ref(null)
@@ -175,10 +177,87 @@ async function initMap(el) {
     'Cycling': cyclOSM,
     'Satellite': satellite
   }
+  // Rider progress layer
+  const riderGroup = L.layerGroup()
+  if (props.riderStats?.riders && props.riderConfig?.riders && props.routeCoords.length > 1) {
+    // Build cumulative distance lookup from route coords
+    const cumDists = [0]
+    for (let i = 1; i < props.routeCoords.length; i++) {
+      const [lng1, lat1] = [props.routeCoords[i - 1][0], props.routeCoords[i - 1][1]]
+      const [lng2, lat2] = [props.routeCoords[i][0], props.routeCoords[i][1]]
+      cumDists.push(cumDists[i - 1] + haversine(lat1, lng1, lat2, lng2))
+    }
+    const totalMeters = cumDists[cumDists.length - 1]
+
+    // Calculate positions and group riders at same distance for offset
+    const riderPositions = []
+    for (const rider of props.riderConfig.riders) {
+      const stats = props.riderStats.riders[rider.id]
+      if (!stats || !stats.totalDistanceCapped) continue
+
+      const targetMeters = stats.totalDistanceCapped * 1000
+      let coordIdx = 0
+      for (let i = 0; i < cumDists.length; i++) {
+        if (cumDists[i] >= targetMeters) {
+          coordIdx = i
+          break
+        }
+        coordIdx = i
+      }
+      riderPositions.push({ rider, stats, coordIdx })
+    }
+
+    // Group by coordIdx to detect overlaps
+    const groups = {}
+    for (const rp of riderPositions) {
+      const key = rp.coordIdx
+      if (!groups[key]) groups[key] = []
+      groups[key].push(rp)
+    }
+
+    for (const key of Object.keys(groups)) {
+      const group = groups[key]
+      const coordIdx = parseInt(key)
+      const coord = props.routeCoords[coordIdx]
+
+      // Calculate perpendicular direction to route at this point
+      const prevIdx = Math.max(0, coordIdx - 1)
+      const nextIdx = Math.min(props.routeCoords.length - 1, coordIdx + 1)
+      const dx = props.routeCoords[nextIdx][0] - props.routeCoords[prevIdx][0]
+      const dy = props.routeCoords[nextIdx][1] - props.routeCoords[prevIdx][1]
+      // Perpendicular: rotate 90 degrees
+      const len = Math.sqrt(dx * dx + dy * dy) || 1
+      const perpLng = -dy / len
+      const perpLat = dx / len
+
+      const spread = 0.001 // ~100m offset between riders
+      const offset0 = -(group.length - 1) / 2
+
+      for (let i = 0; i < group.length; i++) {
+        const { rider, stats: rStats } = group[i]
+        const offsetAmount = (offset0 + i) * spread
+        const lat = coord[1] + perpLat * offsetAmount
+        const lng = coord[0] + perpLng * offsetAmount
+
+        const riderIcon = L.divIcon({
+          html: `<div style="font-size:20px;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.4));background:${rider.color};border-radius:50%;width:28px;height:28px;display:flex;align-items:center;justify-content:center;border:2px solid white">🚴</div>`,
+          className: '',
+          iconSize: [28, 28],
+          iconAnchor: [14, 14]
+        })
+        L.marker([lat, lng], { icon: riderIcon, zIndexOffset: i * 10 })
+          .bindTooltip(rider.name, { direction: 'top', offset: [0, -12], permanent: false })
+          .bindPopup(`<b style="color:${rider.color}">${rider.name}</b><br>${rStats.totalDistanceCapped} km of ${props.riderConfig.totalDistance} km`)
+          .addTo(riderGroup)
+      }
+    }
+  }
+
   const overlays = {
     'Cycle Routes': cycleRoutes,
     'Hillshade': hillshade,
-    'Towns & Climbs': poiGroup
+    'Towns & Climbs': poiGroup,
+    'Rider Progress': riderGroup
   }
   L.control.layers(baseLayers, overlays, { position: 'topleft' }).addTo(map)
 

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -14,6 +14,8 @@
       :segments="segments"
       :route-coords="routeCoords"
       :town-coords="townCoords"
+      :rider-stats="riderStats"
+      :rider-config="riderConfig"
       class="mb-8"
     />
 
@@ -54,6 +56,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import townCoordsJson from '~/data/town-coords.json'
+import riderConfigJson from '~/data/riders/rider-config.json'
 
 const route = useRoute()
 const { data: page } = await useAsyncData(`entry-${route.path}`, () =>
@@ -86,6 +89,15 @@ const { data: next } = await useAsyncData(`next-${route.path}`, () =>
 
 const segments = segmentsJson
 const townCoords = townCoordsJson
+const riderConfig = riderConfigJson
+
+const riderStats = ref(null)
+try {
+  const data = await import('~/data/riders/stats.json')
+  riderStats.value = data.default || data
+} catch {
+  riderStats.value = null
+}
 
 // Load route coordinates
 const routeCoords = ref([])

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,6 +23,8 @@
             :segments="segments"
             :route-coords="routeCoords"
             :town-coords="townCoords"
+            :rider-stats="riderStats"
+            :rider-config="riderConfig"
           />
           <p class="text-xs text-gray-400 mt-2">
             Full 185km route. Use layer controls for topo, cycling, and satellite views.
@@ -65,12 +67,22 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import townCoordsJson from '~/data/town-coords.json'
+import riderConfigJson from '~/data/riders/rider-config.json'
 
 const isDev = process.dev
 const today = new Date().toISOString().split('T')[0]
 
 const segments = segmentsJson
 const townCoords = townCoordsJson
+const riderConfig = riderConfigJson
+
+const riderStats = ref(null)
+try {
+  const data = await import('~/data/riders/stats.json')
+  riderStats.value = data.default || data
+} catch {
+  riderStats.value = null
+}
 
 const overviewElevation = ref(null)
 try {


### PR DESCRIPTION
## Summary

- New "Rider Progress" toggleable overlay in the map layer control
- Shows each rider as a 🚴 emoji at their current position along the route
- Position calculated by walking route coordinates with haversine until cumulative distance matches rider's capped total
- Hover tooltip shows rider name
- Click popup shows rider name (in their colour) and distance progress
- Available on both homepage and entry page maps

## Test plan

- [ ] Toggle "Rider Progress" layer on the homepage map
- [ ] Verify 4 rider markers appear near the start (6km each with test data)
- [ ] Hover shows rider name, click shows distance details
- [ ] Check entry page map also shows rider markers

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)