### PR TITLE
Add attractions layer to map with 34 POIs

### DIFF
--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -29,6 +29,7 @@
 <script setup>
 import { ref, watch, nextTick, onUnmounted } from 'vue'
 import 'leaflet/dist/leaflet.css'
+import attractionsData from '~/data/attractions.json'
 
 const props = defineProps({
   segment: { type: Number, required: true },
@@ -251,10 +252,50 @@ async function initMap(el) {
     }
   }
 
+  // Attractions layer
+  const attractionsGroup = L.layerGroup()
+  const categoryEmoji = {
+    food: '🍷', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
+    museum: '🏛️', nature: '🌿', bridge: '🌉', archaeology: '🏺',
+  }
+
+  // Filter attractions by proximity to current segment
+  for (const poi of attractionsData) {
+    // For overview, show all. For segments, show nearby ones.
+    if (!isOverview) {
+      const seg = props.segments.find(s => s.segment === props.segment)
+      if (seg) {
+        const midLat = (seg.start_lat + seg.end_lat) / 2
+        const midLng = (seg.start_lng + seg.end_lng) / 2
+        const dist = Math.sqrt((poi.lat - midLat) ** 2 + (poi.lng - midLng) ** 2)
+        if (dist > 0.15) continue // ~15km radius
+      }
+    }
+
+    const emoji = categoryEmoji[poi.category] || '📍'
+    const poiIcon = L.divIcon({
+      html: `<div style="font-size:18px;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.3))">${emoji}</div>`,
+      className: '',
+      iconSize: [22, 22],
+      iconAnchor: [11, 11]
+    })
+
+    let popupHtml = `<b>${poi.name}</b><br><span style="font-size:12px;color:#666">${poi.description}</span>`
+    if (poi.link) {
+      popupHtml += `<br><a href="${poi.link}" target="_blank" rel="noopener" style="font-size:12px">More info</a>`
+    }
+
+    L.marker([poi.lat, poi.lng], { icon: poiIcon })
+      .bindTooltip(poi.name, { direction: 'top', offset: [0, -8] })
+      .bindPopup(popupHtml)
+      .addTo(attractionsGroup)
+  }
+
   const overlays = {
     'Cycle Routes': cycleRoutes,
     'Hillshade': hillshade,
     'Towns & Climbs': poiGroup,
+    'Attractions': attractionsGroup,
     'Rider Progress': riderGroup
   }
   L.control.layers(baseLayers, overlays, { position: 'topleft' }).addTo(map)

--- a/data/attractions.json
+++ b/data/attractions.json
@@ -1,0 +1,274 @@
+[
+  {
+    "name": "Grottes de Lacan",
+    "category": "archaeology",
+    "lat": 45.138,
+    "lng": 1.549,
+    "description": "Prehistoric shelters along the Correze river, evidence of habitation at the start of the route.",
+    "link": null
+  },
+  {
+    "name": "Distillerie Denoix",
+    "category": "food",
+    "lat": 45.1589,
+    "lng": 1.5335,
+    "description": "Historic liqueur distillery (est. 1839) producing walnut liqueur and violet mustard. Free tastings.",
+    "link": "https://www.denoix.com/"
+  },
+  {
+    "name": "Marche de Brive",
+    "category": "market",
+    "lat": 45.1590,
+    "lng": 1.5340,
+    "description": "Major covered market (Tue/Thu/Sat). Famous Foires Grasses truffle and foie gras markets Nov-Feb.",
+    "link": null
+  },
+  {
+    "name": "Musee Edmond Michelet",
+    "category": "museum",
+    "lat": 45.1570,
+    "lng": 1.5320,
+    "description": "WWII Resistance museum in the house where Michelet distributed anti-Nazi tracts on June 17, 1940.",
+    "link": "https://en.wikipedia.org/wiki/Edmond_Michelet"
+  },
+  {
+    "name": "Domaine de la Gardelle",
+    "category": "food",
+    "lat": 45.1200,
+    "lng": 1.5100,
+    "description": "Organic vineyard producing Correze PDO wines including traditional vin paille (straw wine).",
+    "link": null
+  },
+  {
+    "name": "Grottes de Lamouroux",
+    "category": "archaeology",
+    "lat": 45.1598,
+    "lng": 1.5347,
+    "description": "Troglodytic cliff dwellings carved into limestone, inhabited from prehistoric through medieval times.",
+    "link": null
+  },
+  {
+    "name": "Aubazine Abbey",
+    "category": "abbey",
+    "lat": 45.1750,
+    "lng": 1.6690,
+    "description": "12th-century Cistercian abbey where Coco Chanel spent six years as an orphan. Geometric patterns may have inspired the Chanel logo.",
+    "link": "https://en.wikipedia.org/wiki/Aubazine_Abbey"
+  },
+  {
+    "name": "Chateau de Turenne",
+    "category": "castle",
+    "lat": 45.0537,
+    "lng": 1.5830,
+    "description": "Ruined hilltop keep of the Viscounty of Turenne. Controlled much of Correze until sold to Louis XV in 1738.",
+    "link": "https://en.wikipedia.org/wiki/Turenne"
+  },
+  {
+    "name": "Eglise Saint-Pierre",
+    "category": "church",
+    "lat": 45.0607,
+    "lng": 1.6555,
+    "description": "11th-century fortified church in Collonges-la-Rouge with carved Romanesque tympanum depicting the Ascension.",
+    "link": null
+  },
+  {
+    "name": "Castel de Vassinhac",
+    "category": "castle",
+    "lat": 45.0610,
+    "lng": 1.6560,
+    "description": "Late 16th-century fortified manor in Collonges-la-Rouge with distinctive turrets and loopholes.",
+    "link": null
+  },
+  {
+    "name": "Maison de la Sirene",
+    "category": "museum",
+    "lat": 45.0608,
+    "lng": 1.6550,
+    "description": "16th-century house with sculpted mermaid in Collonges. Once belonged to Henry de Jouvenel, husband of Colette.",
+    "link": null
+  },
+  {
+    "name": "Beynat Chestnut Festival",
+    "category": "food",
+    "lat": 45.1250,
+    "lng": 1.7280,
+    "description": "Annual October Fete de la Chataigne. Chestnut producers, tastings, and summer Tuesday evening markets.",
+    "link": null
+  },
+  {
+    "name": "Fromagerie Duroux",
+    "category": "food",
+    "lat": 45.1900,
+    "lng": 1.7700,
+    "description": "Artisan fromagerie near Tulle aging cheese in a reconverted railway tunnel. Produces Pave Correzien.",
+    "link": null
+  },
+  {
+    "name": "Cascades de Gimel",
+    "category": "nature",
+    "lat": 45.2970,
+    "lng": 1.8530,
+    "description": "Three waterfalls on the Montane river with a total drop of 143m. Natura 2000 site north of Tulle.",
+    "link": "https://www.cascadesdegimel.com/"
+  },
+  {
+    "name": "Cathedrale Notre-Dame de Tulle",
+    "category": "church",
+    "lat": 45.2680,
+    "lng": 1.7680,
+    "description": "12th-century cathedral with a 75m bell tower, the tallest in the Limousin. Notable carved cloister.",
+    "link": null
+  },
+  {
+    "name": "Cite de l'Accordeon",
+    "category": "museum",
+    "lat": 45.2685,
+    "lng": 1.7695,
+    "description": "Opened 2024 in the former Banque de France. Exhibits on accordion-making, Tulle lace, and arms manufacturing.",
+    "link": "https://www.citedelaccordeon.com/"
+  },
+  {
+    "name": "Les Delices de Mel",
+    "category": "food",
+    "lat": 45.2680,
+    "lng": 1.7700,
+    "description": "Fromagerie in central Tulle. Regional cheeses including Feuille du Limousin, caillade, and cabecou.",
+    "link": null
+  },
+  {
+    "name": "Marche de Tulle",
+    "category": "market",
+    "lat": 45.2680,
+    "lng": 1.7690,
+    "description": "Wednesday and Saturday morning market at Place Gambetta and Quai Baluze along the Correze river.",
+    "link": null
+  },
+  {
+    "name": "Tintignac Gallo-Roman Sanctuary",
+    "category": "archaeology",
+    "lat": 45.3056,
+    "lng": 1.7667,
+    "description": "Celtic bronze carnyx war trumpets discovered 2004. One of the most important Celtic finds in France. Fanum temple and theatre.",
+    "link": "https://en.wikipedia.org/wiki/Tintignac"
+  },
+  {
+    "name": "Chateau de Bach",
+    "category": "castle",
+    "lat": 45.3100,
+    "lng": 1.7600,
+    "description": "Castle near Naves with an 18th-century portal and vestiges of a 14th-century Gothic cloister.",
+    "link": null
+  },
+  {
+    "name": "Chateau de Ventadour",
+    "category": "castle",
+    "lat": 45.3900,
+    "lng": 2.1050,
+    "description": "11th-century ruins on a rocky spur. Cradle of troubadour Bernard de Ventadour and Occitan courtly love tradition.",
+    "link": "https://chateau-ventadour.fr/"
+  },
+  {
+    "name": "Gorges de la Vezere",
+    "category": "nature",
+    "lat": 45.5350,
+    "lng": 1.7930,
+    "description": "Wild granite gorges of the Vezere river near Treignac. The Saut du Loup rapids are a renowned kayaking spot.",
+    "link": null
+  },
+  {
+    "name": "Pont Medieval de Treignac",
+    "category": "bridge",
+    "lat": 45.5365,
+    "lng": 1.7945,
+    "description": "13th/14th-century stone bridge with three arches spanning the Vezere. Iconic view of the medieval town.",
+    "link": null
+  },
+  {
+    "name": "Eglise Notre-Dame-des-Bans",
+    "category": "church",
+    "lat": 45.5370,
+    "lng": 1.7950,
+    "description": "13th-century church in Treignac built by the Comborn family, remodeled in the 15th century with ribbed vaulting.",
+    "link": null
+  },
+  {
+    "name": "Lac des Bariousses",
+    "category": "nature",
+    "lat": 45.5500,
+    "lng": 1.8100,
+    "description": "99-hectare Blue Flag lake on the Vezere. Swimming, kayak and paddleboard rental in the Monedieres hills.",
+    "link": null
+  },
+  {
+    "name": "Les Cars Gallo-Roman Site",
+    "category": "archaeology",
+    "lat": 45.6303,
+    "lng": 1.8850,
+    "description": "Ruins of two 1st-3rd century Gallo-Roman funerary temples with carved granite on the Plateau de Millevaches.",
+    "link": null
+  },
+  {
+    "name": "Tourbiere de Longeyroux",
+    "category": "nature",
+    "lat": 45.5600,
+    "lng": 2.0500,
+    "description": "Largest peat bog in the Limousin (250 hectares, 8,000 years old). Boardwalk trail through heather moors.",
+    "link": null
+  },
+  {
+    "name": "Lac de Sechemailles",
+    "category": "nature",
+    "lat": 45.5200,
+    "lng": 2.1200,
+    "description": "40-hectare Blue Flag lake near Meymac. Swimming, fishing, and hiking trails to Mont Bessou summit.",
+    "link": null
+  },
+  {
+    "name": "Abbaye Saint-Andre",
+    "category": "abbey",
+    "lat": 45.5340,
+    "lng": 2.1470,
+    "description": "Benedictine abbey founded 1085 in Meymac. Now houses the Centre d'Art Contemporain.",
+    "link": null
+  },
+  {
+    "name": "Centre d'Art Contemporain",
+    "category": "museum",
+    "lat": 45.5340,
+    "lng": 2.1470,
+    "description": "Contemporary art center in the Abbaye Saint-Andre. 900m2 across five levels, 3-5 exhibitions per year.",
+    "link": "https://www.cacmeymac.fr/"
+  },
+  {
+    "name": "Chapelle des Penitents",
+    "category": "church",
+    "lat": 45.5480,
+    "lng": 2.3100,
+    "description": "15th-century funeral chapel in Ussel with a classified Baroque altarpiece. Houses sacred art collection.",
+    "link": null
+  },
+  {
+    "name": "Musee du Pays d'Ussel",
+    "category": "museum",
+    "lat": 45.5480,
+    "lng": 2.3105,
+    "description": "Classified Musee de France with collections of art, popular traditions, tapestries, and printing materials.",
+    "link": null
+  },
+  {
+    "name": "Marche d'Ussel",
+    "category": "market",
+    "lat": 45.5480,
+    "lng": 2.3110,
+    "description": "Saturday morning market in the town center and covered market hall behind the church.",
+    "link": null
+  },
+  {
+    "name": "Aigle Romaine",
+    "category": "archaeology",
+    "lat": 45.5485,
+    "lng": 2.3110,
+    "description": "2nd-3rd century granite funerary eagle sculpture at Place Voltaire. Marks the Stage 9 finish line.",
+    "link": null
+  }
+]


### PR DESCRIPTION
## Summary

Toggleable map layer showing 34 points of interest along the route.

### Categories (with emoji markers)

- 🍷 Food & drink (5): Distillerie Denoix, vineyards, cheese producers
- 🛒 Markets (3): Brive, Tulle, Ussel
- 🏰 Castles (4): Turenne, Vassinhac, Bach, Ventadour
- ⛪ Churches & abbeys (6): Aubazine, Collonges, Tulle cathedral, Meymac, Ussel
- 🏛️ Museums (5): Michelet, Maison de la Sirene, Accordeon, contemporary art, Ussel
- 🌿 Natural sites (5): Gimel waterfalls, Vezere gorges, lakes, peat bog
- 🌉 Bridge (1): Medieval bridge at Treignac
- 🏺 Archaeology (4): Lacan caves, Lamouroux, Tintignac Celtic site, Les Cars, Roman eagle

### Behaviour

- Overview map (segment 0): all 34 POIs shown
- Segment pages: filtered to ~15km radius of segment midpoint
- Layer off by default, toggled via map layer control
- Click popup shows name, description, and optional Wikipedia/website link

Closes #50

## Test plan

- [x] ESLint clean
- [x] All 65 tests pass
- [ ] CI passes
- [ ] Visual review: attractions visible on overview, filtered on segment pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)