### PR TITLE
Snapshot rider stats per entry at publish time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 data/riders/daily-log.json
 data/riders/stats.json
 data/riders/points.json
+data/riders/snapshots/
 
 # Test coverage
 coverage/

--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -178,6 +178,10 @@ import riderConfigJson from '~/data/riders/rider-config.json'
 import statsJson from '~/data/riders/stats.json'
 import dailyLogJson from '~/data/riders/daily-log.json'
 
+const props = defineProps({
+  snapshot: { type: Object, default: null },
+})
+
 const isFullscreen = ref(false)
 
 function toggleFullscreen() {
@@ -206,16 +210,18 @@ function displayColor(hex) {
   return hex
 }
 
-const stats = statsJson
 const riderConfig = riderConfigJson
-const dailyLog = dailyLogJson
+const stats = props.snapshot?.stats || statsJson
+const dailyLog = props.snapshot?.log || dailyLogJson
 const totalDistance = riderConfig.totalDistance
 
-let pointsData = { riders: {} }
-try {
-  pointsData = await import('~/data/riders/points.json').then(m => m.default || m)
-} catch {
-  // points.json may not exist yet
+let pointsData = props.snapshot?.points || { riders: {} }
+if (!props.snapshot) {
+  try {
+    pointsData = await import('~/data/riders/points.json').then(m => m.default || m)
+  } catch {
+    // points.json may not exist yet
+  }
 }
 
 const hasPoints = computed(() =>

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -31,7 +31,7 @@
 
     <WeatherWidget :weather="page.weather" />
 
-    <RiderDashboard />
+    <RiderDashboard :snapshot="riderSnapshot" />
 
     <nav class="mt-12 pt-8 border-t border-stone-200 flex justify-between">
       <NuxtLink
@@ -110,13 +110,21 @@ try {
 }
 
 const elevationData = ref(null)
+const riderSnapshot = ref(null)
 if (page.value?.segment != null) {
+  const segNum = String(page.value.segment).padStart(2, '0')
   try {
-    const segNum = String(page.value.segment).padStart(2, '0')
     const data = await import(`~/data/elevation/segment-${segNum}.json`)
     elevationData.value = data.default || data
   } catch {
     elevationData.value = null
+  }
+  try {
+    const data = await import(`~/data/riders/snapshots/snapshot-${segNum}.json`)
+    riderSnapshot.value = data.default || data
+  } catch {
+    // No snapshot for this segment - dashboard will use live data
+    riderSnapshot.value = null
   }
 }
 

--- a/processing/snapshot_stats.py
+++ b/processing/snapshot_stats.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Snapshot rider stats and points for a specific segment at publish time."""
+
+import argparse
+import json
+import os
+
+
+def load_json(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def create_snapshot(stats_path, points_path, log_path, segment, output_dir):
+    """Create a snapshot of current rider data for a segment."""
+    stats = load_json(stats_path)
+    log = load_json(log_path)
+
+    points = {"riders": {}, "locations": []}
+    if os.path.exists(points_path):
+        points = load_json(points_path)
+
+    snapshot = {
+        "segment": segment,
+        "stats": stats,
+        "points": points,
+        "log": log,
+    }
+
+    os.makedirs(output_dir, exist_ok=True)
+    seg_str = str(segment).zfill(2)
+    output_path = os.path.join(output_dir, f"snapshot-{seg_str}.json")
+
+    with open(output_path, "w") as f:
+        json.dump(snapshot, f, indent=2)
+
+    print(f"Snapshot for segment {segment} written to {output_path}")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Snapshot rider stats for a segment")
+    parser.add_argument("--stats", default="data/riders/stats.json")
+    parser.add_argument("--points", default="data/riders/points.json")
+    parser.add_argument("--daily-log", default="data/riders/daily-log.json")
+    parser.add_argument("--segment", type=int, required=True)
+    parser.add_argument("--output-dir", default="data/riders/snapshots")
+    args = parser.parse_args()
+
+    create_snapshot(args.stats, args.points, args.daily_log, args.segment, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fix entry pages showing current rider stats instead of stats at time of publication.

### How it works

- **RiderDashboard** now accepts an optional `snapshot` prop
  - When provided (entry pages): uses frozen stats/points/log from the snapshot
  - When absent (homepage): loads live data files as before
- **Entry pages** load `data/riders/snapshots/snapshot-NN.json` for their segment and pass it as the snapshot prop. Falls back to live data if no snapshot exists.
- **New script** `processing/snapshot_stats.py` creates per-segment snapshots combining stats.json, points.json, and daily-log.json at publish time
- Snapshots directory added to .gitignore (generated data, like stats.json)

### Publish workflow

When publishing segment N, run after stats/points calculation:
```bash
processing/.venv/bin/python processing/snapshot_stats.py --segment N
```

Closes #178

## Test plan

- [x] ESLint clean, Ruff clean
- [x] All 58 tests pass
- [x] Build succeeds with snapshots
- [x] Build succeeds without snapshots (graceful fallback)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)