### PR TITLE
Create JerseyIcon component with improved jersey design

### DIFF
--- a/components/JerseyIcon.vue
+++ b/components/JerseyIcon.vue
@@ -1,0 +1,62 @@
+<template>
+  <svg :class="sizeClass" viewBox="0 0 32 32" :title="title">
+    <!-- Jersey body with sleeves and collar -->
+    <path
+      d="M16 2 L12 4 L8 3 L4 6 L4 12 L8 11 L8 28 L24 28 L24 11 L28 12 L28 6 L24 3 L20 4 L16 2Z"
+      :fill="fill"
+      :stroke="stroke"
+      stroke-width="1.2"
+      stroke-linejoin="round"
+    />
+    <!-- Collar -->
+    <path
+      d="M13 3.5 Q16 6 19 3.5"
+      fill="none"
+      :stroke="stroke"
+      stroke-width="0.8"
+    />
+    <!-- Polka dots (only for polkaDot type) -->
+    <template v-if="type === 'polkaDot'">
+      <circle cx="12" cy="12" r="2" fill="#DC2626" />
+      <circle cx="20" cy="12" r="2" fill="#DC2626" />
+      <circle cx="16" cy="17" r="2" fill="#DC2626" />
+      <circle cx="12" cy="22" r="2" fill="#DC2626" />
+      <circle cx="20" cy="22" r="2" fill="#DC2626" />
+    </template>
+  </svg>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  type: { type: String, required: true },
+  size: { type: String, default: 'sm' },
+  title: { type: String, default: '' },
+})
+
+const sizeClass = computed(() => {
+  const sizes = { xs: 'w-4 h-4', sm: 'w-5 h-5', md: 'w-6 h-6', lg: 'w-8 h-8' }
+  return sizes[props.size] || sizes.sm
+})
+
+const fill = computed(() => {
+  const fills = {
+    yellow: '#FFD100',
+    green: '#22C55E',
+    polkaDot: 'white',
+    red: '#DC2626',
+  }
+  return fills[props.type] || '#999'
+})
+
+const stroke = computed(() => {
+  const strokes = {
+    yellow: '#B8960A',
+    green: '#16A34A',
+    polkaDot: '#DC2626',
+    red: '#991B1B',
+  }
+  return strokes[props.type] || '#666'
+})
+</script>

--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -23,10 +23,10 @@
       <div v-for="rider in rankedRiders" :key="rider.id" class="flex items-center gap-3">
         <div class="w-24 flex items-center gap-1 shrink-0">
           <span class="text-sm font-medium truncate" :style="{ color: rider.textColor }">{{ rider.name }}</span>
-          <svg v-if="jerseys.yellow === rider.id" class="w-4 h-4 shrink-0" viewBox="0 0 24 24" title="Yellow Jersey"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#FFD100" stroke="#B8960A" stroke-width="1"/></svg>
-          <svg v-if="jerseys.green === rider.id" class="w-4 h-4 shrink-0" viewBox="0 0 24 24" title="Green Jersey"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#22C55E" stroke="#16A34A" stroke-width="1"/></svg>
-          <svg v-if="jerseys.polkaDot === rider.id" class="w-4 h-4 shrink-0" viewBox="0 0 24 24" title="Polka Dot Jersey"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="white" stroke="#DC2626" stroke-width="1"/><circle cx="9" cy="10" r="1.5" fill="#DC2626"/><circle cx="15" cy="10" r="1.5" fill="#DC2626"/><circle cx="12" cy="14" r="1.5" fill="#DC2626"/><circle cx="7" cy="16" r="1.5" fill="#DC2626"/><circle cx="17" cy="16" r="1.5" fill="#DC2626"/></svg>
-          <svg v-if="jerseys.red === rider.id" class="w-4 h-4 shrink-0" viewBox="0 0 24 24" title="Lanterne Rouge"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#DC2626" stroke="#991B1B" stroke-width="1"/></svg>
+          <JerseyIcon v-if="jerseys.yellow === rider.id" type="yellow" size="xs" title="Yellow Jersey" class="shrink-0" />
+          <JerseyIcon v-if="jerseys.green === rider.id" type="green" size="xs" title="Green Jersey" class="shrink-0" />
+          <JerseyIcon v-if="jerseys.polkaDot === rider.id" type="polkaDot" size="xs" title="Polka Dot Jersey" class="shrink-0" />
+          <JerseyIcon v-if="jerseys.red === rider.id" type="red" size="xs" title="Lanterne Rouge" class="shrink-0" />
         </div>
         <div class="flex-1 bg-stone-100 rounded-full relative overflow-hidden" :class="isFullscreen ? 'h-8' : 'h-5'">
           <div
@@ -51,7 +51,7 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
     <div v-if="hasPoints" class="grid grid-cols-2 gap-3 mb-6">
       <div class="bg-green-50 rounded-lg p-3 border border-green-200">
         <div class="flex items-center gap-2 mb-2">
-          <svg class="w-5 h-5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#22C55E" stroke="#16A34A" stroke-width="1"/></svg>
+          <JerseyIcon type="green" size="sm" />
           <span class="text-sm font-semibold text-green-800">Points</span>
         </div>
         <div class="space-y-1">
@@ -63,7 +63,7 @@ class="absolute inset-0 flex items-center justify-center text-xs font-mono"
       </div>
       <div class="bg-red-50 rounded-lg p-3 border border-red-200">
         <div class="flex items-center gap-2 mb-2">
-          <svg class="w-5 h-5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="white" stroke="#DC2626" stroke-width="1"/><circle cx="9" cy="10" r="1.5" fill="#DC2626"/><circle cx="15" cy="10" r="1.5" fill="#DC2626"/><circle cx="12" cy="14" r="1.5" fill="#DC2626"/></svg>
+          <JerseyIcon type="polkaDot" size="sm" />
           <span class="text-sm font-semibold text-red-800">KOM</span>
         </div>
         <div class="space-y-1">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,11 +25,11 @@
           185km Stage 9 parcours. Each day, up to 2km counts toward their position on the route -
           but unused cap rolls over, rewarding rest days followed by big efforts. Four jerseys are
           contested:
-          <svg class="w-4 h-4 inline-block mx-0.5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#FFD100" stroke="#B8960A" stroke-width="1"/></svg> yellow for the race leader,
-          <svg class="w-4 h-4 inline-block mx-0.5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#22C55E" stroke="#16A34A" stroke-width="1"/></svg> green for sprint points,
-          <svg class="w-4 h-4 inline-block mx-0.5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="white" stroke="#DC2626" stroke-width="1"/><circle cx="9" cy="10" r="1.5" fill="#DC2626"/><circle cx="15" cy="10" r="1.5" fill="#DC2626"/><circle cx="12" cy="14" r="1.5" fill="#DC2626"/></svg> polka dot for climbing points,
+          <JerseyIcon type="yellow" size="xs" class="inline-block mx-0.5" /> yellow for the race leader,
+          <JerseyIcon type="green" size="xs" class="inline-block mx-0.5" /> green for sprint points,
+          <JerseyIcon type="polkaDot" size="xs" class="inline-block mx-0.5" /> polka dot for climbing points,
           and the
-          <svg class="w-4 h-4 inline-block mx-0.5" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#DC2626" stroke="#991B1B" stroke-width="1"/></svg> lanterne rouge for last place.
+          <JerseyIcon type="red" size="xs" class="inline-block mx-0.5" /> lanterne rouge for last place.
         </p>
         <NuxtLink to="/rules" class="inline-block mt-2 text-correze-red hover:underline font-medium">
           Full competition rules

--- a/pages/rules.vue
+++ b/pages/rules.vue
@@ -33,28 +33,28 @@
       <div class="not-prose grid grid-cols-1 sm:grid-cols-2 gap-4 my-6">
         <div class="bg-white rounded-lg shadow-sm p-4 border-l-4 border-yellow-400">
           <div class="flex items-center gap-2 mb-2">
-            <svg class="w-6 h-6" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#FFD100" stroke="#B8960A" stroke-width="1" /></svg>
+            <JerseyIcon type="yellow" size="md" />
             <span class="font-bold text-stone-800">Yellow Jersey</span>
           </div>
           <p class="text-sm text-stone-600">Race leader. Highest total capped distance. Tiebreaker: highest actual distance ridden.</p>
         </div>
         <div class="bg-white rounded-lg shadow-sm p-4 border-l-4 border-green-500">
           <div class="flex items-center gap-2 mb-2">
-            <svg class="w-6 h-6" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#22C55E" stroke="#16A34A" stroke-width="1" /></svg>
+            <JerseyIcon type="green" size="md" />
             <span class="font-bold text-stone-800">Green Jersey</span>
           </div>
           <p class="text-sm text-stone-600">Sprint leader. Most sprint points accumulated at intermediate sprint locations along the route.</p>
         </div>
         <div class="bg-white rounded-lg shadow-sm p-4 border-l-4 border-red-500">
           <div class="flex items-center gap-2 mb-2">
-            <svg class="w-6 h-6" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="white" stroke="#DC2626" stroke-width="1" /><circle cx="9" cy="10" r="1.5" fill="#DC2626" /><circle cx="15" cy="10" r="1.5" fill="#DC2626" /><circle cx="12" cy="14" r="1.5" fill="#DC2626" /><circle cx="7" cy="16" r="1.5" fill="#DC2626" /><circle cx="17" cy="16" r="1.5" fill="#DC2626" /></svg>
+            <JerseyIcon type="polkaDot" size="md" />
             <span class="font-bold text-stone-800">Polka Dot Jersey</span>
           </div>
           <p class="text-sm text-stone-600">Climbing leader. Most climbing points earned at the summits of the route's categorized climbs.</p>
         </div>
         <div class="bg-white rounded-lg shadow-sm p-4 border-l-4 border-red-800">
           <div class="flex items-center gap-2 mb-2">
-            <svg class="w-6 h-6" viewBox="0 0 24 24"><path d="M12 2L8 5H4v4l-2 2v9h20v-9l-2-2V5h-4l-4-3z" fill="#DC2626" stroke="#991B1B" stroke-width="1" /></svg>
+            <JerseyIcon type="red" size="md" />
             <span class="font-bold text-stone-800">Lanterne Rouge</span>
           </div>
           <p class="text-sm text-stone-600">Last place by capped distance. In Tour tradition, a badge of honour - the rider who refuses to abandon.</p>


### PR DESCRIPTION
## Summary

New reusable `JerseyIcon` component with an improved cycling jersey SVG shape (sleeves, collar, proper polka dot pattern). Replaces all inline jersey SVGs across:

- **RiderDashboard** - progress bar indicators and classification card headers
- **Homepage** - race explainer inline icons
- **Rules page** - jersey description cards

Supports 4 sizes (xs/sm/md/lg) and 4 types (yellow/green/polkaDot/red).

Closes #240

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes
- [x] Visual review of jerseys on dashboard, homepage, rules page

🤖 Generated with [Claude Code](https://claude.com/claude-code)