### PR TITLE
Apply Sandstone and Forest colour theme

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -5,7 +5,7 @@
     :style="isFullscreen ? 'position:fixed;top:0;left:0;width:100vw;height:100vh' : ''"
   >
     <div class="flex items-center justify-between mb-3">
-      <h3 class="text-lg font-semibold text-gray-700">Elevation Profile</h3>
+      <h3 class="text-lg font-semibold text-stone-700">Elevation Profile</h3>
       <div class="flex items-center gap-2">
         <button
           v-if="isZoomed"
@@ -16,7 +16,7 @@
         </button>
         <button
           class="w-8 h-8 flex items-center justify-center rounded border text-lg font-bold cursor-pointer transition-colors"
-          :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-gray-100 text-gray-500 border-gray-300 hover:bg-gray-200'"
+          :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-stone-100 text-stone-500 border-stone-300 hover:bg-stone-200'"
           :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen'"
           @click="toggleFullscreen"
         >
@@ -27,8 +27,8 @@
     <div v-if="chartData" :class="isFullscreen ? 'h-[calc(100vh-160px)]' : 'h-[250px]'">
       <Line ref="chartRef" :data="chartData" :options="chartOptions" />
     </div>
-    <p v-else class="text-gray-400 italic text-sm">Elevation data not available.</p>
-    <p v-if="chartData" class="text-xs text-gray-400 mt-2">Scroll to zoom, drag to pan. Double-click to reset.</p>
+    <p v-else class="text-stone-400 italic text-sm">Elevation data not available.</p>
+    <p v-if="chartData" class="text-xs text-stone-400 mt-2">Scroll to zoom, drag to pan. Double-click to reset.</p>
   </div>
 </template>
 

--- a/components/ImageGallery.vue
+++ b/components/ImageGallery.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="images && images.length" class="mt-8">
-    <h3 class="text-lg font-semibold text-gray-700 mb-4">Gallery</h3>
+    <h3 class="text-lg font-semibold text-stone-700 mb-4">Gallery</h3>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
       <figure v-for="(img, idx) in images" :key="idx" class="bg-white rounded-lg shadow-sm overflow-hidden">
         <a :href="img.src" target="_blank" rel="noopener noreferrer">
@@ -12,8 +12,8 @@
           >
         </a>
         <figcaption class="p-3">
-          <p class="text-sm text-gray-700">{{ img.alt }}</p>
-          <p v-if="img.attribution" class="text-xs text-gray-400 mt-1">{{ stripHtml(img.attribution) }}</p>
+          <p class="text-sm text-stone-700">{{ img.alt }}</p>
+          <p v-if="img.attribution" class="text-xs text-stone-400 mt-1">{{ stripHtml(img.attribution) }}</p>
         </figcaption>
       </figure>
     </div>

--- a/components/PowerStats.vue
+++ b/components/PowerStats.vue
@@ -1,49 +1,49 @@
 <template>
   <div v-if="summary" class="bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-700 mb-4">Power Stats</h3>
-    <p class="text-xs text-gray-400 mb-4">Reference: 70kg rider + 8kg bike, CdA 0.35, Crr 0.005</p>
+    <h3 class="text-lg font-semibold text-stone-700 mb-4">Power Stats</h3>
+    <p class="text-xs text-stone-400 mb-4">Reference: 70kg rider + 8kg bike, CdA 0.35, Crr 0.005</p>
 
     <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-      <div class="text-center p-3 bg-gray-50 rounded">
-        <div class="text-xl font-bold text-gray-700">{{ summary.avg_gradient }}%</div>
-        <div class="text-xs text-gray-500">Avg Gradient</div>
+      <div class="text-center p-3 bg-stone-50 rounded">
+        <div class="text-xl font-bold text-stone-700">{{ summary.avg_gradient }}%</div>
+        <div class="text-xs text-stone-500">Avg Gradient</div>
       </div>
-      <div class="text-center p-3 bg-gray-50 rounded">
+      <div class="text-center p-3 bg-stone-50 rounded">
         <div class="text-xl font-bold text-red-700">{{ summary.max_gradient }}%</div>
-        <div class="text-xs text-gray-500">Max Gradient</div>
+        <div class="text-xs text-stone-500">Max Gradient</div>
       </div>
-      <div class="text-center p-3 bg-gray-50 rounded">
+      <div class="text-center p-3 bg-stone-50 rounded">
         <div class="text-xl font-bold text-correze-green">+{{ summary.elevation_gain }}m</div>
-        <div class="text-xs text-gray-500">Elevation Gain</div>
+        <div class="text-xs text-stone-500">Elevation Gain</div>
       </div>
-      <div class="text-center p-3 bg-gray-50 rounded">
+      <div class="text-center p-3 bg-stone-50 rounded">
         <div class="text-xl font-bold text-blue-600">-{{ summary.elevation_loss }}m</div>
-        <div class="text-xs text-gray-500">Elevation Loss</div>
+        <div class="text-xs text-stone-500">Elevation Loss</div>
       </div>
       <div class="text-center p-3 bg-correze-red/5 rounded col-span-2 md:col-span-1">
         <div class="text-xl font-bold text-correze-red">{{ summary.avg_power_35kmh }}W</div>
-        <div class="text-xs text-gray-500">Avg Power @35km/h</div>
+        <div class="text-xs text-stone-500">Avg Power @35km/h</div>
       </div>
     </div>
 
     <div class="mt-4 border-t pt-4">
-      <h4 class="text-sm font-semibold text-gray-600 mb-2">Estimated Time</h4>
+      <h4 class="text-sm font-semibold text-stone-600 mb-2">Estimated Time</h4>
       <div class="flex gap-4 text-sm">
         <div class="flex-1 text-center">
-          <div class="font-mono font-bold text-gray-600">{{ summary.estimated_time_30kmh }}</div>
-          <div class="text-xs text-gray-400">@30 km/h</div>
+          <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_30kmh }}</div>
+          <div class="text-xs text-stone-400">@30 km/h</div>
         </div>
         <div class="flex-1 text-center">
           <div class="font-mono font-bold text-correze-red">{{ summary.estimated_time_35kmh }}</div>
-          <div class="text-xs text-gray-400">@35 km/h</div>
+          <div class="text-xs text-stone-400">@35 km/h</div>
         </div>
         <div class="flex-1 text-center">
-          <div class="font-mono font-bold text-gray-600">{{ summary.estimated_time_40kmh }}</div>
-          <div class="text-xs text-gray-400">@40 km/h</div>
+          <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_40kmh }}</div>
+          <div class="text-xs text-stone-400">@40 km/h</div>
         </div>
         <div class="flex-1 text-center">
-          <div class="font-mono font-bold text-gray-600">{{ summary.estimated_time_50kmh || '-' }}</div>
-          <div class="text-xs text-gray-400">@50 km/h</div>
+          <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_50kmh || '-' }}</div>
+          <div class="text-xs text-stone-400">@50 km/h</div>
         </div>
       </div>
     </div>

--- a/components/PublishSchedule.vue
+++ b/components/PublishSchedule.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-700 mb-4">Publish Schedule</h3>
+    <h3 class="text-lg font-semibold text-stone-700 mb-4">Publish Schedule</h3>
     <div class="space-y-1">
       <div
         v-for="entry in schedule"
@@ -8,15 +8,15 @@
         class="flex items-center gap-3 py-1.5 px-2 rounded text-sm"
         :class="entryClass(entry)"
       >
-        <span class="w-6 text-right font-mono text-gray-400">{{ entry.segment }}</span>
-        <span class="w-24 font-mono text-xs" :class="entry.published ? 'text-correze-red' : 'text-gray-400'">
+        <span class="w-6 text-right font-mono text-stone-400">{{ entry.segment }}</span>
+        <span class="w-24 font-mono text-xs" :class="entry.published ? 'text-correze-red' : 'text-stone-400'">
           {{ formatDate(entry.date) }}
         </span>
         <component
           :is="entry.published ? 'NuxtLink' : 'span'"
           :to="entry.published ? `/entries/${entry.slug}` : undefined"
           class="flex-1 truncate"
-          :class="entry.published ? 'text-correze-red hover:underline font-medium' : 'text-gray-400'"
+          :class="entry.published ? 'text-correze-red hover:underline font-medium' : 'text-stone-400'"
         >
           {{ entry.title }}
         </component>

--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -6,10 +6,10 @@
     :style="isFullscreen ? 'position:fixed;top:0;left:0;width:100vw;height:100vh' : ''"
   >
     <div class="flex items-center justify-between mb-4">
-      <h3 :class="isFullscreen ? 'text-2xl' : 'text-lg'" class="font-semibold text-gray-700">Rider Standings</h3>
+      <h3 :class="isFullscreen ? 'text-2xl' : 'text-lg'" class="font-semibold text-stone-700">Rider Standings</h3>
       <button
         class="w-8 h-8 flex items-center justify-center rounded border text-lg font-bold cursor-pointer transition-colors"
-        :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-gray-100 text-gray-500 border-gray-300 hover:bg-gray-200'"
+        :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-stone-100 text-stone-500 border-stone-300 hover:bg-stone-200'"
         :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen'"
         @click="toggleFullscreen"
       >
@@ -23,7 +23,7 @@
         <span class="w-16 text-sm font-medium truncate" :style="{ color: rider.textColor }">
           {{ rider.name }}
         </span>
-        <div class="flex-1 bg-gray-100 rounded-full relative overflow-hidden" :class="isFullscreen ? 'h-8' : 'h-5'">
+        <div class="flex-1 bg-stone-100 rounded-full relative overflow-hidden" :class="isFullscreen ? 'h-8' : 'h-5'">
           <div
             class="h-full rounded-full transition-all duration-500"
             :style="{
@@ -34,11 +34,11 @@
           />
           <span
 class="absolute inset-0 flex items-center justify-center text-xs font-mono"
-                :class="rider.stats.totalDistanceCapped > totalDistance * 0.4 ? 'text-white' : 'text-gray-600'">
+                :class="rider.stats.totalDistanceCapped > totalDistance * 0.4 ? 'text-white' : 'text-stone-600'">
             {{ rider.stats.totalDistanceCapped }} km
           </span>
         </div>
-        <span class="w-8 text-xs text-gray-400 text-right">#{{ rider.stats.place }}</span>
+        <span class="w-8 text-xs text-stone-400 text-right">#{{ rider.stats.place }}</span>
       </div>
     </div>
 
@@ -46,12 +46,12 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
     <div class="overflow-x-auto">
       <table class="w-full" :class="isFullscreen ? 'text-xl' : 'text-sm'">
         <thead>
-          <tr class="border-b border-gray-200">
-            <th class="text-left py-2 pr-2 text-gray-500 font-medium">Stat</th>
+          <tr class="border-b border-stone-200">
+            <th class="text-left py-2 pr-2 text-stone-500 font-medium">Stat</th>
             <th
               v-for="rider in rankedRiders"
               :key="rider.id"
-              class="text-center font-medium border-l border-gray-200"
+              class="text-center font-medium border-l border-stone-200"
               :class="isFullscreen ? 'py-2 px-3' : 'py-1 px-1 text-xs'"
               :style="{ color: rider.textColor }"
             >
@@ -59,60 +59,60 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-100">
+        <tbody class="divide-y divide-stone-100">
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Total (capped)</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.totalDistanceCapped }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Total (capped)</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.totalDistanceCapped }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Daily avg (actual)</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.dailyAverageActual }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Daily avg (actual)</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.dailyAverageActual }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Daily avg (capped)</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.dailyAverageCapped }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Daily avg (capped)</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.dailyAverageCapped }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Longest day</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.longestDay }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Longest day</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.longestDay }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Best 3-day</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.bestThreeDayCombo }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Best 3-day</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.bestThreeDayCombo }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Recent 5-day avg</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.recentFiveDayAverage }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Recent 5-day avg</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.recentFiveDayAverage }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Days &lt;3km</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+            <td class="py-1.5 pr-2 text-stone-500">Days &lt;3km</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
               {{ r.stats.daysBelowThreeKm }}
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Remaining</td>
-            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-gray-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
-              {{ r.stats.distanceRemaining }}<br><span class="text-gray-400">km</span>
+            <td class="py-1.5 pr-2 text-stone-500">Remaining</td>
+            <td v-for="r in rankedRiders" :key="r.id" class="text-center font-mono border-l border-stone-200" :class="isFullscreen ? 'py-1.5 px-3' : 'py-1 px-1 text-xs'">
+              {{ r.stats.distanceRemaining }}<br><span class="text-stone-400">km</span>
             </td>
           </tr>
           <tr>
-            <td class="py-1.5 pr-2 text-gray-500">Est. finish</td>
+            <td class="py-1.5 pr-2 text-stone-500">Est. finish</td>
             <td v-for="r in rankedRiders" :key="r.id" class="text-center py-1.5 px-2 font-mono text-xs">
               <template v-if="r.stats.estimatedFinishDate">
-                <span class="text-gray-400 block" :class="isFullscreen ? 'text-base' : 'text-[0.65rem]'" style="line-height:1">{{ formatFinishMonth(r.stats.estimatedFinishDate) }}</span>
+                <span class="text-stone-400 block" :class="isFullscreen ? 'text-base' : 'text-[0.65rem]'" style="line-height:1">{{ formatFinishMonth(r.stats.estimatedFinishDate) }}</span>
                 <span class="block" :class="isFullscreen ? 'text-2xl' : ''">{{ formatFinishDay(r.stats.estimatedFinishDate) }}</span>
               </template>
               <template v-else>-</template>
@@ -124,7 +124,7 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
 
     <!-- Sparklines -->
     <div v-if="dailyLog.entries.length > 1" class="mt-6 border-t pt-4">
-      <h4 class="text-sm font-semibold text-gray-600 mb-3">Daily Distance</h4>
+      <h4 class="text-sm font-semibold text-stone-600 mb-3">Daily Distance</h4>
       <div class="space-y-2">
         <div v-for="rider in rankedRiders" :key="rider.id" class="flex items-center gap-3">
           <span class="w-16 text-xs truncate" :style="{ color: rider.textColor }">{{ rider.name }}</span>
@@ -141,7 +141,7 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
       </div>
       <div class="flex items-center gap-3 mt-1">
         <span class="w-16"/>
-        <div class="flex-1 flex justify-between text-[9px] text-gray-400">
+        <div class="flex-1 flex justify-between text-[9px] text-stone-400">
           <span v-for="label in sparklineDateLabels" :key="label">{{ label }}</span>
         </div>
       </div>

--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -11,7 +11,7 @@
       />
       <button
         class="absolute top-2 right-2 z-[1000] w-8 h-8 flex items-center justify-center rounded border text-lg font-bold cursor-pointer transition-colors shadow"
-        :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-100'"
+        :class="isFullscreen ? 'bg-red-600 text-white border-red-600 hover:bg-red-700' : 'bg-white text-stone-600 border-stone-300 hover:bg-stone-100'"
         :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen'"
         @click="toggleFullscreen"
       >
@@ -19,7 +19,7 @@
       </button>
     </div>
     <template #fallback>
-      <div class="w-full h-[400px] rounded-lg bg-gray-200 flex items-center justify-center text-gray-500">
+      <div class="w-full h-[400px] rounded-lg bg-stone-200 flex items-center justify-center text-stone-500">
         Loading map...
       </div>
     </template>

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -1,28 +1,28 @@
 <template>
   <div class="bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-lg font-semibold text-gray-700 mb-4">Stage Details</h3>
+    <h3 class="text-lg font-semibold text-stone-700 mb-4">Stage Details</h3>
 
     <div class="mb-5">
-      <h4 class="text-sm font-semibold text-gray-500 mb-2">Towns</h4>
+      <h4 class="text-sm font-semibold text-stone-500 mb-2">Towns</h4>
       <div class="space-y-1">
         <div v-for="town in towns" :key="town.name" class="flex justify-between text-sm">
-          <span class="text-gray-700">{{ town.name }}</span>
-          <span class="font-mono text-gray-400">km {{ town.km }} &middot; {{ town.elevation }}m</span>
+          <span class="text-stone-700">{{ town.name }}</span>
+          <span class="font-mono text-stone-400">km {{ town.km }} &middot; {{ town.elevation }}m</span>
         </div>
       </div>
     </div>
 
     <div>
-      <h4 class="text-sm font-semibold text-gray-500 mb-2">Climbs</h4>
+      <h4 class="text-sm font-semibold text-stone-500 mb-2">Climbs</h4>
       <div class="space-y-1">
         <div v-for="climb in climbs" :key="climb.name" class="flex justify-between text-sm">
-          <span class="text-gray-700">{{ climb.name }}</span>
-          <span class="font-mono text-gray-400">km {{ climb.km }} &middot; {{ climb.gradient }}%</span>
+          <span class="text-stone-700">{{ climb.name }}</span>
+          <span class="font-mono text-stone-400">km {{ climb.km }} &middot; {{ climb.gradient }}%</span>
         </div>
       </div>
     </div>
 
-    <div class="mt-4 pt-3 border-t border-gray-100 text-xs text-gray-400">
+    <div class="mt-4 pt-3 border-t border-stone-100 text-xs text-stone-400">
       185 km &middot; 9 climbs &middot; +3,390m elevation
     </div>
   </div>

--- a/components/WeatherWidget.vue
+++ b/components/WeatherWidget.vue
@@ -1,19 +1,19 @@
 <template>
   <div v-if="weather" class="bg-white rounded-lg shadow-sm p-4 mt-8">
-    <h3 class="text-lg font-semibold text-gray-700 mb-3">
+    <h3 class="text-lg font-semibold text-stone-700 mb-3">
       Weather at this location
-      <span v-if="weather.fetchedAt" class="text-sm font-normal text-gray-400 ml-2">{{ formatDate(weather.fetchedAt) }}</span>
+      <span v-if="weather.fetchedAt" class="text-sm font-normal text-stone-400 ml-2">{{ formatDate(weather.fetchedAt) }}</span>
     </h3>
     <div class="flex items-center gap-6">
-      <div class="text-3xl font-bold text-gray-800">
+      <div class="text-3xl font-bold text-stone-800">
         {{ weather.current.temp }}&deg;C
       </div>
-      <div class="text-sm text-gray-600">
+      <div class="text-sm text-stone-600">
         <div>{{ weather.current.conditions }}</div>
-        <div class="text-gray-400">Wind: {{ weather.current.wind }}</div>
+        <div class="text-stone-400">Wind: {{ weather.current.wind }}</div>
       </div>
     </div>
-    <p v-if="weather.forecast" class="text-sm text-gray-500 mt-3 italic">
+    <p v-if="weather.forecast" class="text-sm text-stone-500 mt-3 italic">
       {{ weather.forecast }}
     </p>
   </div>

--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,23 +1,23 @@
 <template>
-  <div class="min-h-screen bg-gray-100">
-    <header class="bg-gray-900 text-white">
+  <div class="min-h-screen bg-stone-100">
+    <header class="bg-stone-900 text-white">
       <nav class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
         <div class="flex items-center gap-6">
-          <NuxtLink to="/admin" class="text-lg font-bold hover:text-yellow-300 transition-colors">
+          <NuxtLink to="/admin" class="text-lg font-bold hover:text-accent transition-colors">
             Admin
           </NuxtLink>
           <div class="hidden md:flex items-center gap-4 text-sm">
-            <NuxtLink to="/admin/riders" class="text-gray-300 hover:text-white">Riders</NuxtLink>
-            <NuxtLink to="/admin/rider-config" class="text-gray-300 hover:text-white">Config</NuxtLink>
-            <NuxtLink to="/admin/entries" class="text-gray-300 hover:text-white">Entries</NuxtLink>
-            <NuxtLink to="/admin/images" class="text-gray-300 hover:text-white">Images</NuxtLink>
-            <NuxtLink to="/admin/weather" class="text-gray-300 hover:text-white">Weather</NuxtLink>
-            <NuxtLink to="/admin/schedule" class="text-gray-300 hover:text-white">Schedule</NuxtLink>
-            <NuxtLink to="/admin/publish" class="text-gray-300 hover:text-white">Publish</NuxtLink>
-            <NuxtLink to="/admin/settings" class="text-gray-300 hover:text-white">Settings</NuxtLink>
+            <NuxtLink to="/admin/riders" class="text-stone-300 hover:text-white">Riders</NuxtLink>
+            <NuxtLink to="/admin/rider-config" class="text-stone-300 hover:text-white">Config</NuxtLink>
+            <NuxtLink to="/admin/entries" class="text-stone-300 hover:text-white">Entries</NuxtLink>
+            <NuxtLink to="/admin/images" class="text-stone-300 hover:text-white">Images</NuxtLink>
+            <NuxtLink to="/admin/weather" class="text-stone-300 hover:text-white">Weather</NuxtLink>
+            <NuxtLink to="/admin/schedule" class="text-stone-300 hover:text-white">Schedule</NuxtLink>
+            <NuxtLink to="/admin/publish" class="text-stone-300 hover:text-white">Publish</NuxtLink>
+            <NuxtLink to="/admin/settings" class="text-stone-300 hover:text-white">Settings</NuxtLink>
           </div>
         </div>
-        <NuxtLink to="/" class="text-sm text-gray-400 hover:text-white">
+        <NuxtLink to="/" class="text-sm text-stone-400 hover:text-white">
           View Site &rarr;
         </NuxtLink>
       </nav>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="min-h-screen bg-gray-50">
+  <div class="min-h-screen bg-stone-50">
     <header class="bg-correze-red text-white">
       <nav class="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-        <NuxtLink to="/" class="text-xl font-serif font-bold hover:text-yellow-300 transition-colors">
+        <NuxtLink to="/" class="text-xl font-serif font-bold hover:text-accent transition-colors">
           Corrèze Travelogue
         </NuxtLink>
         <div class="flex items-center gap-4">
@@ -18,11 +18,11 @@
       <slot />
     </main>
 
-    <footer class="bg-gray-800 text-gray-400 mt-16">
+    <footer class="bg-stone-900 text-stone-400 mt-16">
       <div class="max-w-5xl mx-auto px-4 py-8 text-sm text-center">
         <p>Corrèze Travelogue — Malemort to Ussel, 185km</p>
         <p class="mt-1">Stage 9, Tour de France 2026 — Sunday, July 12</p>
-        <a href="https://github.com/gneeek/tdf26" target="_blank" rel="noopener noreferrer" class="inline-block mt-3 text-gray-500 hover:text-white transition-colors" title="Source code on GitHub">
+        <a href="https://github.com/gneeek/tdf26" target="_blank" rel="noopener noreferrer" class="inline-block mt-3 text-stone-500 hover:text-white transition-colors" title="Source code on GitHub">
           <svg class="w-5 h-5 inline" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         </a>
       </div>

--- a/pages/admin/edit/[filename].vue
+++ b/pages/admin/edit/[filename].vue
@@ -2,8 +2,8 @@
   <div>
     <div class="flex items-center justify-between mb-6">
       <div>
-        <NuxtLink to="/admin/entries" class="text-sm text-gray-500 hover:underline">&larr; Back to entries</NuxtLink>
-        <h1 class="text-2xl font-bold text-gray-800 mt-1">{{ entryTitle || 'Edit Entry' }}</h1>
+        <NuxtLink to="/admin/entries" class="text-sm text-stone-500 hover:underline">&larr; Back to entries</NuxtLink>
+        <h1 class="text-2xl font-bold text-stone-800 mt-1">{{ entryTitle || 'Edit Entry' }}</h1>
       </div>
       <div class="flex items-center gap-3">
         <span v-if="saveMessage" class="text-sm" :class="saveError ? 'text-red-600' : 'text-green-600'">
@@ -11,7 +11,7 @@
         </span>
         <button
           :disabled="saving"
-          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+          class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
           @click="saveEntry"
         >
           {{ saving ? 'Saving...' : 'Save' }}
@@ -23,32 +23,32 @@
       <!-- Editor pane -->
       <div class="flex flex-col overflow-hidden" :style="{ width: editorWidth + '%' }">
         <div class="bg-white rounded-lg shadow-sm p-4 mb-4 flex-shrink-0">
-          <h2 class="text-sm font-semibold text-gray-600 mb-2">Frontmatter</h2>
+          <h2 class="text-sm font-semibold text-stone-600 mb-2">Frontmatter</h2>
           <textarea
             v-model="frontmatter"
-            class="w-full font-mono text-xs border border-gray-300 rounded p-3 bg-gray-50"
+            class="w-full font-mono text-xs border border-stone-300 rounded p-3 bg-stone-50"
             rows="6"
             spellcheck="false"
           />
         </div>
         <div class="bg-white rounded-lg shadow-sm p-4 flex-1 flex flex-col overflow-hidden">
-          <h2 class="text-sm font-semibold text-gray-600 mb-2">Content (Markdown)</h2>
+          <h2 class="text-sm font-semibold text-stone-600 mb-2">Content (Markdown)</h2>
           <!-- Toolbar -->
           <div class="flex gap-1 mb-2 flex-shrink-0">
             <button class="toolbar-btn font-bold" title="Heading 1" @click="insertLinePrefix('# ')">H1</button>
             <button class="toolbar-btn font-bold" title="Heading 2" @click="insertLinePrefix('## ')">H2</button>
             <button class="toolbar-btn font-bold" title="Heading 3" @click="insertLinePrefix('### ')">H3</button>
-            <span class="w-px bg-gray-300 mx-1"/>
+            <span class="w-px bg-stone-300 mx-1"/>
             <button class="toolbar-btn font-bold" title="Bold" @click="wrapMd('**', '**')">B</button>
             <button class="toolbar-btn italic" title="Italic" @click="wrapMd('*', '*')">I</button>
-            <span class="w-px bg-gray-300 mx-1"/>
+            <span class="w-px bg-stone-300 mx-1"/>
             <button class="toolbar-btn" title="Quote" @click="insertLinePrefix('> ')">&ldquo;</button>
             <button class="toolbar-btn" title="Link" @click="wrapMd('[', '](url)')">Link</button>
           </div>
           <textarea
             ref="editorRef"
             v-model="body"
-            class="w-full font-mono text-sm border border-gray-300 rounded p-3 flex-1 resize-none"
+            class="w-full font-mono text-sm border border-stone-300 rounded p-3 flex-1 resize-none"
             spellcheck="true"
           />
         </div>
@@ -56,16 +56,16 @@
 
       <!-- Resize handle -->
       <div
-        class="w-2 cursor-col-resize flex-shrink-0 flex items-center justify-center hover:bg-gray-300 rounded"
+        class="w-2 cursor-col-resize flex-shrink-0 flex items-center justify-center hover:bg-stone-300 rounded"
         @mousedown="startResize"
       >
-        <div class="w-0.5 h-8 bg-gray-400 rounded"/>
+        <div class="w-0.5 h-8 bg-stone-400 rounded"/>
       </div>
 
       <!-- Preview pane -->
       <div class="flex-1 overflow-auto">
         <div class="bg-white rounded-lg shadow-sm p-6 h-full overflow-auto">
-          <h2 class="text-sm font-semibold text-gray-600 mb-4">Preview</h2>
+          <h2 class="text-sm font-semibold text-stone-600 mb-4">Preview</h2>
           <div class="prose prose-lg max-w-none font-serif" v-html="renderedPreview" />
         </div>
       </div>
@@ -221,6 +221,6 @@ onMounted(() => loadEntry())
 
 <style scoped>
 .toolbar-btn {
-  @apply px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-100 text-gray-700 cursor-pointer;
+  @apply px-2 py-1 text-xs border border-stone-300 rounded hover:bg-stone-100 text-stone-700 cursor-pointer;
 }
 </style>

--- a/pages/admin/entries.vue
+++ b/pages/admin/entries.vue
@@ -1,31 +1,31 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Entry Publish Controls</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Entry Publish Controls</h1>
 
     <div class="bg-white rounded-lg shadow-sm p-6">
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-200">
-              <th class="text-left py-2 pr-2 text-gray-500 font-medium w-10">#</th>
-              <th class="text-left py-2 pr-2 text-gray-500 font-medium">Title</th>
-              <th class="text-center py-2 px-2 text-gray-500 font-medium w-32">Publish Date</th>
-              <th class="text-center py-2 px-2 text-gray-500 font-medium w-24">Status</th>
-              <th class="text-center py-2 px-2 text-gray-500 font-medium w-20">Actions</th>
+            <tr class="border-b border-stone-200">
+              <th class="text-left py-2 pr-2 text-stone-500 font-medium w-10">#</th>
+              <th class="text-left py-2 pr-2 text-stone-500 font-medium">Title</th>
+              <th class="text-center py-2 px-2 text-stone-500 font-medium w-32">Publish Date</th>
+              <th class="text-center py-2 px-2 text-stone-500 font-medium w-24">Status</th>
+              <th class="text-center py-2 px-2 text-stone-500 font-medium w-20">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody class="divide-y divide-stone-100">
             <tr v-for="entry in entries" :key="entry.filename" :class="entry.draft ? 'opacity-60' : ''">
-              <td class="py-2 pr-2 font-mono text-gray-400">{{ entry.segment }}</td>
+              <td class="py-2 pr-2 font-mono text-stone-400">{{ entry.segment }}</td>
               <td class="py-2 pr-2">
-                <span class="text-gray-800">{{ entry.title }}</span>
-                <span class="text-xs text-gray-400 ml-2">{{ entry.filename }}</span>
+                <span class="text-stone-800">{{ entry.title }}</span>
+                <span class="text-xs text-stone-400 ml-2">{{ entry.filename }}</span>
               </td>
               <td class="text-center py-2 px-2">
                 <input
                   :value="entry.publishDate"
                   type="date"
-                  class="border border-gray-300 rounded px-2 py-1 text-xs w-full"
+                  class="border border-stone-300 rounded px-2 py-1 text-xs w-full"
                   @change="updateDate(entry, $event)"
                 >
               </td>

--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Image Selector</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Image Selector</h1>
 
     <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
       <div class="flex items-center gap-4">
-        <label class="text-sm font-medium text-gray-600">Segment</label>
-        <select v-model.number="selectedSegment" class="border border-gray-300 rounded px-3 py-2 text-sm">
+        <label class="text-sm font-medium text-stone-600">Segment</label>
+        <select v-model.number="selectedSegment" class="border border-stone-300 rounded px-3 py-2 text-sm">
           <option v-for="n in 26" :key="n" :value="n">{{ n }} - {{ segmentTitle(n) }}</option>
         </select>
         <button
-          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700"
+          class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700"
           @click="loadImages"
         >
           Load
@@ -27,10 +27,10 @@
     <!-- Selected images -->
     <div v-if="selected.length" class="bg-white rounded-lg shadow-sm p-6 mb-6">
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-gray-700">Selected ({{ selected.length }})</h2>
+        <h2 class="text-lg font-semibold text-stone-700">Selected ({{ selected.length }})</h2>
         <button
           :disabled="saving"
-          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+          class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
           @click="saveSelection"
         >
           {{ saving ? 'Saving...' : 'Save to Entry' }}
@@ -45,7 +45,7 @@
           >
             x
           </button>
-          <p class="text-xs text-gray-500 mt-1 truncate">{{ img.alt }}</p>
+          <p class="text-xs text-stone-500 mt-1 truncate">{{ img.alt }}</p>
         </div>
       </div>
       <span v-if="saveMessage" class="block mt-3 text-sm" :class="saveError ? 'text-red-600' : 'text-green-600'">
@@ -55,7 +55,7 @@
 
     <!-- Suggestions grid -->
     <div v-if="suggestions.length" class="bg-white rounded-lg shadow-sm p-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">
         Suggestions ({{ suggestions.length }})
       </h2>
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
@@ -67,7 +67,7 @@
         >
           <div
             class="relative overflow-hidden rounded border-2 transition-all"
-            :class="isSelected(img) ? 'border-green-500 opacity-70' : 'border-gray-200 hover:border-blue-400'"
+            :class="isSelected(img) ? 'border-green-500 opacity-70' : 'border-stone-200 hover:border-blue-400'"
           >
             <img
               :src="img.url"
@@ -86,13 +86,13 @@
               </span>
             </div>
           </div>
-          <p class="text-xs text-gray-600 mt-1 truncate">{{ img.title }}</p>
-          <p class="text-xs text-gray-400 truncate">{{ img.license }} - {{ img.width }}x{{ img.height }}</p>
+          <p class="text-xs text-stone-600 mt-1 truncate">{{ img.title }}</p>
+          <p class="text-xs text-stone-400 truncate">{{ img.license }} - {{ img.width }}x{{ img.height }}</p>
         </div>
       </div>
     </div>
 
-    <p v-else-if="loaded && !fetching" class="text-gray-400 italic text-sm">
+    <p v-else-if="loaded && !fetching" class="text-stone-400 italic text-sm">
       No suggestions found. Click "Fetch from Wikimedia" to search.
     </p>
   </div>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,30 +1,30 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Admin Dashboard</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Admin Dashboard</h1>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       <NuxtLink to="/admin/riders" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Riders</h2>
-        <p class="text-sm text-gray-500 mt-1">Enter daily distances, view standings</p>
+        <h2 class="text-lg font-semibold text-stone-800">Riders</h2>
+        <p class="text-sm text-stone-500 mt-1">Enter daily distances, view standings</p>
       </NuxtLink>
       <NuxtLink to="/admin/entries" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Entries</h2>
-        <p class="text-sm text-gray-500 mt-1">Edit content, toggle draft/publish</p>
+        <h2 class="text-lg font-semibold text-stone-800">Entries</h2>
+        <p class="text-sm text-stone-500 mt-1">Edit content, toggle draft/publish</p>
       </NuxtLink>
       <NuxtLink to="/admin/images" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Images</h2>
-        <p class="text-sm text-gray-500 mt-1">Select CC images per segment</p>
+        <h2 class="text-lg font-semibold text-stone-800">Images</h2>
+        <p class="text-sm text-stone-500 mt-1">Select CC images per segment</p>
       </NuxtLink>
       <NuxtLink to="/admin/weather" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Weather</h2>
-        <p class="text-sm text-gray-500 mt-1">Fetch and inject weather data</p>
+        <h2 class="text-lg font-semibold text-stone-800">Weather</h2>
+        <p class="text-sm text-stone-500 mt-1">Fetch and inject weather data</p>
       </NuxtLink>
       <NuxtLink to="/admin/schedule" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Schedule</h2>
-        <p class="text-sm text-gray-500 mt-1">Configure publish dates</p>
+        <h2 class="text-lg font-semibold text-stone-800">Schedule</h2>
+        <p class="text-sm text-stone-500 mt-1">Configure publish dates</p>
       </NuxtLink>
       <NuxtLink to="/admin/publish" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-gray-800">Publish</h2>
-        <p class="text-sm text-gray-500 mt-1">Build and deploy the site</p>
+        <h2 class="text-lg font-semibold text-stone-800">Publish</h2>
+        <p class="text-sm text-stone-500 mt-1">Build and deploy the site</p>
       </NuxtLink>
     </div>
   </div>

--- a/pages/admin/publish.vue
+++ b/pages/admin/publish.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Publish</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Publish</h1>
 
     <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Pre-publish Steps</h2>
-      <p class="text-sm text-gray-500 mb-4">
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Pre-publish Steps</h2>
+      <p class="text-sm text-stone-500 mb-4">
         Run data processing steps from here. Build and deploy must be done from the terminal
-        (running <code class="bg-gray-100 px-1 rounded">nuxt generate</code> inside the dev server causes conflicts).
+        (running <code class="bg-stone-100 px-1 rounded">nuxt generate</code> inside the dev server causes conflicts).
       </p>
 
       <div class="flex flex-wrap gap-3 mb-4">
@@ -23,7 +23,7 @@
       <div class="flex items-center gap-4">
         <button
           :disabled="running"
-          class="bg-gray-900 text-white px-6 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+          class="bg-stone-900 text-white px-6 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
           @click="runSteps"
         >
           {{ running ? 'Running...' : 'Run' }}
@@ -31,10 +31,10 @@
       </div>
     </div>
 
-    <div v-if="logs.length" class="bg-gray-900 rounded-lg shadow-sm p-6 mb-6">
-      <h2 class="text-sm font-semibold text-gray-400 mb-3">Output</h2>
+    <div v-if="logs.length" class="bg-stone-900 rounded-lg shadow-sm p-6 mb-6">
+      <h2 class="text-sm font-semibold text-stone-400 mb-3">Output</h2>
       <pre class="text-sm font-mono text-green-400 whitespace-pre-wrap max-h-[400px] overflow-auto">{{ logs.join('\n') }}</pre>
-      <div class="mt-4 pt-3 border-t border-gray-700">
+      <div class="mt-4 pt-3 border-t border-stone-700">
         <span class="text-sm" :class="success ? 'text-green-400' : 'text-red-400'">
           {{ success ? '✓ Complete' : '✗ Failed' }}
         </span>
@@ -42,9 +42,9 @@
     </div>
 
     <div class="bg-white rounded-lg shadow-sm p-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Build and Deploy</h2>
-      <p class="text-sm text-gray-500 mb-3">Run these commands in your terminal:</p>
-      <div class="bg-gray-900 rounded p-4 text-sm font-mono text-green-400 space-y-1">
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Build and Deploy</h2>
+      <p class="text-sm text-stone-500 mb-3">Run these commands in your terminal:</p>
+      <div class="bg-stone-900 rounded p-4 text-sm font-mono text-green-400 space-y-1">
         <p># Build only (no deploy)</p>
         <p class="text-white">./scripts/publish.sh --skip-deploy</p>
         <p class="mt-3"># Build and deploy to production</p>

--- a/pages/admin/rider-config.vue
+++ b/pages/admin/rider-config.vue
@@ -1,42 +1,42 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Rider Configuration</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Rider Configuration</h1>
 
     <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Route Settings</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Route Settings</h2>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
         <div>
-          <label class="block text-sm font-medium text-gray-600 mb-1">Total Distance (km)</label>
-          <div class="border border-gray-200 bg-gray-50 rounded px-3 py-2 text-sm text-gray-500">{{ totalDistance }} km (from GPX)</div>
+          <label class="block text-sm font-medium text-stone-600 mb-1">Total Distance (km)</label>
+          <div class="border border-stone-200 bg-stone-50 rounded px-3 py-2 text-sm text-stone-500">{{ totalDistance }} km (from GPX)</div>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-600 mb-1">Daily Cap (km)</label>
-          <input v-model.number="dailyCap" type="number" step="0.1" class="border border-gray-300 rounded px-3 py-2 text-sm w-full" >
+          <label class="block text-sm font-medium text-stone-600 mb-1">Daily Cap (km)</label>
+          <input v-model.number="dailyCap" type="number" step="0.1" class="border border-stone-300 rounded px-3 py-2 text-sm w-full" >
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-600 mb-1">Start Date</label>
-          <input v-model="startDate" type="date" class="border border-gray-300 rounded px-3 py-2 text-sm w-full" >
+          <label class="block text-sm font-medium text-stone-600 mb-1">Start Date</label>
+          <input v-model="startDate" type="date" class="border border-stone-300 rounded px-3 py-2 text-sm w-full" >
         </div>
       </div>
     </div>
 
     <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Riders</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Riders</h2>
       <div class="space-y-4">
-        <div v-for="(rider, idx) in riders" :key="idx" class="flex items-center gap-4 p-3 bg-gray-50 rounded">
+        <div v-for="(rider, idx) in riders" :key="idx" class="flex items-center gap-4 p-3 bg-stone-50 rounded">
           <div class="flex-1">
-            <label class="block text-xs text-gray-500 mb-1">Name</label>
-            <input v-model="rider.name" type="text" class="border border-gray-300 rounded px-3 py-2 text-sm w-full" >
+            <label class="block text-xs text-stone-500 mb-1">Name</label>
+            <input v-model="rider.name" type="text" class="border border-stone-300 rounded px-3 py-2 text-sm w-full" >
           </div>
           <div class="w-32">
-            <label class="block text-xs text-gray-500 mb-1">ID</label>
-            <input v-model="rider.id" type="text" class="border border-gray-300 rounded px-3 py-2 text-sm w-full font-mono" >
+            <label class="block text-xs text-stone-500 mb-1">ID</label>
+            <input v-model="rider.id" type="text" class="border border-stone-300 rounded px-3 py-2 text-sm w-full font-mono" >
           </div>
           <div class="w-24">
-            <label class="block text-xs text-gray-500 mb-1">Colour</label>
+            <label class="block text-xs text-stone-500 mb-1">Colour</label>
             <div class="flex items-center gap-2">
               <input v-model="rider.color" type="color" class="w-8 h-8 rounded cursor-pointer border-0" >
-              <span class="text-xs font-mono text-gray-500">{{ rider.color }}</span>
+              <span class="text-xs font-mono text-stone-500">{{ rider.color }}</span>
             </div>
           </div>
           <button
@@ -56,7 +56,7 @@
     <div class="flex items-center gap-4">
       <button
         :disabled="saving"
-        class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+        class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
         @click="saveConfig"
       >
         {{ saving ? 'Saving...' : 'Save Configuration' }}

--- a/pages/admin/riders.vue
+++ b/pages/admin/riders.vue
@@ -1,16 +1,16 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Rider Daily Distances</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Rider Daily Distances</h1>
 
     <!-- Entry form -->
     <div class="bg-white rounded-lg shadow-sm p-6 mb-8">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Add / Edit Entry</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Add / Edit Entry</h2>
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-600 mb-1">Date</label>
+        <label class="block text-sm font-medium text-stone-600 mb-1">Date</label>
         <input
           v-model="entryDate"
           type="date"
-          class="border border-gray-300 rounded px-3 py-2 text-sm w-48"
+          class="border border-stone-300 rounded px-3 py-2 text-sm w-48"
         >
       </div>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
@@ -23,7 +23,7 @@
             type="number"
             step="0.1"
             min="0"
-            class="border border-gray-300 rounded px-3 py-2 text-sm w-full"
+            class="border border-stone-300 rounded px-3 py-2 text-sm w-full"
             placeholder="0"
           >
         </div>
@@ -31,7 +31,7 @@
       <div class="flex items-center gap-4">
         <button
           :disabled="submitting"
-          class="bg-gray-900 text-white px-4 py-2 rounded text-sm hover:bg-gray-700 disabled:opacity-50"
+          class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
           @click="submitEntry"
         >
           {{ submitting ? 'Saving...' : 'Save Entry' }}
@@ -44,12 +44,12 @@
 
     <!-- History table -->
     <div class="bg-white rounded-lg shadow-sm p-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">History</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">History</h2>
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-200">
-              <th class="text-left py-2 pr-4 text-gray-500 font-medium">Date</th>
+            <tr class="border-b border-stone-200">
+              <th class="text-left py-2 pr-4 text-stone-500 font-medium">Date</th>
               <th
                 v-for="rider in riders"
                 :key="rider.id"
@@ -58,12 +58,12 @@
               >
                 {{ rider.name }}
               </th>
-              <th class="text-center py-2 px-2 text-gray-500 font-medium">Actions</th>
+              <th class="text-center py-2 px-2 text-stone-500 font-medium">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody class="divide-y divide-stone-100">
             <tr v-for="entry in reversedEntries" :key="entry.date">
-              <td class="py-2 pr-4 font-mono text-gray-600">{{ entry.date }}</td>
+              <td class="py-2 pr-4 font-mono text-stone-600">{{ entry.date }}</td>
               <td v-for="rider in riders" :key="rider.id" class="text-center py-2 px-2 font-mono">
                 {{ entry.distances[rider.id] || 0 }}
               </td>
@@ -76,7 +76,7 @@
           </tbody>
         </table>
       </div>
-      <p v-if="!entries.length" class="text-gray-400 italic text-sm">No entries yet.</p>
+      <p v-if="!entries.length" class="text-stone-400 italic text-sm">No entries yet.</p>
     </div>
   </div>
 </template>

--- a/pages/admin/weather.vue
+++ b/pages/admin/weather.vue
@@ -1,44 +1,44 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-gray-800 mb-6">Weather Data</h1>
+    <h1 class="text-2xl font-bold text-stone-800 mb-6">Weather Data</h1>
 
     <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">API Key</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">API Key</h2>
       <div class="flex gap-3 items-center">
         <input
           v-model="apiKey"
           :type="showKey ? 'text' : 'password'"
           placeholder="OpenWeatherMap API key"
-          class="border border-gray-300 rounded px-3 py-2 text-sm flex-1 font-mono"
+          class="border border-stone-300 rounded px-3 py-2 text-sm flex-1 font-mono"
         >
-        <button class="text-sm text-gray-500 hover:underline" @click="showKey = !showKey">
+        <button class="text-sm text-stone-500 hover:underline" @click="showKey = !showKey">
           {{ showKey ? 'Hide' : 'Show' }}
         </button>
       </div>
     </div>
 
     <div class="bg-white rounded-lg shadow-sm p-6">
-      <h2 class="text-lg font-semibold text-gray-700 mb-4">Entries</h2>
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Entries</h2>
       <div class="overflow-x-auto">
         <table class="w-full text-sm">
           <thead>
-            <tr class="border-b border-gray-200">
-              <th class="text-left py-2 pr-2 text-gray-500 font-medium w-10">#</th>
-              <th class="text-left py-2 pr-2 text-gray-500 font-medium">Title</th>
-              <th class="text-left py-2 px-2 text-gray-500 font-medium">Current Weather</th>
-              <th class="text-left py-2 px-2 text-gray-500 font-medium">Fetch</th>
+            <tr class="border-b border-stone-200">
+              <th class="text-left py-2 pr-2 text-stone-500 font-medium w-10">#</th>
+              <th class="text-left py-2 pr-2 text-stone-500 font-medium">Title</th>
+              <th class="text-left py-2 px-2 text-stone-500 font-medium">Current Weather</th>
+              <th class="text-left py-2 px-2 text-stone-500 font-medium">Fetch</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody class="divide-y divide-stone-100">
             <tr v-for="entry in entries" :key="entry.filename">
-              <td class="py-2 pr-2 font-mono text-gray-400">{{ entry.segment }}</td>
-              <td class="py-2 pr-2 text-gray-800">{{ entry.title }}</td>
+              <td class="py-2 pr-2 font-mono text-stone-400">{{ entry.segment }}</td>
+              <td class="py-2 pr-2 text-stone-800">{{ entry.title }}</td>
               <td class="py-2 px-2">
-                <span v-if="entry.weather" class="text-sm text-gray-600">
+                <span v-if="entry.weather" class="text-sm text-stone-600">
                   {{ entry.weather.current.temp }}&deg;C, {{ entry.weather.current.conditions }}, {{ entry.weather.current.wind }}
                   <button class="text-xs text-red-500 hover:underline ml-2" @click="deleteWeather(entry)">delete</button>
                 </span>
-                <span v-else class="text-gray-400 italic">None</span>
+                <span v-else class="text-stone-400 italic">None</span>
               </td>
               <td class="py-2 px-2">
                 <div v-if="preview && preview.filename === entry.filename" class="flex items-center gap-2">
@@ -52,9 +52,9 @@
                   >
                     {{ injecting === entry.filename ? 'Saving...' : 'Save' }}
                   </button>
-                  <button class="text-xs text-gray-400 hover:underline" @click="preview = null">Cancel</button>
+                  <button class="text-xs text-stone-400 hover:underline" @click="preview = null">Cancel</button>
                 </div>
-                <span v-else-if="fetching === entry.filename" class="text-xs text-gray-400">Fetching...</span>
+                <span v-else-if="fetching === entry.filename" class="text-xs text-stone-400">Fetching...</span>
                 <button
                   v-else
                   class="text-xs text-blue-600 hover:underline"

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -4,9 +4,9 @@
       <span class="text-sm text-correze-red font-semibold">
         Segment {{ page.segment }} - Km {{ page.kmStart }}-{{ page.kmEnd }}
       </span>
-      <h1 class="text-4xl font-serif font-bold text-gray-900 mt-2">{{ page.title }}</h1>
-      <p v-if="page.subtitle" class="text-xl text-gray-500 mt-2 font-serif">{{ page.subtitle }}</p>
-      <time class="text-sm text-gray-400 mt-3 block">{{ formatDate(page.publishDate) }}</time>
+      <h1 class="text-4xl font-serif font-bold text-stone-900 mt-2">{{ page.title }}</h1>
+      <p v-if="page.subtitle" class="text-xl text-stone-500 mt-2 font-serif">{{ page.subtitle }}</p>
+      <time class="text-sm text-stone-400 mt-3 block">{{ formatDate(page.publishDate) }}</time>
     </header>
 
     <SegmentMap
@@ -33,7 +33,7 @@
 
     <RiderDashboard />
 
-    <nav class="mt-12 pt-8 border-t border-gray-200 flex justify-between">
+    <nav class="mt-12 pt-8 border-t border-stone-200 flex justify-between">
       <NuxtLink
         v-if="prev"
         :to="prev.path || prev._path"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,11 +4,11 @@
       <h1 class="text-4xl font-serif font-bold text-correze-red mb-4">
         Malemort to Ussel
       </h1>
-      <p class="text-xl text-gray-600 font-serif leading-relaxed">
+      <p class="text-xl text-stone-600 font-serif leading-relaxed">
         A cycling travelogue following the 185km route of Stage 9 of the 2026 Tour de France,
         through the hills, valleys, and villages of Correze.
       </p>
-      <p class="mt-2 text-gray-500">
+      <p class="mt-2 text-stone-500">
         26 entries published twice weekly, Sunday and Wednesday mornings.
         The peloton rides this road on Sunday, July 12.
       </p>
@@ -17,7 +17,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
       <div class="lg:col-span-2">
         <section class="mb-8">
-          <h2 class="text-2xl font-serif font-bold text-gray-800 mb-4">The Route</h2>
+          <h2 class="text-2xl font-serif font-bold text-stone-800 mb-4">The Route</h2>
           <SegmentMap
             :segment="0"
             :segments="segments"
@@ -26,7 +26,7 @@
             :rider-stats="riderStats"
             :rider-config="riderConfig"
           />
-          <p class="text-xs text-gray-400 mt-2">
+          <p class="text-xs text-stone-400 mt-2">
             Full 185km route. Use layer controls for topo, cycling, and satellite views.
           </p>
           <ClientOnly>
@@ -35,7 +35,7 @@
         </section>
 
         <section>
-          <h2 class="text-2xl font-serif font-bold text-gray-800 mb-6">Latest Entries</h2>
+          <h2 class="text-2xl font-serif font-bold text-stone-800 mb-6">Latest Entries</h2>
           <div v-if="entries && entries.length" class="space-y-6">
             <article v-for="entry in entries" :key="entry.path || entry._path" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
               <NuxtLink :to="entry.path || entry._path" class="block">
@@ -43,13 +43,13 @@
                   Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
                 </span>
                 <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
-                <h3 class="text-xl font-serif font-bold text-gray-900 mt-1">{{ entry.title }}</h3>
-                <p v-if="entry.subtitle" class="text-gray-600 mt-1">{{ entry.subtitle }}</p>
-                <time class="text-sm text-gray-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+                <h3 class="text-xl font-serif font-bold text-stone-900 mt-1">{{ entry.title }}</h3>
+                <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+                <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
               </NuxtLink>
             </article>
           </div>
-          <p v-else class="text-gray-500 italic">No entries published yet.</p>
+          <p v-else class="text-stone-500 italic">No entries published yet.</p>
         </section>
       </div>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from 'tailwindcss'
 import typography from '@tailwindcss/typography'
+import colors from 'tailwindcss/colors'
 
 export default {
   content: [],
@@ -8,16 +9,60 @@ export default {
     extend: {
       colors: {
         correze: {
-          red: '#8B2500',
-          gold: '#DAA520',
-          green: '#2E5A1C',
-          slate: '#4A5568'
-        }
+          red: {
+            50: '#fdf3f0',
+            100: '#fbe4dc',
+            200: '#f5c5b5',
+            300: '#ed9e84',
+            400: '#d9714d',
+            500: '#b83a12',
+            600: '#8B2500',
+            700: '#6e1d00',
+            800: '#5a1800',
+            900: '#4a1400',
+            950: '#2d0c00',
+            DEFAULT: '#8B2500',
+          },
+          green: {
+            50: '#f0f7ed',
+            100: '#deefd6',
+            200: '#b8dda8',
+            300: '#89c470',
+            400: '#5da343',
+            500: '#3d7a25',
+            600: '#2E5A1C',
+            700: '#254a17',
+            800: '#1e3b13',
+            900: '#183010',
+            950: '#0d1c09',
+            DEFAULT: '#2E5A1C',
+          },
+          gold: {
+            DEFAULT: '#DAA520',
+          },
+        },
+        accent: '#FFD100',
       },
       fontFamily: {
         serif: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
-        sans: ['Inter', 'system-ui', 'sans-serif']
-      }
-    }
-  }
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+      },
+      typography: {
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': colors.stone['700'],
+            '--tw-prose-headings': colors.stone['900'],
+            '--tw-prose-links': '#8B2500',
+            '--tw-prose-bold': colors.stone['900'],
+            '--tw-prose-counters': colors.stone['500'],
+            '--tw-prose-bullets': colors.stone['400'],
+            '--tw-prose-hr': colors.stone['200'],
+            '--tw-prose-quotes': colors.stone['700'],
+            '--tw-prose-quote-borders': '#8B2500',
+            '--tw-prose-captions': colors.stone['500'],
+          },
+        },
+      },
+    },
+  },
 } satisfies Config


### PR DESCRIPTION
## Summary

Apply the "Sandstone & Forest" colour theme inspired by the Correze landscape.

### Changes

- **Neutral scale:** Swap all `gray-*` to warm `stone-*` across 20 Vue files (218 occurrences)
- **Colour scales:** Expand `correze-red` and `correze-green` from single hex values to full 50-950 shade scales, enabling tinted backgrounds and hover states
- **Accent colour:** Add Tour de France yellow (`#FFD100`) as `accent` for badges and highlights
- **Typography:** Configure `@tailwindcss/typography` prose with stone body text, stone-900 headings, correze-red links and blockquote borders
- **Header:** Yellow hover changed from `yellow-300` to `accent`
- **Footer:** Darkened from `stone-800` to `stone-900`

### What is not changed

- Rider dashboard colours (data-driven from rider-config.json)
- Chart.js elevation gradient colours (data encoding)
- Leaflet map tiles
- Admin layout structure (only gray->stone swap)

Closes #55

## Test plan

- [x] ESLint clean
- [x] All 58 JS tests pass
- [x] Build succeeds (23 routes pre-rendered)
- [x] CI passes
- [x] Visual review of the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)