### PR TITLE
Update README - Nuxt 4, roadmap link, tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Malemort-sur-Correze to Ussel, 185km northeast through the Massif Central. Throu
 
 ## Tech Stack
 
-- **Site:** Nuxt 3, Nuxt Content, Tailwind CSS
+- **Site:** Nuxt 4, Nuxt Content, Tailwind CSS
 - **Maps:** Leaflet.js with OpenStreetMap tiles
 - **Charts:** Chart.js for elevation profiles
 - **Data processing:** Python 3.11+ (gpxpy, numpy)
-- **Hosting:** Static site (nuxt generate)
+- **Testing:** Vitest, pytest, ESLint, Ruff
+- **Hosting:** Static site on OVH VM (nuxt generate + Caddy)
+
+See the [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) for planned work.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Fix Nuxt version: 3 -> 4
- Add testing tools (Vitest, pytest, ESLint, Ruff) to tech stack
- Update hosting description to reflect OVH VM + Caddy
- Add link to the wiki roadmap

Closes #152
Closes #153

## Test plan

- [x] README renders correctly
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)