### PR TITLE
Add tests for server API endpoints

### DIFF
--- a/tests/api/entries.test.ts
+++ b/tests/api/entries.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedReaddir } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedReaddir: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  readdirSync: mockedReaddir,
+  default: { readFileSync: mockedReadFile, readdirSync: mockedReaddir },
+}))
+
+import handler from '~/server/api/entries.get'
+
+describe('GET /api/entries', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns parsed entries with frontmatter', () => {
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile.mockReturnValue(
+      '---\nsegment: 1\ntitle: "Test Entry"\ndraft: false\npublishDate: 2026-04-02\n---\n# Content'
+    )
+
+    const result = (handler as Function)(mockEvent())
+
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0].filename).toBe('01-test.md')
+    expect(result.entries[0].segment).toBe(1)
+    expect(result.entries[0].title).toBe('Test Entry')
+    expect(result.entries[0].draft).toBe(false)
+  })
+
+  it('converts types correctly', () => {
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile.mockReturnValue(
+      '---\nsegment: 5\ndraft: true\nweather: null\nkmStart: 28.4\n---\n'
+    )
+
+    const result = (handler as Function)(mockEvent())
+    const entry = result.entries[0]
+
+    expect(entry.segment).toBe(5)
+    expect(entry.draft).toBe(true)
+    expect(entry.weather).toBe(null)
+    expect(entry.kmStart).toBe(28.4)
+  })
+
+  it('filters non-md files', () => {
+    mockedReaddir.mockReturnValue(['01-test.md', 'readme.txt', '.DS_Store'])
+    mockedReadFile.mockReturnValue('---\nsegment: 1\n---\n')
+
+    const result = (handler as Function)(mockEvent())
+
+    expect(result.entries).toHaveLength(1)
+  })
+
+  it('returns empty array when no entries', () => {
+    mockedReaddir.mockReturnValue([])
+
+    const result = (handler as Function)(mockEvent())
+
+    expect(result.entries).toEqual([])
+  })
+})

--- a/tests/api/entry-content.test.ts
+++ b/tests/api/entry-content.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedWriteFile } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedWriteFile: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  writeFileSync: mockedWriteFile,
+  default: { readFileSync: mockedReadFile, writeFileSync: mockedWriteFile },
+}))
+
+import getHandler from '~/server/api/entry-content.get'
+import postHandler from '~/server/api/entry-content.post'
+
+describe('GET /api/entry-content', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns frontmatter and body separately', () => {
+    mockedReadFile.mockReturnValue(
+      '---\nsegment: 1\ntitle: Test\n---\n# Hello\n\nSome content.'
+    )
+    const result = (getHandler as Function)(mockEvent({ query: { filename: '01-test.md' } }))
+    expect(result.frontmatter).toBe('segment: 1\ntitle: Test')
+    expect(result.body).toBe('# Hello\n\nSome content.')
+  })
+
+  it('throws 400 without filename', () => {
+    expect(() => {
+      (getHandler as Function)(mockEvent({ query: {} }))
+    }).toThrow('Missing filename')
+  })
+
+  it('returns raw content if no frontmatter', () => {
+    mockedReadFile.mockReturnValue('# No frontmatter here')
+    const result = (getHandler as Function)(mockEvent({ query: { filename: 'test.md' } }))
+    expect(result.frontmatter).toBe('')
+    expect(result.body).toBe('# No frontmatter here')
+  })
+})
+
+describe('POST /api/entry-content', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('writes file with frontmatter and body', async () => {
+    const result = await (postHandler as Function)(mockEvent({
+      body: { filename: '01-test.md', frontmatter: 'segment: 1\ntitle: Test', content: '# Hello\n\nBody text.' },
+    }))
+    expect(result.success).toBe(true)
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('---\nsegment: 1\ntitle: Test\n---\n# Hello')
+  })
+
+  it('throws 400 without filename', async () => {
+    await expect((postHandler as Function)(mockEvent({ body: {} }))).rejects.toThrow('Missing filename')
+  })
+})

--- a/tests/api/entry-status.test.ts
+++ b/tests/api/entry-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedWriteFile } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedWriteFile: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  writeFileSync: mockedWriteFile,
+  default: { readFileSync: mockedReadFile, writeFileSync: mockedWriteFile },
+}))
+
+import handler from '~/server/api/entry-status.post'
+
+describe('POST /api/entry-status', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('toggles draft field', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\ndraft: true\npublishDate: 2026-04-02\n---\n# Content')
+    await (handler as Function)(mockEvent({ body: { filename: '01-test.md', draft: false } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('draft: false')
+    expect(written).not.toContain('draft: true')
+  })
+
+  it('updates publishDate', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\ndraft: false\npublishDate: 2026-04-02\n---\n')
+    await (handler as Function)(mockEvent({ body: { filename: '01-test.md', publishDate: '2026-05-01' } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('publishDate: 2026-05-01')
+    expect(written).not.toContain('publishDate: 2026-04-02')
+  })
+
+  it('preserves other fields', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\ntitle: "My Title"\ndraft: true\npublishDate: 2026-04-02\n---\n# Body')
+    await (handler as Function)(mockEvent({ body: { filename: '01-test.md', draft: false } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('segment: 1')
+    expect(written).toContain('title: "My Title"')
+    expect(written).toContain('# Body')
+  })
+
+  it('throws 400 without filename', async () => {
+    await expect((handler as Function)(mockEvent({ body: {} }))).rejects.toThrow('Missing filename')
+  })
+})

--- a/tests/api/helpers.ts
+++ b/tests/api/helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Test helpers for server API endpoint tests.
+ */
+
+/** Create a mock H3 event with optional query and body. */
+export function mockEvent(opts: { query?: Record<string, string>; body?: any } = {}) {
+  return {
+    _query: opts.query || {},
+    _body: opts.body || {},
+  }
+}

--- a/tests/api/images.test.ts
+++ b/tests/api/images.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedWriteFile, mockedReaddir, mockedExists } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedWriteFile: vi.fn(),
+  mockedReaddir: vi.fn(),
+  mockedExists: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  writeFileSync: mockedWriteFile,
+  readdirSync: mockedReaddir,
+  existsSync: mockedExists,
+  default: { readFileSync: mockedReadFile, writeFileSync: mockedWriteFile, readdirSync: mockedReaddir, existsSync: mockedExists },
+}))
+
+import getHandler from '~/server/api/images.get'
+import postHandler from '~/server/api/images.post'
+
+describe('GET /api/images', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns suggestions and entry images', () => {
+    mockedExists.mockReturnValue(true)
+    mockedReadFile
+      .mockReturnValueOnce(JSON.stringify({ images: [{ title: 'File:Photo.jpg', url: 'https://example.com/photo.jpg' }] }))
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile
+      .mockReturnValueOnce('---\nsegment: 1\nimages: [{"src": "/img/test.jpg"}]\n---\n')
+    const result = (getHandler as Function)(mockEvent({ query: { segment: '1' } }))
+    expect(result.segment).toBe(1)
+    expect(result.suggestions).toHaveLength(1)
+    expect(result.entryFilename).toBe('01-test.md')
+  })
+
+  it('returns empty suggestions when file missing', () => {
+    mockedExists.mockReturnValue(false)
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile.mockReturnValue('---\nsegment: 1\nimages: []\n---\n')
+    const result = (getHandler as Function)(mockEvent({ query: { segment: '1' } }))
+    expect(result.suggestions).toEqual([])
+  })
+
+  it('throws 400 without segment', () => {
+    expect(() => {
+      (getHandler as Function)(mockEvent({ query: {} }))
+    }).toThrow('Missing segment number')
+  })
+})
+
+describe('POST /api/images', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('updates images in frontmatter', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\nimages: []\n---\n# Content')
+    const images = [{ src: '/img/new.jpg', alt: 'New photo' }]
+    await (postHandler as Function)(mockEvent({ body: { filename: '01-test.md', images } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('/img/new.jpg')
+  })
+})

--- a/tests/api/rider-config.test.ts
+++ b/tests/api/rider-config.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedWriteFile } = vi.hoisted(() => ({
+  mockedWriteFile: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: mockedWriteFile,
+  default: { readFileSync: vi.fn(), writeFileSync: mockedWriteFile },
+}))
+
+import handler from '~/server/api/rider-config.post'
+
+describe('POST /api/rider-config', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('saves config with provided values', async () => {
+    const riders = [{ id: 'alice', name: 'Alice', color: '#FF0000' }]
+    const result = await (handler as Function)(mockEvent({
+      body: { riders, totalDistance: 200, dailyCap: 3, startDate: '2026-05-01' },
+    }))
+    expect(result.success).toBe(true)
+    const written = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
+    expect(written.riders).toEqual(riders)
+    expect(written.totalDistance).toBe(200)
+    expect(written.dailyCap).toBe(3)
+  })
+
+  it('uses defaults for optional fields', async () => {
+    const riders = [{ id: 'bob', name: 'Bob', color: '#0000FF' }]
+    await (handler as Function)(mockEvent({ body: { riders } }))
+    const written = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
+    expect(written.totalDistance).toBe(185)
+    expect(written.dailyCap).toBe(2)
+    expect(written.startDate).toBe('2026-04-01')
+  })
+
+  it('throws 400 without riders array', async () => {
+    await expect((handler as Function)(mockEvent({ body: {} }))).rejects.toThrow('Missing or invalid riders array')
+  })
+
+  it('throws 400 with non-array riders', async () => {
+    await expect((handler as Function)(mockEvent({ body: { riders: 'not-array' } }))).rejects.toThrow('Missing or invalid riders array')
+  })
+})

--- a/tests/api/riders.test.ts
+++ b/tests/api/riders.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedWriteFile, mockedExec } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedWriteFile: vi.fn(),
+  mockedExec: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  writeFileSync: mockedWriteFile,
+  default: { readFileSync: mockedReadFile, writeFileSync: mockedWriteFile },
+}))
+
+vi.mock('child_process', () => ({
+  execSync: mockedExec,
+  default: { execSync: mockedExec },
+}))
+
+import getHandler from '~/server/api/riders.get'
+import postHandler from '~/server/api/riders.post'
+
+const sampleConfig = JSON.stringify({
+  riders: [{ id: 'alice', name: 'Alice', color: '#FF0000' }],
+  totalDistance: 185, dailyCap: 2,
+})
+const sampleLog = JSON.stringify({
+  entries: [{ date: '2026-04-02', distances: { alice: 1.5 } }],
+})
+const sampleStats = JSON.stringify({
+  asOf: '2026-04-02', riders: { alice: { totalDistanceCapped: 1.5, place: 1 } },
+})
+
+describe('GET /api/riders', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns log, config, and stats', () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog).mockReturnValueOnce(sampleConfig).mockReturnValueOnce(sampleStats)
+    const result = (getHandler as Function)(mockEvent())
+    expect(result.log.entries).toHaveLength(1)
+    expect(result.config.riders).toHaveLength(1)
+    expect(result.stats.riders.alice.place).toBe(1)
+  })
+
+  it('returns empty stats if stats file missing', () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog).mockReturnValueOnce(sampleConfig).mockImplementationOnce(() => { throw new Error('ENOENT') })
+    const result = (getHandler as Function)(mockEvent())
+    expect(result.stats).toEqual({ riders: {} })
+  })
+})
+
+describe('POST /api/riders', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('adds entry to log and regenerates stats', async () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog).mockReturnValueOnce(sampleStats)
+    const result = await (postHandler as Function)(mockEvent({ body: { date: '2026-04-03', distances: { alice: 2.0 } } }))
+    expect(result.success).toBe(true)
+    const writtenLog = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
+    expect(writtenLog.entries).toHaveLength(2)
+    expect(mockedExec).toHaveBeenCalledOnce()
+  })
+
+  it('replaces existing entry for same date', async () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog).mockReturnValueOnce(sampleStats)
+    await (postHandler as Function)(mockEvent({ body: { date: '2026-04-02', distances: { alice: 3.0 } } }))
+    const writtenLog = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
+    expect(writtenLog.entries).toHaveLength(1)
+    expect(writtenLog.entries[0].distances.alice).toBe(3.0)
+  })
+
+  it('sorts entries by date', async () => {
+    const logWithEntries = JSON.stringify({
+      entries: [
+        { date: '2026-04-05', distances: { alice: 1.0 } },
+        { date: '2026-04-02', distances: { alice: 2.0 } },
+      ],
+    })
+    mockedReadFile.mockReturnValueOnce(logWithEntries).mockReturnValueOnce(sampleStats)
+    await (postHandler as Function)(mockEvent({ body: { date: '2026-04-03', distances: { alice: 1.5 } } }))
+    const writtenLog = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
+    expect(writtenLog.entries.map((e: any) => e.date)).toEqual(['2026-04-02', '2026-04-03', '2026-04-05'])
+  })
+
+  it('throws 400 without date', async () => {
+    await expect((postHandler as Function)(mockEvent({ body: { distances: {} } }))).rejects.toThrow('Missing date or distances')
+  })
+
+  it('throws 400 without distances', async () => {
+    await expect((postHandler as Function)(mockEvent({ body: { date: '2026-04-02' } }))).rejects.toThrow('Missing date or distances')
+  })
+})

--- a/tests/api/setup.ts
+++ b/tests/api/setup.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest setup file for API tests.
+ * Sets up Nuxt server auto-import globals before any test modules load.
+ */
+
+// defineEventHandler just returns the handler function
+;(globalThis as any).defineEventHandler = (fn: Function) => fn
+
+// readBody returns the event's body
+;(globalThis as any).readBody = (event: any) => Promise.resolve(event._body)
+
+// getQuery returns the event's query
+;(globalThis as any).getQuery = (event: any) => event._query
+
+// createError creates an Error with statusCode
+;(globalThis as any).createError = (opts: { statusCode: number; message: string }) => {
+  const err = new Error(opts.message) as any
+  err.statusCode = opts.statusCode
+  return err
+}

--- a/tests/api/weather.test.ts
+++ b/tests/api/weather.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from './helpers'
+
+const { mockedReadFile, mockedWriteFile, mockedReaddir } = vi.hoisted(() => ({
+  mockedReadFile: vi.fn(),
+  mockedWriteFile: vi.fn(),
+  mockedReaddir: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  readFileSync: mockedReadFile,
+  writeFileSync: mockedWriteFile,
+  readdirSync: mockedReaddir,
+  default: { readFileSync: mockedReadFile, writeFileSync: mockedWriteFile, readdirSync: mockedReaddir },
+}))
+
+import getHandler from '~/server/api/weather.get'
+import injectHandler from '~/server/api/weather-inject.post'
+
+describe('GET /api/weather', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns entries with weather data', () => {
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile.mockReturnValue('---\nsegment: 1\ntitle: "Test"\nweather: {"current": {"temp": 18}}\n---\n')
+    const result = (getHandler as Function)(mockEvent())
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0].segment).toBe(1)
+    expect(result.entries[0].weather.current.temp).toBe(18)
+  })
+
+  it('returns null weather for entries without weather', () => {
+    mockedReaddir.mockReturnValue(['01-test.md'])
+    mockedReadFile.mockReturnValue('---\nsegment: 1\ntitle: "Test"\nweather: null\n---\n')
+    const result = (getHandler as Function)(mockEvent())
+    expect(result.entries[0].weather).toBe(null)
+  })
+})
+
+describe('POST /api/weather-inject', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('injects weather into frontmatter', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\nweather: null\n---\n# Content')
+    const weather = { current: { temp: 20, conditions: 'Clear', wind: '5 km/h' } }
+    await (injectHandler as Function)(mockEvent({ body: { filename: '01-test.md', weather } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('"temp":20')
+    expect(written).not.toContain('weather: null')
+  })
+
+  it('sets weather to null when passed null', async () => {
+    mockedReadFile.mockReturnValue('---\nsegment: 1\nweather: {"current": {"temp": 15}}\n---\n')
+    await (injectHandler as Function)(mockEvent({ body: { filename: '01-test.md', weather: null } }))
+    const written = mockedWriteFile.mock.calls[0][1] as string
+    expect(written).toContain('weather: null')
+  })
+
+  it('throws 400 without filename', async () => {
+    await expect((injectHandler as Function)(mockEvent({ body: {} }))).rejects.toThrow('Missing filename')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'happy-dom',
     include: ['tests/**/*.test.ts', 'tests/**/*.test.js'],
     globals: true,
+    setupFiles: ['tests/api/setup.ts'],
     coverage: {
       provider: 'v8',
       include: ['components/**', 'pages/**', 'server/**'],


### PR DESCRIPTION
## Summary

- 33 tests across 7 test files covering all server API routes:
  - `entries.test.ts` — GET /api/entries: frontmatter parsing, type conversion, filtering
  - `entry-content.test.ts` — GET/POST /api/entry-content: read/write markdown with frontmatter
  - `entry-status.test.ts` — POST /api/entry-status: draft toggle, publish date update
  - `riders.test.ts` — GET/POST /api/riders: log/config/stats loading, entry add/replace/sort
  - `rider-config.test.ts` — POST /api/rider-config: save with defaults, validation
  - `weather.test.ts` — GET /api/weather, POST /api/weather-inject: weather read/write
  - `images.test.ts` — GET/POST /api/images: suggestions, entry images, frontmatter update
- Test infrastructure: `setup.ts` for Nuxt auto-import globals, `helpers.ts` for mock event factory
- Uses `vi.hoisted()` pattern for proper `fs` module mocking

Closes #94

## Test plan

- [x] All 33 API tests pass locally
- [x] Full suite (34 tests) passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)