### PR TITLE
Add points calculation script with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 # Rider data (managed locally, synced to VM via admin)
 data/riders/daily-log.json
 data/riders/stats.json
+data/riders/points.json
 
 # Test coverage
 coverage/

--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -1,0 +1,103 @@
+{
+  "description": "Sprint and climbing point locations for the rider competition",
+  "sprints": [
+    {
+      "name": "Sprint - Turenne",
+      "segment": 3,
+      "km": 17,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Before Tulle",
+      "segment": 9,
+      "km": 60,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Bugeat",
+      "segment": 19,
+      "km": 130,
+      "points": [20, 17, 15, 13]
+    },
+    {
+      "name": "Sprint - Ussel Finish",
+      "segment": 26,
+      "km": 183,
+      "points": [20, 17, 15, 13]
+    }
+  ],
+  "climbs": [
+    {
+      "name": "Puy Boubou",
+      "segment": 5,
+      "km": 32.8,
+      "category": 3,
+      "gradient": 4.1,
+      "points": [4, 3, 2, 1]
+    },
+    {
+      "name": "Cote de Lagleygeolle",
+      "segment": 7,
+      "km": 43.2,
+      "category": 4,
+      "gradient": 3.9,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote de Miel",
+      "segment": 8,
+      "km": 56.6,
+      "category": 4,
+      "gradient": 3.9,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote des Naves",
+      "segment": 11,
+      "km": 74.8,
+      "category": 2,
+      "gradient": 6.7,
+      "points": [6, 4, 2, 1]
+    },
+    {
+      "name": "Puy de Lachaud",
+      "segment": 13,
+      "km": 85.6,
+      "category": 2,
+      "gradient": 5.3,
+      "points": [6, 4, 2, 1]
+    },
+    {
+      "name": "Suc au May",
+      "segment": 15,
+      "km": 104.8,
+      "category": "HC",
+      "gradient": 7.7,
+      "points": [10, 8, 6, 4]
+    },
+    {
+      "name": "Cote de la Croix de Pey",
+      "segment": 18,
+      "km": 127,
+      "category": 3,
+      "gradient": 4.9,
+      "points": [4, 3, 2, 1]
+    },
+    {
+      "name": "Mont Bessou",
+      "segment": 22,
+      "km": 153,
+      "category": 4,
+      "gradient": 3.5,
+      "points": [2, 1, 0, 0]
+    },
+    {
+      "name": "Cote des Gardes",
+      "segment": 24,
+      "km": 167.2,
+      "category": 3,
+      "gradient": 4.8,
+      "points": [4, 3, 2, 1]
+    }
+  ]
+}

--- a/processing/calculate_points.py
+++ b/processing/calculate_points.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Calculate sprint and climbing points for each rider based on capped distance progress."""
+
+import argparse
+import json
+import random
+
+
+def load_json(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def calculate_capped_distances(daily_log, rider_config):
+    """Calculate cumulative capped distance per rider per day.
+
+    Returns dict of rider_id -> list of (date, cumulative_capped_km).
+    """
+    daily_cap = rider_config["dailyCap"]
+    entries = sorted(daily_log["entries"], key=lambda e: e["date"])
+    rider_ids = [r["id"] for r in rider_config["riders"]]
+
+    result = {}
+    for rider_id in rider_ids:
+        carry = 0.0
+        cumulative = 0.0
+        progress = []
+        for entry in entries:
+            dist = entry.get("distances", {}).get(rider_id, 0)
+            available = daily_cap + carry
+            credited = min(dist, available)
+            cumulative += credited
+            carry = available - credited
+            progress.append({"date": entry["date"], "cumulative_km": cumulative})
+        result[rider_id] = progress
+
+    return result
+
+
+def find_arrival_day(progress, km_mark):
+    """Find the date a rider's cumulative distance first passes a km mark.
+
+    Returns (date, cumulative_km) or None if not yet reached.
+    """
+    for entry in progress:
+        if entry["cumulative_km"] >= km_mark:
+            return entry["date"], entry["cumulative_km"]
+    return None
+
+
+def calculate_points(daily_log, rider_config, points_config, seed=42):
+    """Calculate all sprint and climbing points.
+
+    Returns dict with per-rider totals and per-location results.
+    """
+    rider_ids = [r["id"] for r in rider_config["riders"]]
+    cumulative = calculate_capped_distances(daily_log, rider_config)
+
+    rng = random.Random(seed)
+
+    all_locations = []
+    for sprint in points_config["sprints"]:
+        all_locations.append({**sprint, "type": "sprint"})
+    for climb in points_config["climbs"]:
+        all_locations.append({**climb, "type": "climb"})
+
+    # Initialize per-rider totals
+    rider_totals = {}
+    for rider_id in rider_ids:
+        rider_totals[rider_id] = {
+            "sprintPoints": 0,
+            "climbPoints": 0,
+            "totalPoints": 0,
+        }
+
+    # Calculate points per location
+    location_results = []
+    for loc in all_locations:
+        km_mark = loc["km"]
+        points_available = loc["points"]
+
+        # Find which riders have passed this point and when
+        arrivals = []
+        for rider_id in rider_ids:
+            result = find_arrival_day(cumulative[rider_id], km_mark)
+            if result:
+                date, cum_km = result
+                arrivals.append({
+                    "rider": rider_id,
+                    "date": date,
+                    "cumulative_km": cum_km,
+                })
+
+        if not arrivals:
+            location_results.append({
+                "name": loc["name"],
+                "type": loc["type"],
+                "segment": loc["segment"],
+                "km": km_mark,
+                "awards": [],
+                "reached": False,
+            })
+            continue
+
+        # Sort by arrival date, then by cumulative km (further = arrived earlier
+        # in the day conceptually), then random tiebreak
+        arrivals.sort(key=lambda a: (a["date"], -a["cumulative_km"], rng.random()))
+
+        awards = []
+        for place, arrival in enumerate(arrivals):
+            pts = points_available[place] if place < len(points_available) else 0
+            awards.append({
+                "place": place + 1,
+                "rider": arrival["rider"],
+                "date": arrival["date"],
+                "points": pts,
+            })
+
+            # Add to rider totals
+            if loc["type"] == "sprint":
+                rider_totals[arrival["rider"]]["sprintPoints"] += pts
+            else:
+                rider_totals[arrival["rider"]]["climbPoints"] += pts
+            rider_totals[arrival["rider"]]["totalPoints"] += pts
+
+        location_results.append({
+            "name": loc["name"],
+            "type": loc["type"],
+            "segment": loc["segment"],
+            "km": km_mark,
+            "awards": awards,
+            "reached": True,
+        })
+
+    return {
+        "riders": rider_totals,
+        "locations": location_results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate rider competition points")
+    parser.add_argument("--daily-log", default="data/riders/daily-log.json")
+    parser.add_argument("--rider-config", default="data/riders/rider-config.json")
+    parser.add_argument("--points-config", default="data/competition/points-config.json")
+    parser.add_argument("--output", default="data/riders/points.json")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for tiebreaking")
+    args = parser.parse_args()
+
+    daily_log = load_json(args.daily_log)
+    rider_config = load_json(args.rider_config)
+    points_config = load_json(args.points_config)
+
+    result = calculate_points(daily_log, rider_config, points_config, seed=args.seed)
+
+    with open(args.output, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"Points calculated ({len(result['locations'])} locations)")
+    print()
+    for rider_id, totals in result["riders"].items():
+        rider_name = next(r["name"] for r in rider_config["riders"] if r["id"] == rider_id)
+        print(f"  {rider_name}: sprint={totals['sprintPoints']} climb={totals['climbPoints']} total={totals['totalPoints']}")
+
+    reached = sum(1 for loc in result["locations"] if loc["reached"])
+    print(f"\n  {reached}/{len(result['locations'])} point locations reached")
+    print(f"\nWrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/tests/test_calculate_points.py
+++ b/processing/tests/test_calculate_points.py
@@ -1,0 +1,172 @@
+"""Tests for calculate_points.py - sprint and climbing point calculations."""
+
+from processing.calculate_points import (
+    calculate_capped_distances,
+    calculate_points,
+    find_arrival_day,
+)
+
+
+def make_config(daily_cap=2):
+    return {
+        "riders": [
+            {"id": "alice", "name": "Alice", "color": "#FF0000"},
+            {"id": "bob", "name": "Bob", "color": "#0000FF"},
+        ],
+        "totalDistance": 185,
+        "dailyCap": daily_cap,
+        "startDate": "2026-04-02",
+    }
+
+
+def make_log(alice_dists, bob_dists=None):
+    if bob_dists is None:
+        bob_dists = [0] * len(alice_dists)
+    entries = []
+    for i, (a, b) in enumerate(zip(alice_dists, bob_dists)):
+        entries.append({
+            "date": f"2026-04-{(i + 2):02d}",
+            "distances": {"alice": a, "bob": b},
+        })
+    return {"entries": entries}
+
+
+SIMPLE_POINTS_CONFIG = {
+    "sprints": [
+        {"name": "Sprint 1", "segment": 1, "km": 5, "points": [20, 17, 15, 13]},
+    ],
+    "climbs": [
+        {"name": "Climb 1", "segment": 2, "km": 10, "points": [6, 4, 2, 1]},
+    ],
+}
+
+
+class TestCappedDistances:
+    def test_basic_accumulation(self):
+        log = make_log([2.0, 2.0, 2.0], [1.0, 1.0, 1.0])
+        result = calculate_capped_distances(log, make_config(daily_cap=2))
+        alice = result["alice"]
+        assert alice[-1]["cumulative_km"] == 6.0
+        bob = result["bob"]
+        assert bob[-1]["cumulative_km"] == 3.0
+
+    def test_cap_applied(self):
+        log = make_log([10.0], [10.0])
+        result = calculate_capped_distances(log, make_config(daily_cap=2))
+        assert result["alice"][-1]["cumulative_km"] == 2.0
+
+    def test_carry_over(self):
+        # Day 1: ride 0, carry 2. Day 2: ride 4, available 4, credited 4.
+        log = make_log([0, 4.0])
+        result = calculate_capped_distances(log, make_config(daily_cap=2))
+        assert result["alice"][-1]["cumulative_km"] == 4.0
+
+
+class TestFindArrivalDay:
+    def test_finds_first_day_past_mark(self):
+        progress = [
+            {"date": "2026-04-02", "cumulative_km": 2.0},
+            {"date": "2026-04-03", "cumulative_km": 4.0},
+            {"date": "2026-04-04", "cumulative_km": 6.0},
+        ]
+        date, km = find_arrival_day(progress, 5.0)
+        assert date == "2026-04-04"
+        assert km == 6.0
+
+    def test_exact_match(self):
+        progress = [
+            {"date": "2026-04-02", "cumulative_km": 5.0},
+        ]
+        date, km = find_arrival_day(progress, 5.0)
+        assert date == "2026-04-02"
+
+    def test_not_yet_reached(self):
+        progress = [
+            {"date": "2026-04-02", "cumulative_km": 2.0},
+        ]
+        assert find_arrival_day(progress, 10.0) is None
+
+    def test_empty_progress(self):
+        assert find_arrival_day([], 5.0) is None
+
+
+class TestCalculatePoints:
+    def test_no_points_when_not_reached(self):
+        log = make_log([1.0])
+        result = calculate_points(log, make_config(), SIMPLE_POINTS_CONFIG)
+        assert result["riders"]["alice"]["totalPoints"] == 0
+        assert result["locations"][0]["reached"] is False
+
+    def test_sprint_points_awarded(self):
+        # Alice reaches km 5 first (day 3), Bob reaches day 4
+        log = make_log([2.0, 2.0, 2.0, 2.0], [1.0, 1.0, 1.0, 2.0])
+        config = make_config(daily_cap=2)
+        result = calculate_points(log, config, SIMPLE_POINTS_CONFIG)
+        alice = result["riders"]["alice"]
+        bob = result["riders"]["bob"]
+        # Alice arrives day 3 (6km), Bob arrives day 4 (5km)
+        assert alice["sprintPoints"] == 20
+        assert bob["sprintPoints"] == 17
+
+    def test_climb_points_awarded(self):
+        # Both reach km 10 eventually
+        log = make_log([2.0] * 6, [2.0] * 6)
+        config = make_config(daily_cap=2)
+        result = calculate_points(log, config, SIMPLE_POINTS_CONFIG)
+        # Both arrive on same day (day 5, 10km) - tiebreak is random but seeded
+        alice_climb = result["riders"]["alice"]["climbPoints"]
+        bob_climb = result["riders"]["bob"]["climbPoints"]
+        assert {alice_climb, bob_climb} == {6, 4}
+
+    def test_only_reached_locations_have_awards(self):
+        log = make_log([2.0, 2.0, 2.0])  # 6km - past sprint at 5, not climb at 10
+        result = calculate_points(log, make_config(), SIMPLE_POINTS_CONFIG)
+        sprint = result["locations"][0]
+        climb = result["locations"][1]
+        assert sprint["reached"] is True
+        assert len(sprint["awards"]) > 0
+        assert climb["reached"] is False
+        assert len(climb["awards"]) == 0
+
+    def test_seed_produces_consistent_results(self):
+        log = make_log([2.0] * 6, [2.0] * 6)
+        config = make_config(daily_cap=2)
+        r1 = calculate_points(log, config, SIMPLE_POINTS_CONFIG, seed=42)
+        r2 = calculate_points(log, config, SIMPLE_POINTS_CONFIG, seed=42)
+        assert r1 == r2
+
+    def test_different_seed_may_change_tiebreak(self):
+        log = make_log([2.0] * 6, [2.0] * 6)
+        config = make_config(daily_cap=2)
+        # With identical progress, tiebreak depends on seed
+        r1 = calculate_points(log, config, SIMPLE_POINTS_CONFIG, seed=1)
+        r2 = calculate_points(log, config, SIMPLE_POINTS_CONFIG, seed=2)
+        # At least one location should potentially differ (not guaranteed but likely)
+        # Just verify both are valid
+        assert r1["riders"]["alice"]["totalPoints"] + r1["riders"]["bob"]["totalPoints"] > 0
+        assert r2["riders"]["alice"]["totalPoints"] + r2["riders"]["bob"]["totalPoints"] > 0
+
+    def test_empty_log(self):
+        log = {"entries": []}
+        result = calculate_points(log, make_config(), SIMPLE_POINTS_CONFIG)
+        assert result["riders"]["alice"]["totalPoints"] == 0
+        assert all(not loc["reached"] for loc in result["locations"])
+
+    def test_total_points_is_sum(self):
+        log = make_log([2.0] * 6, [1.0] * 10)
+        config = make_config(daily_cap=2)
+        result = calculate_points(log, config, SIMPLE_POINTS_CONFIG)
+        for rider_id, totals in result["riders"].items():
+            assert totals["totalPoints"] == totals["sprintPoints"] + totals["climbPoints"]
+
+    def test_location_results_structure(self):
+        log = make_log([2.0] * 3)
+        result = calculate_points(log, make_config(), SIMPLE_POINTS_CONFIG)
+        for loc in result["locations"]:
+            assert "name" in loc
+            assert "type" in loc
+            assert loc["type"] in ("sprint", "climb")
+            assert "segment" in loc
+            assert "km" in loc
+            assert "reached" in loc
+            assert "awards" in loc


### PR DESCRIPTION
## Summary

New Python script `processing/calculate_points.py` that calculates sprint and climbing points for the rider competition.

### How it works

- Reads daily-log.json, rider-config.json, and points-config.json
- Calculates cumulative capped distance per rider per day
- For each point location (sprint or climb), determines which riders have passed that km mark and in what order
- Awards points: 1st place gets most, decreasing for 2nd/3rd/4th
- Ties (same arrival day) broken randomly with configurable seed for reproducibility
- Outputs `data/riders/points.json` with per-rider totals and per-location awards

### Tests

16 tests covering:
- Capped distance accumulation and carry-over
- Arrival day detection (first past, exact match, not reached, empty)
- Sprint and climbing point awards
- Tiebreaking consistency with seed
- Empty log, total calculation, output structure

Also includes points-config.json from #156 and adds points.json to .gitignore.

Closes #157

## Test plan

- [x] All 16 new tests pass
- [x] Ruff clean
- [x] Script runs locally with example data
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)