### PR TITLE
Add day counter badge to homepage and fullscreen rider stats

### DIFF
--- a/components/DayCounter.vue
+++ b/components/DayCounter.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="flex flex-wrap items-center gap-3 text-sm">
+    <span class="bg-correze-red text-white font-bold px-3 py-1.5 rounded-lg text-lg">
+      Day {{ raceDay }}
+    </span>
+    <span v-if="daysUntilTour > 0" class="text-stone-500">
+      Tour starts in <span class="font-semibold text-stone-700">{{ daysUntilTour }}</span> days
+    </span>
+    <span v-if="daysUntilStage > 0" class="text-stone-500">
+      Stage 9 in <span class="font-semibold text-stone-700">{{ daysUntilStage }}</span> days
+    </span>
+    <span v-if="daysUntilStage <= 0" class="text-correze-red font-semibold">
+      Stage 9 is today!
+    </span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const raceStart = new Date('2026-04-01T00:00:00')
+const tourStart = new Date('2026-07-04T00:00:00')
+const stage9Date = new Date('2026-07-12T00:00:00')
+
+const now = new Date()
+const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+
+const raceDay = computed(() => {
+  const diff = Math.floor((today.getTime() - raceStart.getTime()) / (1000 * 60 * 60 * 24)) + 1
+  return Math.max(1, diff)
+})
+
+const daysUntilTour = computed(() => {
+  return Math.ceil((tourStart.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+})
+
+const daysUntilStage = computed(() => {
+  return Math.ceil((stage9Date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+})
+</script>

--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -5,6 +5,7 @@
     :class="isFullscreen ? 'z-[9999] overflow-auto p-12 text-lg' : 'p-6 text-sm'"
     :style="isFullscreen ? 'position:fixed;top:0;left:0;width:100vw;height:100vh' : ''"
   >
+    <DayCounter v-if="isFullscreen" class="mb-4" />
     <div class="flex items-center justify-between mb-4">
       <h3 :class="isFullscreen ? 'text-2xl' : 'text-lg'" class="font-semibold text-stone-700">Rider Standings</h3>
       <button

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -35,6 +35,7 @@
           Full competition rules
         </NuxtLink>
       </div>
+      <DayCounter class="mt-4" />
     </section>
 
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">


### PR DESCRIPTION
## Summary

New `DayCounter` component showing:
- **Day N** badge (correze-red, bold) counting from April 1
- Days until Tour de France start (July 4)
- Days until Stage 9 (July 12)

Shown on homepage below the title section and in fullscreen rider standings view.

Closes #241

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)