### PR TITLE
Define sprint and climbing point locations

### DIFF
--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -1,0 +1,103 @@
+{
+  "description": "Sprint and climbing point locations for the rider competition",
+  "sprints": [
+    {
+      "name": "Sprint - Turenne",
+      "segment": 3,
+      "km": 17,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Before Tulle",
+      "segment": 9,
+      "km": 60,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Bugeat",
+      "segment": 19,
+      "km": 130,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Ussel Finish",
+      "segment": 26,
+      "km": 183,
+      "points": [20, 17, 15, 13]
+    }
+  ],
+  "climbs": [
+    {
+      "name": "Puy Boubou",
+      "segment": 5,
+      "km": 32.8,
+      "category": 3,
+      "gradient": 4.1,
+      "points": [4, 3, 2, 1]
+    },
+    {
+      "name": "Cote de Lagleygeolle",
+      "segment": 7,
+      "km": 43.2,
+      "category": 4,
+      "gradient": 3.9,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote de Miel",
+      "segment": 8,
+      "km": 56.6,
+      "category": 4,
+      "gradient": 3.9,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote des Naves",
+      "segment": 11,
+      "km": 74.8,
+      "category": 2,
+      "gradient": 6.7,
+      "points": [6, 4, 2, 1]
+    },
+    {
+      "name": "Puy de Lachaud",
+      "segment": 13,
+      "km": 85.6,
+      "category": 2,
+      "gradient": 5.3,
+      "points": [6, 4, 2, 1]
+    },
+    {
+      "name": "Suc au May",
+      "segment": 15,
+      "km": 104.8,
+      "category": "HC",
+      "gradient": 7.7,
+      "points": [10, 8, 6, 4]
+    },
+    {
+      "name": "Cote de la Croix de Pey",
+      "segment": 18,
+      "km": 127,
+      "category": 3,
+      "gradient": 4.9,
+      "points": [4, 3, 2, 1]
+    },
+    {
+      "name": "Mont Bessou",
+      "segment": 22,
+      "km": 153,
+      "category": 4,
+      "gradient": 3.5,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote des Gardes",
+      "segment": 24,
+      "km": 167.2,
+      "category": 3,
+      "gradient": 4.8,
+      "points": [4, 3, 2, 1]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Create `data/competition/points-config.json` mapping point opportunities to segments.

### Sprint points (green jersey)
4 intermediate sprints in flat/town segments, each awarding 20/17/15/13 points:
- Segment 3: Turenne (km 17)
- Segment 9: Before Tulle (km 60)
- Segment 19: Bugeat (km 130)
- Segment 26: Ussel finish (km 183)

### Climbing points (polka dot jersey)
9 climbs categorized by gradient, points scaled by difficulty:
- **HC** - Suc au May (7.7%): 10/8/6/4
- **Cat 2** - Cote des Naves (6.7%), Puy de Lachaud (5.3%): 6/4/2/1
- **Cat 3** - Puy Boubou (4.1%), Cote de la Croix de Pey (4.9%), Cote des Gardes (4.8%): 4/3/2/1
- **Cat 4** - Cote de Lagleygeolle (3.9%), Cote de Miel (3.9%), Mont Bessou (3.5%): 2/1/0/0

Closes #156

## Test plan

- [x] JSON is valid
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)