### PR TITLE
Add Flickr CC image search to admin

### DIFF
--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -95,6 +95,66 @@
     <p v-else-if="loaded && !fetching" class="text-stone-400 italic text-sm">
       No suggestions found. Click "Fetch from Wikimedia" to search.
     </p>
+
+    <!-- Flickr search -->
+    <div class="bg-white rounded-lg shadow-sm p-6 mt-6">
+      <h2 class="text-lg font-semibold text-stone-700 mb-4">Flickr CC Search</h2>
+      <div class="flex items-center gap-3 mb-4">
+        <input
+          v-model="flickrQuery"
+          type="text"
+          placeholder="Search Flickr (e.g. Turenne castle, Correze landscape)..."
+          class="flex-1 border border-stone-300 rounded px-3 py-2 text-sm"
+          @keyup.enter="searchFlickr"
+        >
+        <button
+          :disabled="flickrSearching"
+          class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700 disabled:opacity-50"
+          @click="searchFlickr"
+        >
+          {{ flickrSearching ? 'Searching...' : 'Search' }}
+        </button>
+        <button
+          :disabled="flickrSearching"
+          class="text-sm text-blue-600 hover:underline disabled:opacity-50"
+          @click="searchFlickrByLocation"
+        >
+          Search near segment
+        </button>
+      </div>
+      <div v-if="flickrResults.length" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div
+          v-for="photo in flickrResults"
+          :key="photo.id"
+          class="cursor-pointer group"
+          @click="selectFlickrImage(photo)"
+        >
+          <div
+            class="relative overflow-hidden rounded border-2 transition-all"
+            :class="isSelected({ url: photo.url }) ? 'border-green-500 opacity-70' : 'border-stone-200 hover:border-blue-400'"
+          >
+            <img
+              :src="photo.url"
+              :alt="photo.title"
+              class="w-full h-36 object-cover"
+              loading="lazy"
+            >
+            <div v-if="isSelected({ url: photo.url })" class="absolute top-1 left-1 bg-green-500 text-white w-6 h-6 rounded-full flex items-center justify-center text-sm font-bold shadow">
+              &#10003;
+            </div>
+            <div v-else class="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
+              <span class="text-white text-xs bg-blue-600 px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity">Select</span>
+            </div>
+          </div>
+          <p class="text-xs text-stone-600 mt-1 truncate">{{ photo.title }}</p>
+          <p class="text-xs text-stone-400 truncate">{{ photo.owner }} - {{ photo.license }}</p>
+        </div>
+      </div>
+      <p v-if="flickrSearched && !flickrResults.length && !flickrSearching" class="text-stone-400 italic text-sm">
+        No Flickr results found.
+      </p>
+      <p v-if="flickrError" class="text-red-600 text-sm mt-2">{{ flickrError }}</p>
+    </div>
   </div>
 </template>
 
@@ -188,6 +248,70 @@ async function saveSelection() {
     saveError.value = true
   } finally {
     saving.value = false
+  }
+}
+
+// --- Flickr search ---
+const flickrQuery = ref('')
+const flickrResults = ref([])
+const flickrSearching = ref(false)
+const flickrSearched = ref(false)
+const flickrError = ref('')
+
+async function searchFlickr() {
+  if (!flickrQuery.value) return
+  flickrSearching.value = true
+  flickrSearched.value = false
+  flickrError.value = ''
+  try {
+    const data = await $fetch('/api/flickr-search', {
+      method: 'POST',
+      body: { query: flickrQuery.value }
+    })
+    flickrResults.value = data.photos
+    flickrSearched.value = true
+  } catch (err) {
+    flickrError.value = err.data?.message || 'Flickr search failed'
+    flickrResults.value = []
+    flickrSearched.value = true
+  } finally {
+    flickrSearching.value = false
+  }
+}
+
+async function searchFlickrByLocation() {
+  const seg = segmentsJson.find(s => s.segment === selectedSegment.value)
+  if (!seg) return
+  const lat = (seg.start_lat + seg.end_lat) / 2
+  const lng = (seg.start_lng + seg.end_lng) / 2
+  flickrSearching.value = true
+  flickrSearched.value = false
+  flickrError.value = ''
+  try {
+    const data = await $fetch('/api/flickr-search', {
+      method: 'POST',
+      body: { lat, lng, query: flickrQuery.value || undefined }
+    })
+    flickrResults.value = data.photos
+    flickrSearched.value = true
+  } catch (err) {
+    flickrError.value = err.data?.message || 'Flickr search failed'
+    flickrResults.value = []
+    flickrSearched.value = true
+  } finally {
+    flickrSearching.value = false
+  }
+}
+
+function selectFlickrImage(photo) {
+  if (isSelected({ url: photo.url })) {
+    selected.value = selected.value.filter(s => s.src !== photo.url)
+  } else {
+    selected.value.push({
+      src: photo.url,
+      alt: photo.title,
+      attribution: `${photo.owner}, ${photo.license}, Flickr`
+    })
   }
 }
 

--- a/server/api/flickr-search.post.ts
+++ b/server/api/flickr-search.post.ts
@@ -1,0 +1,83 @@
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { query, lat, lng, page } = body
+
+  if (!query && !lat) {
+    throw createError({ statusCode: 400, message: 'Missing query or coordinates' })
+  }
+
+  const apiKey = process.env.FLICKR_API_KEY
+  if (!apiKey) {
+    throw createError({ statusCode: 400, message: 'No FLICKR_API_KEY set in environment' })
+  }
+
+  const params = new URLSearchParams({
+    method: 'flickr.photos.search',
+    api_key: apiKey,
+    format: 'json',
+    nojsoncallback: '1',
+    license: '1,2,3,4,5,6,9,10',
+    extras: 'url_m,url_l,owner_name,license,description',
+    per_page: '24',
+    page: String(page || 1),
+    sort: 'relevance',
+    content_type: '1',
+    media: 'photos',
+  })
+
+  if (query) {
+    params.set('text', query)
+  }
+  if (lat && lng) {
+    params.set('lat', String(lat))
+    params.set('lon', String(lng))
+    params.set('radius', '20')
+    params.set('radius_units', 'km')
+  }
+
+  const url = `https://api.flickr.com/services/rest/?${params}`
+
+  try {
+    const resp = await fetch(url)
+    if (!resp.ok) {
+      throw new Error(`Flickr API returned ${resp.status}`)
+    }
+    const data = await resp.json()
+
+    if (data.stat !== 'ok') {
+      throw new Error(data.message || 'Flickr API error')
+    }
+
+    const licenseNames: Record<string, string> = {
+      '1': 'CC BY-NC-SA 2.0',
+      '2': 'CC BY-NC 2.0',
+      '3': 'CC BY-NC-ND 2.0',
+      '4': 'CC BY 2.0',
+      '5': 'CC BY-SA 2.0',
+      '6': 'CC BY-ND 2.0',
+      '9': 'CC0 1.0',
+      '10': 'Public Domain Mark',
+    }
+
+    const photos = data.photos.photo.map((p: Record<string, string>) => ({
+      id: p.id,
+      title: p.title,
+      owner: p.ownername,
+      url: p.url_m || p.url_l || `https://live.staticflickr.com/${p.server}/${p.id}_${p.secret}_z.jpg`,
+      fullUrl: p.url_l || p.url_m || `https://live.staticflickr.com/${p.server}/${p.id}_${p.secret}_b.jpg`,
+      flickrPage: `https://www.flickr.com/photos/${p.owner}/${p.id}`,
+      license: licenseNames[p.license] || `License ${p.license}`,
+      description: (p.description as unknown as Record<string, string>)?._content?.slice(0, 200) || '',
+    }))
+
+    return {
+      photos,
+      page: data.photos.page,
+      pages: data.photos.pages,
+      total: data.photos.total,
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    throw createError({ statusCode: 502, message: `Flickr search failed: ${message}` })
+  }
+})


### PR DESCRIPTION
## Summary

Add Flickr Creative Commons image search to the admin images page.

### Features

- **Search by keyword** - type a query and search Flickr's CC-licensed photos
- **Search near segment** - uses segment midpoint coordinates with 20km radius
- **CC license filter** - only returns CC BY, CC BY-SA, CC BY-NC, CC0, and Public Domain
- **Click to select** - adds image to entry selection with proper attribution (owner, license, Flickr)
- **Server-side proxy** - `/api/flickr-search` keeps the API key secure

### Setup

Add `FLICKR_API_KEY=your_key` to `.env`. Free API key from https://www.flickr.com/services/api/

Closes #103

## Test plan

- [x] ESLint clean, all tests pass
- [ ] CI passes
- [ ] Search Flickr by keyword, verify CC results shown
- [ ] Search near segment, verify location-based results

🤖 Generated with [Claude Code](https://claude.com/claude-code)