### PR TITLE
Fix time unit label for segment 0 overview

### DIFF
--- a/components/PowerStats.vue
+++ b/components/PowerStats.vue
@@ -31,22 +31,22 @@
       <div class="flex gap-4 text-sm">
         <div class="flex-1 text-center">
           <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_30kmh }}</div>
-          <div class="text-xs text-stone-400">{{ timeUnit(summary.estimated_time_30kmh) }}</div>
+          <div class="text-xs text-stone-400">{{ timeLabel }}</div>
           <div class="text-xs text-stone-400">@30 km/h</div>
         </div>
         <div class="flex-1 text-center">
           <div class="font-mono font-bold text-correze-red">{{ summary.estimated_time_35kmh }}</div>
-          <div class="text-xs text-stone-400">{{ timeUnit(summary.estimated_time_35kmh) }}</div>
+          <div class="text-xs text-stone-400">{{ timeLabel }}</div>
           <div class="text-xs text-stone-400">@35 km/h</div>
         </div>
         <div class="flex-1 text-center">
           <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_40kmh }}</div>
-          <div class="text-xs text-stone-400">{{ timeUnit(summary.estimated_time_40kmh) }}</div>
+          <div class="text-xs text-stone-400">{{ timeLabel }}</div>
           <div class="text-xs text-stone-400">@40 km/h</div>
         </div>
         <div class="flex-1 text-center">
           <div class="font-mono font-bold text-stone-600">{{ summary.estimated_time_50kmh || '-' }}</div>
-          <div class="text-xs text-stone-400">{{ timeUnit(summary.estimated_time_50kmh) }}</div>
+          <div class="text-xs text-stone-400">{{ timeLabel }}</div>
           <div class="text-xs text-stone-400">@50 km/h</div>
         </div>
       </div>
@@ -61,11 +61,6 @@ const props = defineProps({
   elevationData: { type: Object, default: null }
 })
 
-function timeUnit(timeStr) {
-  if (!timeStr) return ''
-  const mins = parseInt(timeStr.split(':')[0])
-  return mins >= 60 ? 'hr:min' : 'min:sec'
-}
-
 const summary = computed(() => props.elevationData?.summary || null)
+const timeLabel = computed(() => summary.value?.time_unit || 'min:sec')
 </script>

--- a/data/elevation/segment-00.json
+++ b/data/elevation/segment-00.json
@@ -1846,6 +1846,7 @@
     "estimated_time_30kmh": "6:10",
     "estimated_time_35kmh": "5:17",
     "estimated_time_40kmh": "4:38",
-    "estimated_time_50kmh": "3:42"
+    "estimated_time_50kmh": "3:42",
+    "time_unit": "hr:min"
   }
 }

--- a/data/elevation/segment-01.json
+++ b/data/elevation/segment-01.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:12",
     "estimated_time_35kmh": "12:11",
     "estimated_time_40kmh": "10:39",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-02.json
+++ b/data/elevation/segment-02.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-03.json
+++ b/data/elevation/segment-03.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-04.json
+++ b/data/elevation/segment-04.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-05.json
+++ b/data/elevation/segment-05.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-06.json
+++ b/data/elevation/segment-06.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-07.json
+++ b/data/elevation/segment-07.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-08.json
+++ b/data/elevation/segment-08.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-09.json
+++ b/data/elevation/segment-09.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:10",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-10.json
+++ b/data/elevation/segment-10.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-11.json
+++ b/data/elevation/segment-11.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:08",
     "estimated_time_35kmh": "12:07",
     "estimated_time_40kmh": "10:36",
-    "estimated_time_50kmh": "8:28"
+    "estimated_time_50kmh": "8:28",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-12.json
+++ b/data/elevation/segment-12.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:08",
     "estimated_time_35kmh": "12:07",
     "estimated_time_40kmh": "10:36",
-    "estimated_time_50kmh": "8:28"
+    "estimated_time_50kmh": "8:28",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-13.json
+++ b/data/elevation/segment-13.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-14.json
+++ b/data/elevation/segment-14.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:09",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:29"
+    "estimated_time_50kmh": "8:29",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-15.json
+++ b/data/elevation/segment-15.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:10",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-16.json
+++ b/data/elevation/segment-16.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-17.json
+++ b/data/elevation/segment-17.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:12",
     "estimated_time_35kmh": "12:10",
     "estimated_time_40kmh": "10:39",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-18.json
+++ b/data/elevation/segment-18.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:13",
     "estimated_time_35kmh": "12:11",
     "estimated_time_40kmh": "10:40",
-    "estimated_time_50kmh": "8:32"
+    "estimated_time_50kmh": "8:32",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-19.json
+++ b/data/elevation/segment-19.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:13",
     "estimated_time_35kmh": "12:11",
     "estimated_time_40kmh": "10:40",
-    "estimated_time_50kmh": "8:32"
+    "estimated_time_50kmh": "8:32",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-20.json
+++ b/data/elevation/segment-20.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:12",
     "estimated_time_35kmh": "12:11",
     "estimated_time_40kmh": "10:39",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-21.json
+++ b/data/elevation/segment-21.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-22.json
+++ b/data/elevation/segment-22.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:11",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-23.json
+++ b/data/elevation/segment-23.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:13",
     "estimated_time_35kmh": "12:11",
     "estimated_time_40kmh": "10:40",
-    "estimated_time_50kmh": "8:32"
+    "estimated_time_50kmh": "8:32",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-24.json
+++ b/data/elevation/segment-24.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:12",
     "estimated_time_35kmh": "12:10",
     "estimated_time_40kmh": "10:39",
-    "estimated_time_50kmh": "8:31"
+    "estimated_time_50kmh": "8:31",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-25.json
+++ b/data/elevation/segment-25.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:09",
     "estimated_time_35kmh": "12:08",
     "estimated_time_40kmh": "10:37",
-    "estimated_time_50kmh": "8:29"
+    "estimated_time_50kmh": "8:29",
+    "time_unit": "min:sec"
   }
 }

--- a/data/elevation/segment-26.json
+++ b/data/elevation/segment-26.json
@@ -236,6 +236,7 @@
     "estimated_time_30kmh": "14:10",
     "estimated_time_35kmh": "12:09",
     "estimated_time_40kmh": "10:38",
-    "estimated_time_50kmh": "8:30"
+    "estimated_time_50kmh": "8:30",
+    "time_unit": "min:sec"
   }
 }

--- a/processing/elevation_profile.py
+++ b/processing/elevation_profile.py
@@ -134,6 +134,7 @@ def process_segment(gpx_path, segment_num):
         "estimated_time_35kmh": format_time(total_km / 35 * 60),
         "estimated_time_40kmh": format_time(total_km / 40 * 60),
         "estimated_time_50kmh": format_time(total_km / 50 * 60),
+        "time_unit": "hr:min" if total_km / 50 * 60 >= 60 else "min:sec",
     }
 
     return {


### PR DESCRIPTION
## Summary

Segment 0 (full route overview) showed "min:sec" when it should show "hr:min" (times are 6:10, 5:17 etc - hours not minutes).

Root cause: the timeUnit function guessed the unit by checking if the number before the colon was >= 60, but after the format_time fix, hour values like "6:10" have small numbers before the colon.

Fix: add `time_unit` field to the elevation summary data, set at generation time based on actual minutes. PowerStats reads this field instead of guessing.

## Test plan

- [x] All 65 tests pass
- [x] Lint clean
- [x] CI passes
- [x] Segment 0 shows "hr:min", segments 1-26 show "min:sec"

🤖 Generated with [Claude Code](https://claude.com/claude-code)