### PR TITLE
Update competition points and historical data for 27 segments

### DIFF
--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "Sprint - Ussel Finish",
-      "segment": 26,
+      "segment": 27,
       "km": 183,
       "points": [20, 17, 15, 13]
     }
@@ -59,7 +59,7 @@
     },
     {
       "name": "Cote de Miel",
-      "segment": 8,
+      "segment": 9,
       "km": 56.6,
       "category": 4,
       "gradient": 3.9,
@@ -83,7 +83,7 @@
     },
     {
       "name": "Suc au May",
-      "segment": 15,
+      "segment": 16,
       "km": 104.8,
       "category": "HC",
       "gradient": 7.7,
@@ -91,7 +91,7 @@
     },
     {
       "name": "Cote de la Croix de Pey",
-      "segment": 18,
+      "segment": 19,
       "km": 127,
       "category": 3,
       "gradient": 4.9,

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -23,7 +23,7 @@
     ]
   },
   {
-    "segments": [9, 10],
+    "segments": [10, 11],
     "events": [
       {
         "year": null,
@@ -34,7 +34,7 @@
     ]
   },
   {
-    "segments": [14, 15, 16],
+    "segments": [15, 16, 17],
     "events": [
       {
         "year": 2024,
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "segments": [25, 26],
+    "segments": [26, 27],
     "events": [
       {
         "year": null,


### PR DESCRIPTION
## Summary

Recalculate segment assignments for sprint/climb points and historical TdF data after the boundary shift to 6km/8km alternating segments.

### Points config changes
- Ussel Finish sprint: segment 26 -> 27
- Cote de Miel: segment 8 -> 9
- Suc au May: segment 15 -> 16
- Cote de la Croix de Pey: segment 18 -> 19

### Historical data changes
- Tulle events: [9,10] -> [10,11]
- Massif Central events: [14,15,16] -> [15,16,17]
- Ussel events: [25,26] -> [26,27]

Depends on #228.
Closes #231

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)