### PR TITLE
Cheese emoji for fromageries, segment info in attraction popups

### DIFF
--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -255,7 +255,7 @@ async function initMap(el) {
   // Attractions layer
   const attractionsGroup = L.layerGroup()
   const categoryEmoji = {
-    food: '🍷', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
+    food: '🍷', cheese: '🧀', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
     museum: '🏛️', nature: '🌿', bridge: '🌉', archaeology: '🏺',
   }
 
@@ -280,7 +280,20 @@ async function initMap(el) {
       iconAnchor: [11, 11]
     })
 
+    // Find nearest segment for entry link
+    let nearestSeg = null
+    let nearestDist = Infinity
+    for (const seg of props.segments) {
+      const midLat = (seg.start_lat + seg.end_lat) / 2
+      const midLng = (seg.start_lng + seg.end_lng) / 2
+      const d = Math.sqrt((poi.lat - midLat) ** 2 + (poi.lng - midLng) ** 2)
+      if (d < nearestDist) { nearestDist = d; nearestSeg = seg }
+    }
+
     let popupHtml = `<b>${poi.name}</b><br><span style="font-size:12px;color:#666">${poi.description}</span>`
+    if (nearestSeg) {
+      popupHtml += `<br><span style="font-size:11px;color:#8B2500">Segment ${nearestSeg.segment} (km ${nearestSeg.km_start}-${nearestSeg.km_end})</span>`
+    }
     if (poi.link) {
       popupHtml += `<br><a href="${poi.link}" target="_blank" rel="noopener" style="font-size:12px">More info</a>`
     }

--- a/data/attractions.json
+++ b/data/attractions.json
@@ -97,7 +97,7 @@
   },
   {
     "name": "Fromagerie Duroux",
-    "category": "food",
+    "category": "cheese",
     "lat": 45.1900,
     "lng": 1.7700,
     "description": "Artisan fromagerie near Tulle aging cheese in a reconverted railway tunnel. Produces Pave Correzien.",
@@ -129,7 +129,7 @@
   },
   {
     "name": "Les Delices de Mel",
-    "category": "food",
+    "category": "cheese",
     "lat": 45.2680,
     "lng": 1.7700,
     "description": "Fromagerie in central Tulle. Regional cheeses including Feuille du Limousin, caillade, and cabecou.",


### PR DESCRIPTION
## Summary

Two quick fixes for map attractions:

- **#208** - Fromageries (Duroux, Les Delices de Mel) now use 🧀 instead of generic 🍷
- **#207** - Attraction popups show nearest segment number and km range in correze-red, plus external link when available

Note: decided against linking directly to entry pages from popups since we don't have entry slugs in the map component. Showing "Segment N (km X-Y)" gives readers enough context to use the Parcours dropdown to navigate.

Closes #207
Closes #208

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)