### PR TITLE
Add historical Tour de France context to entries

### DIFF
--- a/components/HistoricalContext.vue
+++ b/components/HistoricalContext.vue
@@ -1,0 +1,30 @@
+<template>
+  <div v-if="events.length" class="bg-white rounded-lg shadow-sm p-6 mt-8">
+    <h3 class="text-lg font-semibold text-stone-700 mb-4">Tour de France History</h3>
+    <div class="space-y-4">
+      <div v-for="(event, idx) in events" :key="idx" class="border-l-4 border-correze-red pl-4">
+        <div v-if="event.year" class="flex items-baseline gap-2 mb-1">
+          <span class="font-mono font-bold text-correze-red">{{ event.year }}</span>
+          <span v-if="event.stage" class="text-sm text-stone-500">{{ event.stage }}</span>
+          <span v-if="event.route" class="text-sm text-stone-400">{{ event.route }}</span>
+        </div>
+        <p class="text-sm text-stone-600 leading-relaxed">{{ event.description }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+import historicalData from '~/data/historical-tdf.json'
+
+const props = defineProps({
+  segment: { type: Number, required: true },
+})
+
+const events = computed(() => {
+  const entries = historicalData.filter(h => h.segments.includes(props.segment))
+  return entries.flatMap(h => h.events)
+})
+</script>

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -1,0 +1,64 @@
+[
+  {
+    "segments": [1, 2],
+    "events": [
+      {
+        "year": 1951,
+        "stage": "Stage 11",
+        "route": "Brive to Agen",
+        "description": "Hugo Koblet's legendary 135km solo breakaway, holding off Coppi, Bobet, Bartali, Magni, Geminiani, and Robic. One of the greatest solo rides in Tour history."
+      },
+      {
+        "year": 2012,
+        "stage": "Stage 18",
+        "route": "Blagnac to Brive",
+        "description": "Mark Cavendish sprint victory in the rainbow jersey of world champion. Bradley Wiggins in yellow on his way to becoming the first British Tour winner."
+      },
+      {
+        "year": 1996,
+        "stage": "Stage 15",
+        "route": "Departure from Brive",
+        "description": "The Tour departed from Brive-la-Gaillarde heading to Villeneuve-sur-Lot."
+      }
+    ]
+  },
+  {
+    "segments": [9, 10],
+    "events": [
+      {
+        "year": null,
+        "stage": null,
+        "route": null,
+        "description": "Tulle, the departmental capital, has hosted Tour du Limousin stages and is the base for local cycling clubs. The L'Agglomeree cyclosportive, departing from Tulle in April 2026, covers 40km of the Stage 9 route including Suc au May."
+      }
+    ]
+  },
+  {
+    "segments": [14, 15, 16],
+    "events": [
+      {
+        "year": 2024,
+        "stage": "Stage 11",
+        "route": "Evaux-les-Bains to Le Lioran",
+        "description": "211km through the Massif Central with 4,350m climbing. Vingegaard vs Pogacar on terrain very similar to Stage 9's second half. The battle on these hills foreshadowed what the 2026 peloton will face."
+      }
+    ]
+  },
+  {
+    "segments": [25, 26],
+    "events": [
+      {
+        "year": null,
+        "stage": null,
+        "route": null,
+        "description": "Ussel served as a stage town for the now-defunct Paris-Correze professional race (UCI 2.1) which ran through the 2000s. The 2026 Tour marks Ussel's first appearance as a Tour de France stage town."
+      },
+      {
+        "year": 2026,
+        "stage": "Stage 10",
+        "route": "Aurillac to Le Lioran",
+        "description": "The day after Stage 9, the peloton rides the adjacent Cantal roads from Aurillac to Le Lioran - the same finale where Vingegaard beat Pogacar in a photo finish in 2024."
+      }
+    ]
+  }
+]

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -29,6 +29,8 @@
 
     <ImageGallery :images="page.images" />
 
+    <HistoricalContext :segment="page.segment" />
+
     <WeatherWidget :weather="page.weather" />
 
     <RiderDashboard :snapshot="riderSnapshot" />


### PR DESCRIPTION
## Summary

Add Tour de France historical context to entry pages.

### Data

`data/historical-tdf.json` maps events to segments:
- **Segments 1-2** (Brive): Koblet 1951 solo breakaway, Cavendish 2012 sprint, 1996 departure
- **Segments 9-10** (Tulle): Tour du Limousin, L'Agglomeree cyclosportive
- **Segments 14-16** (Massif Central): Vingegaard vs Pogacar 2024 Stage 11
- **Segments 25-26** (Ussel): Paris-Correze history, 2026 Stage 10 preview

### Component

`HistoricalContext.vue` - card with correze-red left border, shows year, stage, route, and description. Only renders when history exists for the current segment.

Closes #202

## Test plan

- [x] ESLint clean
- [x] All tests pass
- [x] CI passes
- [x] Visual review: segment 1 entry shows Brive history

🤖 Generated with [Claude Code](https://claude.com/claude-code)