### PR TITLE
Add tests for GPX processing scripts

### DIFF
--- a/processing/tests/test_elevation_profile.py
+++ b/processing/tests/test_elevation_profile.py
@@ -1,0 +1,203 @@
+"""Tests for elevation_profile.py — elevation profiles, gradients, and power estimates."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from processing.elevation_profile import (
+    calculate_power,
+    format_time,
+    haversine,
+    process_segment,
+)
+
+
+# Minimal GPX for a segment with some elevation change
+SEGMENT_GPX = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test"
+     xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <name>Test Segment</name>
+    <trkseg>
+      <trkpt lat="45.0" lon="1.5"><ele>200</ele></trkpt>
+      <trkpt lat="45.001" lon="1.5"><ele>210</ele></trkpt>
+      <trkpt lat="45.002" lon="1.5"><ele>220</ele></trkpt>
+      <trkpt lat="45.003" lon="1.5"><ele>230</ele></trkpt>
+      <trkpt lat="45.004" lon="1.5"><ele>240</ele></trkpt>
+      <trkpt lat="45.005" lon="1.5"><ele>250</ele></trkpt>
+      <trkpt lat="45.006" lon="1.5"><ele>245</ele></trkpt>
+      <trkpt lat="45.007" lon="1.5"><ele>260</ele></trkpt>
+      <trkpt lat="45.008" lon="1.5"><ele>270</ele></trkpt>
+      <trkpt lat="45.009" lon="1.5"><ele>280</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+"""
+
+
+@pytest.fixture
+def segment_gpx_file(tmp_path):
+    path = tmp_path / "segment-01.gpx"
+    path.write_text(SEGMENT_GPX)
+    return str(path)
+
+
+# --- calculate_power ---
+
+class TestCalculatePower:
+    def test_flat_road_positive_power(self):
+        power = calculate_power(0.0, 35)
+        assert power > 0
+
+    def test_uphill_more_power_than_flat(self):
+        flat = calculate_power(0.0, 35)
+        uphill = calculate_power(5.0, 35)
+        assert uphill > flat
+
+    def test_steeper_requires_more_power(self):
+        mild = calculate_power(3.0, 35)
+        steep = calculate_power(8.0, 35)
+        assert steep > mild
+
+    def test_faster_requires_more_power(self):
+        slow = calculate_power(0.0, 30)
+        fast = calculate_power(0.0, 50)
+        assert fast > slow
+
+    def test_downhill_can_be_zero(self):
+        # Steep enough downhill at low speed should return 0 (freewheeling)
+        power = calculate_power(-10.0, 10)
+        assert power == 0
+
+    def test_returns_non_negative(self):
+        for gradient in [-15, -10, -5, 0, 5, 10]:
+            for speed in [20, 30, 40, 50]:
+                assert calculate_power(gradient, speed) >= 0
+
+    def test_reasonable_flat_power_at_35kmh(self):
+        # A 78kg rider+bike at 35km/h on flat should need ~150-300W
+        power = calculate_power(0.0, 35)
+        assert 100 < power < 400
+
+
+# --- format_time ---
+
+class TestFormatTime:
+    def test_whole_minutes(self):
+        assert format_time(10.0) == "10:00"
+
+    def test_fractional_minutes(self):
+        assert format_time(10.5) == "10:30"
+
+    def test_small_value(self):
+        assert format_time(1.25) == "1:15"
+
+
+# --- haversine ---
+
+class TestHaversine:
+    def test_same_point(self):
+        assert haversine(45.0, 1.5, 45.0, 1.5) == 0.0
+
+    def test_known_distance(self):
+        dist = haversine(45.0, 1.5, 46.0, 1.5)
+        assert 110_000 < dist < 112_000
+
+
+# --- process_segment ---
+
+class TestProcessSegment:
+    def test_returns_expected_keys(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        expected_keys = {
+            "segment", "distance", "elevation", "gradient",
+            "power_30kmh", "power_35kmh", "power_40kmh", "power_50kmh",
+            "summary",
+        }
+        assert expected_keys == set(result.keys())
+
+    def test_segment_number_preserved(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 7)
+        assert result["segment"] == 7
+
+    def test_arrays_same_length(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        n = len(result["distance"])
+        assert len(result["elevation"]) == n
+        assert len(result["gradient"]) == n
+        assert len(result["power_30kmh"]) == n
+        assert len(result["power_35kmh"]) == n
+        assert len(result["power_40kmh"]) == n
+        assert len(result["power_50kmh"]) == n
+
+    def test_distance_starts_at_zero(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        assert result["distance"][0] == 0.0
+
+    def test_distance_increases(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        for i in range(1, len(result["distance"])):
+            assert result["distance"][i] >= result["distance"][i - 1]
+
+    def test_summary_has_required_fields(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        summary = result["summary"]
+        required = {
+            "avg_gradient", "max_gradient", "elevation_gain", "elevation_loss",
+            "avg_power_30kmh", "avg_power_35kmh", "avg_power_40kmh", "avg_power_50kmh",
+            "estimated_time_30kmh", "estimated_time_35kmh",
+            "estimated_time_40kmh", "estimated_time_50kmh",
+        }
+        assert required.issubset(summary.keys())
+
+    def test_elevation_gain_positive_for_uphill(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        # Our test GPX goes mostly uphill
+        assert result["summary"]["elevation_gain"] > 0
+
+    def test_power_increases_with_speed(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        s = result["summary"]
+        assert s["avg_power_30kmh"] < s["avg_power_35kmh"]
+        assert s["avg_power_35kmh"] < s["avg_power_40kmh"]
+        assert s["avg_power_40kmh"] < s["avg_power_50kmh"]
+
+    def test_estimated_time_format(self, segment_gpx_file):
+        result = process_segment(segment_gpx_file, 1)
+        import re
+        for key in ["estimated_time_30kmh", "estimated_time_35kmh",
+                     "estimated_time_40kmh", "estimated_time_50kmh"]:
+            assert re.match(r"^\d+:\d{2}$", result["summary"][key])
+
+
+# --- Integration with real data ---
+
+class TestRealElevationData:
+    """Tests using actual generated elevation data (skipped if not available)."""
+
+    @pytest.fixture
+    def real_elevation(self):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "data", "elevation", "segment-01.json"
+        )
+        if not os.path.exists(path):
+            pytest.skip("data/elevation/segment-01.json not found")
+        with open(path) as f:
+            return json.load(f)
+
+    def test_output_structure(self, real_elevation):
+        assert real_elevation["segment"] == 1
+        assert len(real_elevation["distance"]) == len(real_elevation["elevation"])
+
+    def test_power_in_reasonable_range(self, real_elevation):
+        s = real_elevation["summary"]
+        # Average power at 35km/h should be 100-600W for any segment
+        assert 100 < s["avg_power_35kmh"] < 600
+
+    def test_gradient_in_reasonable_range(self, real_elevation):
+        s = real_elevation["summary"]
+        assert 0 <= s["avg_gradient"] < 15
+        assert s["max_gradient"] < 25

--- a/processing/tests/test_split_gpx.py
+++ b/processing/tests/test_split_gpx.py
@@ -1,0 +1,229 @@
+"""Tests for split_gpx.py — GPX parsing and segment splitting."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from processing.split_gpx import (
+    haversine,
+    parse_gpx,
+    split_into_segments,
+    write_segment_gpx,
+    KNOWN_TOWNS,
+    KNOWN_CLIMBS,
+)
+
+
+# Minimal GPX content: a short track with 5 points spanning ~1km
+MINIMAL_GPX = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test"
+     xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <name>Test Route</name>
+    <trkseg>
+      <trkpt lat="45.0" lon="1.5"><ele>200</ele></trkpt>
+      <trkpt lat="45.001" lon="1.5"><ele>210</ele></trkpt>
+      <trkpt lat="45.002" lon="1.5"><ele>220</ele></trkpt>
+      <trkpt lat="45.003" lon="1.5"><ele>215</ele></trkpt>
+      <trkpt lat="45.004" lon="1.5"><ele>230</ele></trkpt>
+      <trkpt lat="45.005" lon="1.5"><ele>225</ele></trkpt>
+      <trkpt lat="45.006" lon="1.5"><ele>240</ele></trkpt>
+      <trkpt lat="45.007" lon="1.5"><ele>235</ele></trkpt>
+      <trkpt lat="45.008" lon="1.5"><ele>250</ele></trkpt>
+      <trkpt lat="45.009" lon="1.5"><ele>245</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>
+"""
+
+
+@pytest.fixture
+def gpx_file(tmp_path):
+    """Write minimal GPX to a temp file."""
+    path = tmp_path / "test.gpx"
+    path.write_text(MINIMAL_GPX)
+    return str(path)
+
+
+# --- haversine ---
+
+class TestHaversine:
+    def test_same_point_is_zero(self):
+        assert haversine(45.0, 1.5, 45.0, 1.5) == 0.0
+
+    def test_known_distance(self):
+        # ~111km per degree of latitude
+        dist = haversine(45.0, 1.5, 46.0, 1.5)
+        assert 110_000 < dist < 112_000
+
+    def test_symmetry(self):
+        d1 = haversine(45.0, 1.5, 45.1, 1.6)
+        d2 = haversine(45.1, 1.6, 45.0, 1.5)
+        assert abs(d1 - d2) < 0.01
+
+
+# --- parse_gpx ---
+
+class TestParseGpx:
+    def test_returns_correct_point_count(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        assert len(points) == 10
+
+    def test_first_point_zero_distance(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        assert points[0]["cum_km"] == 0.0
+
+    def test_cumulative_distance_increases(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        for i in range(1, len(points)):
+            assert points[i]["cum_km"] > points[i - 1]["cum_km"]
+
+    def test_elevation_preserved(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        assert points[0]["ele"] == 200
+        assert points[4]["ele"] == 230
+
+    def test_coordinates_preserved(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        assert points[0]["lat"] == 45.0
+        assert points[0]["lon"] == 1.5
+
+
+# --- split_into_segments ---
+
+class TestSplitIntoSegments:
+    def test_correct_segment_count(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        assert len(segments) == 2
+
+    def test_segment_numbering(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=3)
+        assert [s["segment"] for s in segments] == [1, 2, 3]
+
+    def test_km_start_end_continuous(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        assert segments[0]["km_start"] == 0.0
+        assert segments[0]["km_end"] == pytest.approx(segments[1]["km_start"], abs=0.2)
+
+    def test_elevation_gain_non_negative(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        for seg in segments:
+            assert seg["elevation_gain"] >= 0
+            assert seg["elevation_loss"] >= 0
+
+    def test_min_max_elevation_consistent(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        for seg in segments:
+            assert seg["min_elevation"] <= seg["max_elevation"]
+
+    def test_segment_has_required_keys(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        required = {
+            "segment", "km_start", "km_end", "start_lat", "start_lng",
+            "end_lat", "end_lng", "elevation_gain", "elevation_loss",
+            "min_elevation", "max_elevation", "notable_points", "towns",
+            "climbs", "points",
+        }
+        for seg in segments:
+            assert required.issubset(seg.keys())
+
+    def test_towns_assigned_to_correct_segment(self, gpx_file):
+        # Use the real GPX to verify town assignment
+        points = parse_gpx(gpx_file)
+        # Our test GPX is too short for real towns — just verify lists are returned
+        segments = split_into_segments(points, num_segments=2)
+        for seg in segments:
+            assert isinstance(seg["towns"], list)
+            assert isinstance(seg["climbs"], list)
+
+
+# --- write_segment_gpx ---
+
+class TestWriteSegmentGpx:
+    def test_writes_valid_gpx(self, gpx_file, tmp_path):
+        import gpxpy as gpxpy_lib
+
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        output_dir = str(tmp_path / "output")
+        os.makedirs(output_dir)
+
+        path = write_segment_gpx(segments[0], output_dir)
+        assert os.path.exists(path)
+
+        # Verify the output is parseable GPX
+        with open(path) as f:
+            gpx = gpxpy_lib.parse(f)
+        assert len(gpx.tracks) == 1
+        assert len(gpx.tracks[0].segments[0].points) > 0
+
+    def test_filename_zero_padded(self, gpx_file, tmp_path):
+        points = parse_gpx(gpx_file)
+        segments = split_into_segments(points, num_segments=2)
+        output_dir = str(tmp_path / "output")
+        os.makedirs(output_dir)
+
+        path = write_segment_gpx(segments[0], output_dir)
+        assert path.endswith("segment-01.gpx")
+
+
+# --- Integration with real data ---
+
+class TestRealData:
+    """Tests using the actual project GPX data (skipped if not available)."""
+
+    @pytest.fixture
+    def real_segments(self):
+        segments_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "data", "segments.json"
+        )
+        if not os.path.exists(segments_path):
+            pytest.skip("data/segments.json not found")
+        with open(segments_path) as f:
+            return json.load(f)
+
+    def test_26_segments(self, real_segments):
+        assert len(real_segments) == 26
+
+    def test_segments_approximately_equal_length(self, real_segments):
+        for seg in real_segments:
+            length = seg["km_end"] - seg["km_start"]
+            assert 5.0 < length < 10.0, f"Segment {seg['segment']} length {length} out of range"
+
+    def test_total_distance_approximately_185km(self, real_segments):
+        total = real_segments[-1]["km_end"]
+        assert 180 < total < 190
+
+    def test_malemort_in_segment_1(self, real_segments):
+        assert "Malemort" in real_segments[0]["towns"]
+
+    def test_ussel_in_segment_26(self, real_segments):
+        assert "Ussel" in real_segments[25]["towns"]
+
+    def test_all_towns_assigned(self, real_segments):
+        all_towns = set()
+        for seg in real_segments:
+            all_towns.update(seg["towns"])
+        for town in KNOWN_TOWNS:
+            assert town in all_towns, f"Town {town} not assigned to any segment"
+
+    def test_all_climbs_assigned(self, real_segments):
+        all_climbs = set()
+        for seg in real_segments:
+            all_climbs.update(seg["climbs"])
+        for climb in KNOWN_CLIMBS:
+            assert climb in all_climbs, f"Climb {climb} not assigned to any segment"
+
+    def test_coordinates_in_france(self, real_segments):
+        for seg in real_segments:
+            assert 44.5 < seg["start_lat"] < 46.0
+            assert 1.0 < seg["start_lng"] < 3.0


### PR DESCRIPTION
## Summary

- Add `test_split_gpx.py` — 25 tests covering haversine, parse_gpx, split_into_segments, write_segment_gpx, plus integration tests verifying all 26 segments, town/climb assignments, and coordinate bounds
- Add `test_elevation_profile.py` — 24 tests covering calculate_power, format_time, process_segment, plus integration tests validating real elevation data ranges

Closes #91

## Test plan

- [x] All 49 tests pass locally (`pytest processing/tests/ -v`)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)