### PR TITLE
Move Malemort marker to race start point

### DIFF
--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -1,8 +1,8 @@
 {
   "Malemort": {
     "type": "town",
-    "lat": 45.1752984,
-    "lng": 1.574502
+    "lat": 45.13834,
+    "lng": 1.54947
   },
   "Brive-la-Gaillarde": {
     "type": "town",


### PR DESCRIPTION
## Summary

Move the Malemort town marker from the commune centre (Malemort-sur-Correze) to the GPX track start point where the stage actually begins.

- Old: 45.1753, 1.5745 (commune centre)
- New: 45.1383, 1.5495 (segment 1 start from segments.json)

Closes #165

## Test plan

- [x] CI passes
- [x] Visual review: Malemort marker sits at the start of the route on the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)