### PR TITLE
Refine typography for travelogue feel

### DIFF
--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -4,8 +4,8 @@
       <span class="text-sm text-correze-red font-semibold">
         Segment {{ page.segment }} - Km {{ page.kmStart }}-{{ page.kmEnd }}
       </span>
-      <h1 class="text-4xl font-serif font-bold text-stone-900 mt-2">{{ page.title }}</h1>
-      <p v-if="page.subtitle" class="text-xl text-stone-500 mt-2 font-serif">{{ page.subtitle }}</p>
+      <h1 class="text-4xl font-serif font-semibold text-stone-900 mt-2 tracking-wide">{{ page.title }}</h1>
+      <p v-if="page.subtitle" class="text-xl text-stone-500 mt-2 font-serif tracking-wide">{{ page.subtitle }}</p>
       <time class="text-sm text-stone-400 mt-3 block">{{ formatDate(page.publishDate) }}</time>
     </header>
 
@@ -23,7 +23,7 @@
 
     <PowerStats :elevation-data="elevationData" class="mb-8" />
 
-    <div class="prose prose-lg max-w-none font-serif">
+    <div class="prose md:prose-lg max-w-none font-serif">
       <ContentRenderer :value="page" />
     </div>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <section class="mb-12">
-      <h1 class="text-4xl font-serif font-bold text-correze-red mb-4">
+      <h1 class="text-4xl font-serif font-semibold text-correze-red mb-4 tracking-wide">
         Malemort to Ussel
       </h1>
       <p class="text-xl text-stone-600 font-serif leading-relaxed">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,6 +60,14 @@ export default {
             '--tw-prose-quotes': colors.stone['700'],
             '--tw-prose-quote-borders': '#8B2500',
             '--tw-prose-captions': colors.stone['500'],
+            'h1, h2, h3, h4': {
+              fontFamily: 'Georgia, Cambria, "Times New Roman", serif',
+              fontWeight: '600',
+              letterSpacing: '0.01em',
+            },
+            p: {
+              lineHeight: '1.8',
+            },
           },
         },
       },


### PR DESCRIPTION
## Summary

Shift typography from "default blog" toward "travel magazine":

- **Prose headings:** Serif font (Georgia), semibold weight (was bold), slight letter-spacing (0.01em)
- **Body text:** Line height increased to 1.8 for more relaxed reading
- **Responsive prose size:** `prose` on mobile, `prose-lg` on medium+ screens (was always prose-lg)
- **Page headings:** Updated from `font-bold` to `font-semibold tracking-wide` on homepage and entry pages

Closes #160

## Test plan

- [x] ESLint clean
- [x] All 58 tests pass
- [x] CI passes
- [x] Visual review: check entry pages on desktop and narrow mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)