### PR TITLE
Add prose image component for inline images in entries

### DIFF
--- a/components/content/ProseImg.vue
+++ b/components/content/ProseImg.vue
@@ -1,0 +1,24 @@
+<template>
+  <figure class="my-6">
+    <img
+      :src="src"
+      :alt="alt"
+      :width="width"
+      :height="height"
+      class="w-full rounded-lg shadow-md"
+      loading="lazy"
+    >
+    <figcaption v-if="alt" class="mt-2 text-sm text-stone-500 text-center italic">
+      {{ alt }}
+    </figcaption>
+  </figure>
+</template>
+
+<script setup>
+defineProps({
+  src: { type: String, default: '' },
+  alt: { type: String, default: '' },
+  width: { type: [String, Number], default: undefined },
+  height: { type: [String, Number], default: undefined },
+})
+</script>


### PR DESCRIPTION
## Summary

New `components/content/ProseImg.vue` - a Nuxt Content prose override that styles markdown images within entry content.

Authors can now write `![A view of Turenne castle](/images/turenne.jpg)` in entry markdown and it renders as a responsive image with rounded corners, shadow, lazy loading, and the alt text as an italic caption below.

This works alongside the existing ImageGallery component - the gallery shows images from frontmatter, while inline images are placed at specific positions within the narrative.

Closes #221

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes
- [x] Add a test image to an entry and verify rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)