### PR TITLE
Update components and tests for 27 segments

### DIFF
--- a/components/PublishSchedule.vue
+++ b/components/PublishSchedule.vue
@@ -39,7 +39,7 @@ function generateSchedule() {
   const dates = []
   const current = new Date(start)
 
-  for (let i = 0; i < 26; i++) {
+  for (let i = 0; i < 27; i++) {
     dates.push(current.toISOString().split('T')[0])
     // Alternate: Sun -> Wed (3 days), Wed -> Sun (4 days)
     const day = current.getDay()

--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -6,7 +6,7 @@
       <div class="flex items-center gap-4">
         <label class="text-sm font-medium text-stone-600">Segment</label>
         <select v-model.number="selectedSegment" class="border border-stone-300 rounded px-3 py-2 text-sm">
-          <option v-for="n in 26" :key="n" :value="n">{{ n }} - {{ segmentTitle(n) }}</option>
+          <option v-for="n in 27" :key="n" :value="n">{{ n }} - {{ segmentTitle(n) }}</option>
         </select>
         <button
           class="bg-stone-900 text-white px-4 py-2 rounded text-sm hover:bg-stone-700"

--- a/processing/elevation_profile.py
+++ b/processing/elevation_profile.py
@@ -165,7 +165,7 @@ def main():
     parser = argparse.ArgumentParser(description="Generate elevation profiles and power estimates")
     parser.add_argument("--segments-dir", default="data/segments", help="Directory with segment GPX files")
     parser.add_argument("--output-dir", default="data/elevation", help="Output directory for elevation JSON files")
-    parser.add_argument("--num-segments", type=int, default=26)
+    parser.add_argument("--num-segments", type=int, default=27)
     args = parser.parse_args()
 
     os.makedirs(args.output_dir, exist_ok=True)

--- a/tests/e2e/build-verify.sh
+++ b/tests/e2e/build-verify.sh
@@ -112,10 +112,10 @@ check_contains "entries/01-malemort-departure/index.html" "Elevation" "elevation
 # --- Draft entries should NOT be pre-rendered ---
 echo ""
 echo "Draft filtering:"
-# Entries 02-26 are drafts — their directories should not exist
+# Entries 02-27 are drafts - their directories should not exist
 # (or if they do, they should be 404 pages)
 DRAFT_RENDERED=0
-for i in $(seq 2 26); do
+for i in $(seq 2 27); do
   NUM=$(printf "%02d" "$i")
   DRAFT_DIR=$(find "$OUTPUT_DIR/entries" -maxdepth 1 -type d -name "${NUM}-*" 2>/dev/null | head -1)
   if [ -n "$DRAFT_DIR" ] && [ -f "$DRAFT_DIR/index.html" ]; then


### PR DESCRIPTION
## Summary

Update hardcoded 26 references to 27 across the codebase:
- PublishSchedule: 27 dates
- Admin images selector: segments 1-27
- elevation_profile.py default: 27
- build-verify.sh draft check: through 27

Depends on #228.
Closes #232

## Test plan
- [x] All tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)