### PR TITLE
Add tests for Vue components

### DIFF
--- a/tests/components/ElevationChart.test.ts
+++ b/tests/components/ElevationChart.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Mock Chart.js and vue-chartjs to avoid canvas rendering
+vi.mock('vue-chartjs', () => ({
+  Line: { template: '<canvas data-testid="chart" />', props: ['data', 'options', 'plugins'] },
+}))
+
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  CategoryScale: {},
+  LinearScale: {},
+  LineElement: {},
+  PointElement: {},
+  Filler: {},
+  Tooltip: {},
+}))
+
+vi.mock('chartjs-plugin-zoom', () => ({ default: {} }))
+
+import ElevationChart from '~/components/ElevationChart.vue'
+
+const elevationData = {
+  distance: [0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+  elevation: [200, 220, 250, 240, 260, 280, 270, 290],
+  gradient: [0, 1.8, 2.7, -0.9, 1.8, 1.8, -0.9, 1.8],
+  power_35kmh: [280, 300, 320, 260, 300, 300, 260, 300],
+  summary: {
+    avg_gradient: 2.5,
+    max_gradient: 7.3,
+    elevation_gain: 144,
+    elevation_loss: 32,
+  },
+}
+
+describe('ElevationChart', () => {
+  it('renders chart when data is provided', () => {
+    const wrapper = mount(ElevationChart, {
+      props: { elevationData, segments: [], currentSegment: 1 },
+    })
+    expect(wrapper.find('[data-testid="chart"]').exists()).toBe(true)
+  })
+
+  it('shows placeholder when no data', () => {
+    const wrapper = mount(ElevationChart, {
+      props: { elevationData: null, segments: [], currentSegment: 1 },
+    })
+    expect(wrapper.find('[data-testid="chart"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Elevation')
+  })
+
+  it('has fullscreen toggle button', () => {
+    const wrapper = mount(ElevationChart, {
+      props: { elevationData, segments: [], currentSegment: 1 },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/components/ImageGallery.test.ts
+++ b/tests/components/ImageGallery.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ImageGallery from '~/components/ImageGallery.vue'
+
+describe('ImageGallery', () => {
+  it('renders images when provided', () => {
+    const images = [
+      { src: '/img/photo1.jpg', alt: 'Photo one', attribution: 'Author A, CC BY 4.0' },
+      { src: '/img/photo2.jpg', alt: 'Photo two', attribution: 'Author B, CC BY-SA 4.0' },
+    ]
+    const wrapper = mount(ImageGallery, { props: { images } })
+    const imgs = wrapper.findAll('img')
+    expect(imgs).toHaveLength(2)
+    expect(imgs[0].attributes('alt')).toBe('Photo one')
+    expect(imgs[1].attributes('alt')).toBe('Photo two')
+  })
+
+  it('shows attribution text', () => {
+    const images = [
+      { src: '/img/test.jpg', alt: 'Test', attribution: 'John Doe, CC BY 4.0' },
+    ]
+    const wrapper = mount(ImageGallery, { props: { images } })
+    expect(wrapper.text()).toContain('John Doe')
+  })
+
+  it('renders nothing when images array is empty', () => {
+    const wrapper = mount(ImageGallery, { props: { images: [] } })
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('renders nothing when images prop is missing', () => {
+    const wrapper = mount(ImageGallery)
+    expect(wrapper.find('img').exists()).toBe(false)
+  })
+
+  it('uses lazy loading on images', () => {
+    const images = [{ src: '/img/test.jpg', alt: 'Test', attribution: '' }]
+    const wrapper = mount(ImageGallery, { props: { images } })
+    expect(wrapper.find('img').attributes('loading')).toBe('lazy')
+  })
+
+  it('strips HTML from attribution', () => {
+    const images = [
+      { src: '/img/test.jpg', alt: 'Test', attribution: '<a href="http://example.com">Author</a>' },
+    ]
+    const wrapper = mount(ImageGallery, { props: { images } })
+    const figcaption = wrapper.find('figcaption')
+    expect(figcaption.text()).toContain('Author')
+  })
+})

--- a/tests/components/PowerStats.test.ts
+++ b/tests/components/PowerStats.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PowerStats from '~/components/PowerStats.vue'
+
+describe('PowerStats', () => {
+  const elevationData = {
+    summary: {
+      avg_gradient: 3.2,
+      max_gradient: 8.5,
+      elevation_gain: 245,
+      elevation_loss: 120,
+      avg_power_30kmh: 220,
+      avg_power_35kmh: 310,
+      avg_power_40kmh: 420,
+      avg_power_50kmh: 700,
+      estimated_time_30kmh: '14:12',
+      estimated_time_35kmh: '12:10',
+      estimated_time_40kmh: '10:39',
+      estimated_time_50kmh: '8:31',
+    },
+  }
+
+  it('displays gradient stats', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData } })
+    expect(wrapper.text()).toContain('3.2')
+    expect(wrapper.text()).toContain('8.5')
+  })
+
+  it('displays elevation gain and loss', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData } })
+    expect(wrapper.text()).toContain('245')
+    expect(wrapper.text()).toContain('120')
+  })
+
+  it('displays power at 35km/h', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData } })
+    expect(wrapper.text()).toContain('310')
+  })
+
+  it('displays estimated times', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData } })
+    expect(wrapper.text()).toContain('14:12')
+    expect(wrapper.text()).toContain('12:10')
+    expect(wrapper.text()).toContain('10:39')
+    expect(wrapper.text()).toContain('8:31')
+  })
+
+  it('renders nothing when elevationData is null', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData: null } })
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('shows reference rider spec', () => {
+    const wrapper = mount(PowerStats, { props: { elevationData } })
+    expect(wrapper.text()).toContain('70kg')
+  })
+})

--- a/tests/components/SegmentMap.test.ts
+++ b/tests/components/SegmentMap.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+// Mock Leaflet — it requires DOM APIs not available in happy-dom
+vi.mock('leaflet', () => ({
+  default: {
+    map: vi.fn(() => ({
+      setView: vi.fn().mockReturnThis(),
+      addLayer: vi.fn(),
+      removeLayer: vi.fn(),
+      fitBounds: vi.fn(),
+      invalidateSize: vi.fn(),
+      remove: vi.fn(),
+    })),
+    tileLayer: vi.fn(() => ({ addTo: vi.fn() })),
+    marker: vi.fn(() => ({ addTo: vi.fn(), bindPopup: vi.fn().mockReturnThis() })),
+    polyline: vi.fn(() => ({ addTo: vi.fn(), getBounds: vi.fn(() => ({})) })),
+    layerGroup: vi.fn(() => ({ addTo: vi.fn() })),
+    divIcon: vi.fn(),
+    control: { layers: vi.fn(() => ({ addTo: vi.fn() })) },
+    Icon: { Default: { mergeOptions: vi.fn() } },
+  },
+}))
+
+vi.mock('leaflet/dist/leaflet.css', () => ({}))
+
+import SegmentMap from '~/components/SegmentMap.vue'
+
+describe('SegmentMap', () => {
+  // SegmentMap uses ClientOnly which won't render in test env
+  // We test that it mounts without errors
+
+  it('mounts without errors', () => {
+    const wrapper = mount(SegmentMap, {
+      props: { segment: 1, segments: [], routeCoords: [] },
+      global: {
+        stubs: { ClientOnly: { template: '<div><slot /></div>' } },
+      },
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders map container', () => {
+    const wrapper = mount(SegmentMap, {
+      props: { segment: 1, segments: [], routeCoords: [] },
+      global: {
+        stubs: { ClientOnly: { template: '<div><slot /></div>' } },
+      },
+    })
+    expect(wrapper.find('div').exists()).toBe(true)
+  })
+
+  it('has fullscreen toggle', () => {
+    const wrapper = mount(SegmentMap, {
+      props: { segment: 1, segments: [], routeCoords: [] },
+      global: {
+        stubs: { ClientOnly: { template: '<div><slot /></div>' } },
+      },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/components/WeatherWidget.test.ts
+++ b/tests/components/WeatherWidget.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WeatherWidget from '~/components/WeatherWidget.vue'
+
+describe('WeatherWidget', () => {
+  const weather = {
+    fetchedAt: '2026-04-04',
+    current: {
+      temp: 18,
+      conditions: 'Partly cloudy',
+      wind: '12 km/h SW',
+    },
+    forecast: 'Warm and dry through the weekend',
+  }
+
+  it('renders weather data', () => {
+    const wrapper = mount(WeatherWidget, { props: { weather } })
+    expect(wrapper.text()).toContain('18')
+    expect(wrapper.text()).toContain('°C')
+    expect(wrapper.text()).toContain('Partly cloudy')
+    expect(wrapper.text()).toContain('12 km/h SW')
+  })
+
+  it('shows forecast when present', () => {
+    const wrapper = mount(WeatherWidget, { props: { weather } })
+    expect(wrapper.text()).toContain('Warm and dry through the weekend')
+  })
+
+  it('renders nothing when weather is null', () => {
+    const wrapper = mount(WeatherWidget, { props: { weather: null } })
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('renders nothing when weather prop is missing', () => {
+    const wrapper = mount(WeatherWidget)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('handles weather without forecast', () => {
+    const noForecast = { ...weather, forecast: null }
+    const wrapper = mount(WeatherWidget, { props: { weather: noForecast } })
+    expect(wrapper.text()).toContain('18')
+    expect(wrapper.text()).not.toContain('Warm and dry')
+  })
+
+  it('shows fetchedAt date', () => {
+    const wrapper = mount(WeatherWidget, { props: { weather } })
+    expect(wrapper.text()).toContain('April 4, 2026')
+  })
+})


### PR DESCRIPTION
## Summary

- 24 tests across 5 component test files:
  - `ImageGallery.test.ts` — rendering, empty/missing props, lazy loading, HTML attribution stripping
  - `WeatherWidget.test.ts` — weather display, null/missing handling, date formatting, forecast
  - `PowerStats.test.ts` — gradient/power/time display, null handling, reference spec text
  - `ElevationChart.test.ts` — chart render with mocked Chart.js/vue-chartjs, placeholder for null data
  - `SegmentMap.test.ts` — mount with mocked Leaflet and ClientOnly stub, fullscreen toggle
- Chart.js and Leaflet are fully mocked — upstream libraries have their own test suites, so these tests focus on our component logic and prop handling

Closes #95

## Test plan

- [x] All 24 component tests pass locally
- [x] Full suite (58 tests) passes
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)