### PR TITLE
Add StageDetails and PublishSchedule component tests

### DIFF
--- a/tests/components/PublishSchedule.test.ts
+++ b/tests/components/PublishSchedule.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import PublishSchedule from '~/components/PublishSchedule.vue'
+
+vi.mock('~/data/segments.json', () => ({
+  default: [
+    { segment: 1, towns: ['Malemort'], climbs: [] },
+    { segment: 2, towns: [], climbs: [] },
+  ],
+}))
+
+describe('PublishSchedule', () => {
+  it('renders schedule title', () => {
+    const wrapper = mount(PublishSchedule)
+    expect(wrapper.text()).toContain('Publish Schedule')
+  })
+
+  it('shows segment numbers', () => {
+    const wrapper = mount(PublishSchedule)
+    expect(wrapper.text()).toContain('1')
+    expect(wrapper.text()).toContain('2')
+  })
+
+  it('generates publish dates', () => {
+    const wrapper = mount(PublishSchedule)
+    // First entry should be April 5
+    expect(wrapper.text()).toContain('Apr')
+  })
+})

--- a/tests/components/StageDetails.test.ts
+++ b/tests/components/StageDetails.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import StageDetails from '~/components/StageDetails.vue'
+
+vi.mock('~/data/segments.json', () => ({
+  default: [
+    {
+      segment: 1, km_start: 0, km_end: 7.1,
+      towns: ['Malemort', 'Brive-la-Gaillarde'], climbs: [],
+      min_elevation: 214, start_lat: 45.13, start_lng: 1.54,
+    },
+    {
+      segment: 2, km_start: 7.1, km_end: 14.2,
+      towns: [], climbs: ['Puy Boubou'],
+      min_elevation: 172, start_lat: 45.08, start_lng: 1.56,
+    },
+  ],
+}))
+
+describe('StageDetails', () => {
+  it('renders towns', () => {
+    const wrapper = mount(StageDetails)
+    expect(wrapper.text()).toContain('Malemort')
+    expect(wrapper.text()).toContain('Brive-la-Gaillarde')
+  })
+
+  it('renders climbs', () => {
+    const wrapper = mount(StageDetails)
+    expect(wrapper.text()).toContain('Puy Boubou')
+  })
+
+  it('shows stage summary', () => {
+    const wrapper = mount(StageDetails)
+    expect(wrapper.text()).toContain('185 km')
+    expect(wrapper.text()).toContain('9 climbs')
+  })
+
+  it('shows Towns and Climbs section headers', () => {
+    const wrapper = mount(StageDetails)
+    expect(wrapper.text()).toContain('Towns')
+    expect(wrapper.text()).toContain('Climbs')
+  })
+})


### PR DESCRIPTION
## Summary

- 4 tests for StageDetails: towns rendering, climbs rendering, section headers, summary stats
- 3 tests for PublishSchedule: title, segment numbers, date generation
- Both use mocked segments.json data
- JS component coverage: 20% -> 32%
- Overall JS coverage: ~26%
- RiderDashboard tests skipped - async setup with await import() requires Suspense/Nuxt runtime, not practical to unit test

Closes #198

## Test plan

- [x] All 65 tests pass
- [x] ESLint clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)