### PR TITLE
Remove Brive-la-Gaillarde from route towns

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -174,7 +174,7 @@ const chartData = computed(() => {
 
 // Known town km positions along the route
 const townKmPositions = {
-  'Malemort': 0, 'Brive-la-Gaillarde': 4.5, 'Turenne': 17,
+  'Malemort': 0, 'Turenne': 17,
   'Collonges-la-Rouge': 23.5, 'Beynat': 37.5, 'Tulle': 65.5,
   'Naves': 73.5, 'Chaumeil': 90, 'Treignac': 116.5,
   'Bugeat': 130, 'Meymac': 157.5, 'Ussel': 182.5,

--- a/data/segments.json
+++ b/data/segments.json
@@ -13,8 +13,7 @@
     "max_elevation": 326,
     "notable_points": [],
     "towns": [
-      "Malemort",
-      "Brive-la-Gaillarde"
+      "Malemort"
     ],
     "climbs": []
   },

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -4,11 +4,6 @@
     "lat": 45.13834,
     "lng": 1.54947
   },
-  "Brive-la-Gaillarde": {
-    "type": "town",
-    "lat": 45.1584982,
-    "lng": 1.5332389
-  },
   "Turenne": {
     "type": "town",
     "lat": 45.053482,

--- a/processing/split_gpx.py
+++ b/processing/split_gpx.py
@@ -12,7 +12,6 @@ import gpxpy.gpx
 # Known waypoints with approximate km positions along the route
 KNOWN_TOWNS = {
     "Malemort": 0,
-    "Brive-la-Gaillarde": 4.5,
     "Turenne": 17,
     "Collonges-la-Rouge": 23.5,
     "Beynat": 37.5,


### PR DESCRIPTION
## Summary

Brive-la-Gaillarde is near the route but not on the race course. The race starts at Malemort and heads southeast, not through central Brive.

Removed from:
- `processing/split_gpx.py` KNOWN_TOWNS
- `data/segments.json` (regenerated - segment 1 now only has Malemort)
- `data/town-coords.json`
- `components/ElevationChart.vue` townKmPositions

Brive remains in `towns-detail.json` and `attractions.json` for reference content (museum, market, distillery).

Closes #218

## Test plan

- [x] ESLint clean, Ruff clean, all tests pass
- [x] CI passes
- [x] Segment 1 shows only Malemort, not Brive

🤖 Generated with [Claude Code](https://claude.com/claude-code)