### PR TITLE
Add race narrative generator with tests

### DIFF
--- a/processing/generate_narrative.py
+++ b/processing/generate_narrative.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate fictional race narrative for point locations in a segment."""
+
+import argparse
+import json
+import random
+
+
+def load_json(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def rider_name(rider_id, rider_config):
+    """Look up rider display name from config."""
+    for r in rider_config["riders"]:
+        if r["id"] == rider_id:
+            return r["name"]
+    return rider_id
+
+
+SPRINT_TEMPLATES = [
+    "At the intermediate sprint in {name} (km {km}), {first} powered through first to claim {pts1} points{rest}.",
+    "The sprint at {name} (km {km}) saw {first} surge ahead for {pts1} points{rest}.",
+    "{first} took the sprint at {name} (km {km}), picking up {pts1} points{rest}.",
+    "Through {name} (km {km}), {first} hit the line first for {pts1} sprint points{rest}.",
+]
+
+CLIMB_TEMPLATES = [
+    "On the slopes of {name} (km {km}, {cat}), {first} crested first, taking {pts1} climbing points{rest}.",
+    "{first} reached the summit of {name} (km {km}, {cat}) first for {pts1} points{rest}.",
+    "The {cat} climb at {name} (km {km}) went to {first} with {pts1} points{rest}.",
+    "At the top of {name} (km {km}, {cat}), {first} crossed first to claim {pts1} climbing points{rest}.",
+]
+
+NO_POINTS_TEMPLATES = [
+    "No points were contested in this segment. The riders pressed on through the terrain.",
+    "This stretch of road held no sprints or summits. The riders settled into their rhythm.",
+    "With no points on offer, the riders focused on the road ahead.",
+]
+
+NOT_REACHED_TEMPLATES = [
+    "The {type} at {name} (km {km}) awaits - no riders have reached it yet.",
+    "Ahead lies the {type} at {name} (km {km}), still unclaimed.",
+]
+
+
+def format_category(category):
+    """Format climb category for display."""
+    if category == "HC":
+        return "Hors Categorie"
+    return f"Cat {category}"
+
+
+def format_rest(awards, rider_config):
+    """Format the rest of the finishers after 1st place."""
+    if len(awards) < 2:
+        return ". No other riders had reached this far"
+
+    parts = []
+    for award in awards[1:]:
+        if award["points"] > 0:
+            name = rider_name(award["rider"], rider_config)
+            parts.append(f"{name} for {award['points']}")
+
+    if not parts:
+        return ""
+
+    if len(parts) == 1:
+        return f", with {parts[0]}"
+
+    return ", with " + ", ".join(parts[:-1]) + f" and {parts[-1]}"
+
+
+def generate_narrative(points_data, rider_config, segment, seed=42):
+    """Generate narrative text for point locations in a segment.
+
+    Returns a string with one paragraph per point location, or a
+    brief message if no points are in this segment.
+    """
+    rng = random.Random(seed)
+
+    locations = [
+        loc for loc in points_data.get("locations", [])
+        if loc["segment"] == segment
+    ]
+
+    if not locations:
+        return rng.choice(NO_POINTS_TEMPLATES)
+
+    paragraphs = []
+    for loc in locations:
+        if not loc["reached"] or not loc["awards"]:
+            template = rng.choice(NOT_REACHED_TEMPLATES)
+            paragraphs.append(template.format(
+                type="sprint" if loc["type"] == "sprint" else "climb",
+                name=loc["name"],
+                km=loc["km"],
+            ))
+            continue
+
+        first_award = loc["awards"][0]
+        first_name = rider_name(first_award["rider"], rider_config)
+        rest_text = format_rest(loc["awards"], rider_config)
+
+        if loc["type"] == "sprint":
+            template = rng.choice(SPRINT_TEMPLATES)
+            paragraphs.append(template.format(
+                name=loc["name"],
+                km=loc["km"],
+                first=first_name,
+                pts1=first_award["points"],
+                rest=rest_text,
+            ))
+        else:
+            cat = format_category(loc.get("category", "?"))
+            template = rng.choice(CLIMB_TEMPLATES)
+            paragraphs.append(template.format(
+                name=loc["name"],
+                km=loc["km"],
+                cat=cat,
+                first=first_name,
+                pts1=first_award["points"],
+                rest=rest_text,
+            ))
+
+    return "\n\n".join(paragraphs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate segment race narrative")
+    parser.add_argument("--points", default="data/riders/points.json")
+    parser.add_argument("--rider-config", default="data/riders/rider-config.json")
+    parser.add_argument("--segment", type=int, required=True, help="Segment number")
+    parser.add_argument("--output", help="Optional output file (default: stdout)")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    points_data = load_json(args.points)
+    rider_config = load_json(args.rider_config)
+
+    narrative = generate_narrative(points_data, rider_config, args.segment, seed=args.seed)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(narrative)
+        print(f"Wrote narrative for segment {args.segment} to {args.output}")
+    else:
+        print(narrative)
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/tests/test_generate_narrative.py
+++ b/processing/tests/test_generate_narrative.py
@@ -1,0 +1,128 @@
+"""Tests for generate_narrative.py - race narrative generation."""
+
+from processing.generate_narrative import (
+    format_category,
+    format_rest,
+    generate_narrative,
+    rider_name,
+)
+
+CONFIG = {
+    "riders": [
+        {"id": "alice", "name": "Alice", "color": "#FF0000"},
+        {"id": "bob", "name": "Bob", "color": "#0000FF"},
+    ],
+}
+
+
+def make_points(locations):
+    return {"riders": {}, "locations": locations}
+
+
+class TestRiderName:
+    def test_found(self):
+        assert rider_name("alice", CONFIG) == "Alice"
+
+    def test_fallback(self):
+        assert rider_name("unknown", CONFIG) == "unknown"
+
+
+class TestFormatCategory:
+    def test_hc(self):
+        assert format_category("HC") == "Hors Categorie"
+
+    def test_numbered(self):
+        assert format_category(2) == "Cat 2"
+
+
+class TestFormatRest:
+    def test_no_others(self):
+        awards = [{"place": 1, "rider": "alice", "points": 20}]
+        assert "No other riders" in format_rest(awards, CONFIG)
+
+    def test_one_other(self):
+        awards = [
+            {"place": 1, "rider": "alice", "points": 20},
+            {"place": 2, "rider": "bob", "points": 17},
+        ]
+        result = format_rest(awards, CONFIG)
+        assert "Bob" in result
+        assert "17" in result
+
+    def test_zero_points_excluded(self):
+        awards = [
+            {"place": 1, "rider": "alice", "points": 6},
+            {"place": 2, "rider": "bob", "points": 0},
+        ]
+        result = format_rest(awards, CONFIG)
+        assert "Bob" not in result
+
+
+class TestGenerateNarrative:
+    def test_no_locations_in_segment(self):
+        points = make_points([
+            {"name": "Sprint 1", "type": "sprint", "segment": 5, "km": 30,
+             "reached": True, "awards": [{"place": 1, "rider": "alice", "points": 20}]},
+        ])
+        result = generate_narrative(points, CONFIG, segment=1)
+        assert "no" in result.lower() or "No" in result
+
+    def test_sprint_narrative(self):
+        points = make_points([
+            {"name": "Sprint - Turenne", "type": "sprint", "segment": 3, "km": 17,
+             "reached": True, "awards": [
+                 {"place": 1, "rider": "alice", "points": 20},
+                 {"place": 2, "rider": "bob", "points": 17},
+             ]},
+        ])
+        result = generate_narrative(points, CONFIG, segment=3)
+        assert "Alice" in result
+        assert "20" in result
+        assert "Turenne" in result
+
+    def test_climb_narrative(self):
+        points = make_points([
+            {"name": "Suc au May", "type": "climb", "segment": 15, "km": 104.8,
+             "category": "HC", "reached": True, "awards": [
+                 {"place": 1, "rider": "bob", "points": 10},
+                 {"place": 2, "rider": "alice", "points": 8},
+             ]},
+        ])
+        result = generate_narrative(points, CONFIG, segment=15)
+        assert "Bob" in result
+        assert "10" in result
+        assert "Suc au May" in result
+        assert "Hors Categorie" in result or "HC" in result
+
+    def test_not_reached(self):
+        points = make_points([
+            {"name": "Sprint - Bugeat", "type": "sprint", "segment": 19, "km": 130,
+             "reached": False, "awards": []},
+        ])
+        result = generate_narrative(points, CONFIG, segment=19)
+        assert "Bugeat" in result
+        assert "await" in result.lower() or "unclaimed" in result.lower()
+
+    def test_seed_consistency(self):
+        points = make_points([
+            {"name": "Test Sprint", "type": "sprint", "segment": 1, "km": 5,
+             "reached": True, "awards": [{"place": 1, "rider": "alice", "points": 20}]},
+        ])
+        r1 = generate_narrative(points, CONFIG, segment=1, seed=42)
+        r2 = generate_narrative(points, CONFIG, segment=1, seed=42)
+        assert r1 == r2
+
+    def test_multiple_locations_in_segment(self):
+        points = make_points([
+            {"name": "Sprint A", "type": "sprint", "segment": 3, "km": 15,
+             "reached": True, "awards": [{"place": 1, "rider": "alice", "points": 20}]},
+            {"name": "Climb B", "type": "climb", "segment": 3, "km": 18,
+             "category": 3, "reached": True, "awards": [{"place": 1, "rider": "bob", "points": 4}]},
+        ])
+        result = generate_narrative(points, CONFIG, segment=3)
+        assert "Sprint A" in result
+        assert "Climb B" in result
+
+    def test_empty_points_data(self):
+        result = generate_narrative({"riders": {}, "locations": []}, CONFIG, segment=1)
+        assert len(result) > 0


### PR DESCRIPTION
## Summary

New Python script `processing/generate_narrative.py` that generates fictional race commentary for point locations in a segment.

### Features

- Varied templates for sprint and climb narratives (4 templates each, randomly selected)
- Handles: sprints, categorized climbs (HC through Cat 4), unreached locations, no-points segments
- Mentions rider names, location names, km marks, points awarded, and climb categories
- Configurable random seed for reproducible output
- CLI with --segment, --points, --rider-config, --output args

### Example output

Sprint: "At the intermediate sprint in Turenne (km 17), Alice powered through first to claim 20 points, with Bob for 17."

Climb: "On the slopes of Suc au May (km 105, Hors Categorie), Bob crested first, taking 10 climbing points, with Alice for 8."

### Tests

14 tests covering rider name lookup, category formatting, rest-of-field formatting, sprint/climb/unreached narratives, seed consistency, multiple locations, and empty data.

Closes #159

## Test plan

- [x] All 14 tests pass
- [x] Ruff clean
- [x] Script runs with real data
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)