### PR TITLE
Register annotation plugin for rider elevation markers

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -44,7 +44,8 @@ import {
   Filler,
   Tooltip
 } from 'chart.js'
-ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Filler, Tooltip)
+import annotationPlugin from 'chartjs-plugin-annotation'
+ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Filler, Tooltip, annotationPlugin)
 
 const zoomReady = ref(false)
 


### PR DESCRIPTION
## Summary

Rider position markers on the elevation profile were not rendering because `chartjs-plugin-annotation` was never imported or registered with Chart.js. The plugin was referenced in the chart options but silently did nothing.

Fix: import and register `annotationPlugin` alongside the other Chart.js plugins.

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes
- [x] Rider dashed lines visible on segment 1 elevation profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)