### PR TITLE
Drop dev branch, simplify release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
   push:
-    branches: [main, dev]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Remove the dev branch from the workflow. Feature branches now merge directly to main via PR.

### Changes

- CI workflow: remove dev from pull_request and push triggers (main only)
- This is the first PR merged directly to main under the new workflow

### After merging

- Delete the dev branch (remote and local)
- Update branch protection rules (remove dev)
- Update wiki with new workflow

Closes #195

## Test plan

- [x] All tests pass
- [x] CI passes on this PR (targeting main directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)