### PR TITLE
Add tests for weather and image suggestion scripts

### DIFF
--- a/processing/tests/test_suggest_images.py
+++ b/processing/tests/test_suggest_images.py
@@ -1,0 +1,282 @@
+"""Tests for suggest_images.py — Wikimedia Commons image suggestions."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from processing.suggest_images import (
+    geosearch,
+    get_image_info,
+    process_segment,
+)
+
+
+# --- geosearch ---
+
+class TestGeosearch:
+    def test_successful_search(self):
+        mock_data = json.dumps({
+            "query": {
+                "geosearch": [
+                    {"pageid": 1, "title": "File:Photo1.jpg", "lat": 45.0, "lon": 1.5},
+                    {"pageid": 2, "title": "File:Photo2.jpg", "lat": 45.01, "lon": 1.51},
+                ]
+            }
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = geosearch(45.0, 1.5)
+
+        assert len(results) == 2
+        assert results[0]["title"] == "File:Photo1.jpg"
+
+    def test_api_url_has_correct_params(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("test")) as mock_open:
+            geosearch(45.1, 1.6, radius=3000, limit=25)
+
+        req = mock_open.call_args[0][0]
+        assert "gscoord=45.1%7C1.6" in req.full_url
+        assert "gsradius=3000" in req.full_url
+        assert "gslimit=25" in req.full_url
+        assert "gsnamespace=6" in req.full_url
+
+    def test_handles_failure(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            results = geosearch(45.0, 1.5)
+        assert results == []
+
+    def test_handles_empty_response(self):
+        mock_data = json.dumps({"query": {"geosearch": []}}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = geosearch(45.0, 1.5)
+        assert results == []
+
+
+# --- get_image_info ---
+
+class TestGetImageInfo:
+    def _mock_imageinfo_response(self, pages):
+        mock_data = json.dumps({"query": {"pages": pages}}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_filters_cc_licensed(self):
+        pages = {
+            "1": {
+                "title": "File:CC_Photo.jpg",
+                "imageinfo": [{
+                    "url": "https://example.com/photo.jpg",
+                    "thumburl": "https://example.com/thumb.jpg",
+                    "descriptionurl": "https://commons.wikimedia.org/wiki/File:CC_Photo.jpg",
+                    "mime": "image/jpeg",
+                    "width": 800,
+                    "height": 600,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "CC BY-SA 4.0"},
+                        "Artist": {"value": "Test Author"},
+                        "ImageDescription": {"value": "A photo"},
+                    },
+                }],
+            },
+            "2": {
+                "title": "File:NonCC.jpg",
+                "imageinfo": [{
+                    "url": "https://example.com/noncc.jpg",
+                    "mime": "image/jpeg",
+                    "width": 800,
+                    "height": 600,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "All rights reserved"},
+                        "Artist": {"value": "Someone"},
+                        "ImageDescription": {"value": ""},
+                    },
+                }],
+            },
+        }
+        mock_resp = self._mock_imageinfo_response(pages)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = get_image_info(["File:CC_Photo.jpg", "File:NonCC.jpg"])
+
+        assert len(results) == 1
+        assert results[0]["license"] == "CC BY-SA 4.0"
+
+    def test_filters_small_images(self):
+        pages = {
+            "1": {
+                "title": "File:Tiny.jpg",
+                "imageinfo": [{
+                    "url": "https://example.com/tiny.jpg",
+                    "mime": "image/jpeg",
+                    "width": 200,
+                    "height": 150,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "CC BY 4.0"},
+                        "Artist": {"value": "Author"},
+                        "ImageDescription": {"value": ""},
+                    },
+                }],
+            },
+        }
+        mock_resp = self._mock_imageinfo_response(pages)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = get_image_info(["File:Tiny.jpg"])
+
+        assert len(results) == 0
+
+    def test_filters_svg(self):
+        pages = {
+            "1": {
+                "title": "File:Map.svg",
+                "imageinfo": [{
+                    "url": "https://example.com/map.svg",
+                    "mime": "image/svg+xml",
+                    "width": 800,
+                    "height": 600,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "CC BY-SA 4.0"},
+                        "Artist": {"value": "Author"},
+                        "ImageDescription": {"value": ""},
+                    },
+                }],
+            },
+        }
+        mock_resp = self._mock_imageinfo_response(pages)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = get_image_info(["File:Map.svg"])
+
+        assert len(results) == 0
+
+    def test_empty_titles(self):
+        results = get_image_info([])
+        assert results == []
+
+    def test_output_structure(self):
+        pages = {
+            "1": {
+                "title": "File:Test.jpg",
+                "imageinfo": [{
+                    "url": "https://example.com/full.jpg",
+                    "thumburl": "https://example.com/thumb.jpg",
+                    "descriptionurl": "https://commons.wikimedia.org/wiki/File:Test.jpg",
+                    "mime": "image/jpeg",
+                    "width": 1024,
+                    "height": 768,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "CC BY 2.0"},
+                        "Artist": {"value": "Photographer"},
+                        "ImageDescription": {"value": "Nice photo"},
+                    },
+                }],
+            },
+        }
+        mock_resp = self._mock_imageinfo_response(pages)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = get_image_info(["File:Test.jpg"])
+
+        assert len(results) == 1
+        img = results[0]
+        assert img["title"] == "File:Test.jpg"
+        assert img["url"] == "https://example.com/thumb.jpg"
+        assert img["full_url"] == "https://example.com/full.jpg"
+        assert img["width"] == 1024
+        assert img["height"] == 768
+        assert img["license"] == "CC BY 2.0"
+        assert img["artist"] == "Photographer"
+        assert img["description"] == "Nice photo"
+
+    def test_accepts_public_domain(self):
+        pages = {
+            "1": {
+                "title": "File:PD.jpg",
+                "imageinfo": [{
+                    "url": "https://example.com/pd.jpg",
+                    "mime": "image/jpeg",
+                    "width": 800,
+                    "height": 600,
+                    "extmetadata": {
+                        "LicenseShortName": {"value": "Public domain"},
+                        "Artist": {"value": "Old Author"},
+                        "ImageDescription": {"value": ""},
+                    },
+                }],
+            },
+        }
+        mock_resp = self._mock_imageinfo_response(pages)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = get_image_info(["File:PD.jpg"])
+
+        assert len(results) == 1
+
+
+# --- process_segment ---
+
+class TestProcessSegment:
+    def test_uses_midpoint_coordinates(self):
+        segment = {
+            "start_lat": 45.0, "end_lat": 45.1,
+            "start_lng": 1.5, "end_lng": 1.6,
+        }
+
+        with patch("processing.suggest_images.geosearch", return_value=[]) as mock_geo:
+            process_segment(segment)
+
+        mock_geo.assert_called_once()
+        call_lat, call_lng = mock_geo.call_args[0][:2]
+        assert call_lat == pytest.approx(45.05)
+        assert call_lng == pytest.approx(1.55)
+
+    def test_sorts_by_width(self):
+        segment = {
+            "start_lat": 45.0, "end_lat": 45.1,
+            "start_lng": 1.5, "end_lng": 1.6,
+        }
+
+        geo_results = [
+            {"title": "File:Small.jpg"},
+            {"title": "File:Large.jpg"},
+        ]
+
+        image_results = [
+            {"title": "File:Small.jpg", "width": 400, "height": 300,
+             "url": "", "full_url": "", "description_url": "",
+             "license": "CC BY 4.0", "artist": "", "description": ""},
+            {"title": "File:Large.jpg", "width": 1200, "height": 900,
+             "url": "", "full_url": "", "description_url": "",
+             "license": "CC BY 4.0", "artist": "", "description": ""},
+        ]
+
+        with patch("processing.suggest_images.geosearch", return_value=geo_results), \
+             patch("processing.suggest_images.get_image_info", return_value=image_results):
+            results = process_segment(segment)
+
+        assert results[0]["width"] >= results[1]["width"]
+
+    def test_empty_geosearch(self):
+        segment = {
+            "start_lat": 45.0, "end_lat": 45.1,
+            "start_lng": 1.5, "end_lng": 1.6,
+        }
+
+        with patch("processing.suggest_images.geosearch", return_value=[]):
+            results = process_segment(segment)
+
+        assert results == []

--- a/processing/tests/test_weather.py
+++ b/processing/tests/test_weather.py
@@ -1,0 +1,210 @@
+"""Tests for weather.py — weather fetching and frontmatter injection."""
+
+import json
+import os
+import re
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from processing.weather import (
+    degree_to_compass,
+    get_weather,
+    inject_weather_into_entry,
+    find_current_entry,
+)
+
+
+# --- degree_to_compass ---
+
+class TestDegreeToCompass:
+    def test_north(self):
+        assert degree_to_compass(0) == "N"
+        assert degree_to_compass(360) == "N"
+
+    def test_east(self):
+        assert degree_to_compass(90) == "E"
+
+    def test_south(self):
+        assert degree_to_compass(180) == "S"
+
+    def test_west(self):
+        assert degree_to_compass(270) == "W"
+
+    def test_intermediate(self):
+        assert degree_to_compass(45) == "NE"
+        assert degree_to_compass(135) == "SE"
+        assert degree_to_compass(225) == "SW"
+        assert degree_to_compass(315) == "NW"
+
+
+# --- get_weather ---
+
+class TestGetWeather:
+    def test_successful_fetch(self):
+        mock_response = json.dumps({
+            "main": {"temp": 18.3},
+            "weather": [{"description": "broken clouds"}],
+            "wind": {"speed": 3.5, "deg": 180},
+        }).encode()
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = mock_response
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = get_weather(45.0, 1.5, "fake-key")
+
+        assert result is not None
+        assert result["current"]["temp"] == 18
+        assert result["current"]["conditions"] == "Broken clouds"
+        assert "km/h" in result["current"]["wind"]
+        assert result["forecast"] is None
+
+    def test_api_url_construction(self):
+        """Verify the API is called with correct parameters."""
+        with patch("urllib.request.urlopen", side_effect=Exception("test")) as mock_open:
+            result = get_weather(45.1, 1.6, "my-key")
+
+        assert result is None
+        # Verify the request was made
+        call_args = mock_open.call_args
+        req = call_args[0][0]
+        assert "lat=45.1" in req.full_url
+        assert "lon=1.6" in req.full_url
+        assert "appid=my-key" in req.full_url
+        assert "units=metric" in req.full_url
+
+    def test_handles_api_failure(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+            result = get_weather(45.0, 1.5, "fake-key")
+        assert result is None
+
+
+# --- inject_weather_into_entry ---
+
+class TestInjectWeather:
+    def test_replaces_weather_field(self, tmp_path):
+        entry = tmp_path / "01-test.md"
+        entry.write_text(
+            "---\n"
+            "segment: 1\n"
+            "title: Test\n"
+            "weather: null\n"
+            "draft: false\n"
+            "---\n"
+            "# Content here\n"
+        )
+
+        weather = {"current": {"temp": 20, "conditions": "Clear", "wind": "5 km/h N"}, "forecast": None}
+        inject_weather_into_entry(str(entry), weather)
+
+        content = entry.read_text()
+        assert '"temp": 20' in content
+        assert "weather: null" not in content
+
+    def test_preserves_other_fields(self, tmp_path):
+        entry = tmp_path / "01-test.md"
+        entry.write_text(
+            "---\n"
+            "segment: 1\n"
+            "title: My Title\n"
+            "weather: null\n"
+            "draft: false\n"
+            "---\n"
+            "# Content here\n"
+        )
+
+        weather = {"current": {"temp": 15}, "forecast": None}
+        inject_weather_into_entry(str(entry), weather)
+
+        content = entry.read_text()
+        assert "segment: 1" in content
+        assert 'title: My Title' in content
+        assert "draft: false" in content
+        assert "# Content here" in content
+
+    def test_replaces_existing_weather(self, tmp_path):
+        entry = tmp_path / "01-test.md"
+        entry.write_text(
+            "---\n"
+            "segment: 1\n"
+            'weather: {"current": {"temp": 10}}\n'
+            "draft: false\n"
+            "---\n"
+        )
+
+        weather = {"current": {"temp": 25}, "forecast": None}
+        inject_weather_into_entry(str(entry), weather)
+
+        content = entry.read_text()
+        assert '"temp": 25' in content
+        assert '"temp": 10' not in content
+
+    def test_no_change_when_weather_is_none(self, tmp_path):
+        entry = tmp_path / "01-test.md"
+        original = "---\nsegment: 1\nweather: null\n---\n"
+        entry.write_text(original)
+
+        inject_weather_into_entry(str(entry), None)
+
+        assert entry.read_text() == original
+
+
+# --- find_current_entry ---
+
+class TestFindCurrentEntry:
+    def test_finds_most_recent_published(self, tmp_path):
+        entries_dir = tmp_path / "entries"
+        entries_dir.mkdir()
+
+        (entries_dir / "01-first.md").write_text(
+            "---\nsegment: 1\npublishDate: 2026-01-01\ndraft: false\n---\n"
+        )
+        (entries_dir / "02-second.md").write_text(
+            "---\nsegment: 2\npublishDate: 2026-01-05\ndraft: false\n---\n"
+        )
+        (entries_dir / "03-draft.md").write_text(
+            "---\nsegment: 3\npublishDate: 2026-01-10\ndraft: true\n---\n"
+        )
+
+        segments = [
+            {"segment": 1, "start_lat": 45.0, "end_lat": 45.1, "start_lng": 1.5, "end_lng": 1.6},
+            {"segment": 2, "start_lat": 45.1, "end_lat": 45.2, "start_lng": 1.6, "end_lng": 1.7},
+            {"segment": 3, "start_lat": 45.2, "end_lat": 45.3, "start_lng": 1.7, "end_lng": 1.8},
+        ]
+        seg_json = tmp_path / "segments.json"
+        seg_json.write_text(json.dumps(segments))
+
+        result = find_current_entry(str(entries_dir), str(seg_json))
+
+        assert result is not None
+        assert result["segment"] == 2
+        assert result["lat"] is not None
+        assert result["lng"] is not None
+
+    def test_skips_drafts(self, tmp_path):
+        entries_dir = tmp_path / "entries"
+        entries_dir.mkdir()
+
+        (entries_dir / "01-draft.md").write_text(
+            "---\nsegment: 1\npublishDate: 2026-01-01\ndraft: true\n---\n"
+        )
+
+        seg_json = tmp_path / "segments.json"
+        seg_json.write_text("[]")
+
+        result = find_current_entry(str(entries_dir), str(seg_json))
+        assert result is None
+
+    def test_empty_directory(self, tmp_path):
+        entries_dir = tmp_path / "entries"
+        entries_dir.mkdir()
+
+        seg_json = tmp_path / "segments.json"
+        seg_json.write_text("[]")
+
+        result = find_current_entry(str(entries_dir), str(seg_json))
+        assert result is None


### PR DESCRIPTION
## Summary

- `test_weather.py` (15 tests): compass direction conversion, weather API fetch with mocked responses, URL parameter verification, frontmatter injection (replaces weather field, preserves other fields, handles existing/null weather), current entry finder (most recent published, skips drafts, empty dir)
- `test_suggest_images.py` (13 tests): geosearch API with mocks, CC license filtering, minimum width filtering, SVG exclusion, public domain acceptance, output structure validation, midpoint coordinate calculation, width-sorted results

All external API calls are mocked — no network requests during tests.

Closes #93

## Test plan

- [x] All 28 tests pass locally
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)