### PR TITLE
Update Marian rider colour from white to steel blue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ The name alone should give our four riders pause...
 {
   "riders": [
     { "id": "justin", "name": "Justin", "color": "#DAA520" },
-    { "id": "marian", "name": "Marian", "color": "#FFFFFF" },
+    { "id": "marian", "name": "Marian", "color": "#4682B4" },
     { "id": "nan", "name": "Nan", "color": "#FF00FF" },
     { "id": "wally", "name": "Wally", "color": "#8B0000" }
   ],


### PR DESCRIPTION
## Summary

Change Marian's rider colour from #FFFFFF (white) to #4682B4 (steel blue) in CLAUDE.md spec. Complements the sandstone red, forest green, and gold in the site theme.

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)