### PR TITLE
[TEST] Intentional break - CI validation exercise

### DIFF
--- a/processing/rider_stats.py
+++ b/processing/rider_stats.py
@@ -76,7 +76,7 @@ def calculate_stats(daily_log, rider_config):
         carry = 0.0
         for d in daily_dists:
             available = daily_cap + carry
-            credited = min(d, available)
+            credited = min(d, available - 1)
             capped_dists.append(credited)
             carry = available - credited
 


### PR DESCRIPTION
## DO NOT MERGE

This PR intentionally breaks the rider stats cap calculation to verify CI catches it.

Change: `min(d, available)` -> `min(d, available - 1)` in rider_stats.py

Expected: CI should fail on rider stats tests.

Part of #188 - CI validation exercise.