### PR TITLE
Show jersey indicators on elevation profile rider markers

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -105,6 +105,7 @@ const props = defineProps({
   currentSegment: { type: Number, default: 0 },
   riderStats: { type: Object, default: null },
   riderConfig: { type: Object, default: null },
+  riderPoints: { type: Object, default: null },
 })
 
 const chartRef = ref(null)
@@ -259,6 +260,49 @@ function buildLabelItems() {
   return items
 }
 
+function getJerseyEmoji(riderId) {
+  if (!props.riderStats?.riders || !props.riderConfig?.riders) return ''
+  const riders = props.riderConfig.riders
+  const pts = props.riderPoints?.riders || {}
+
+  // Compute jerseys with precedence: yellow > green > polka dot > red
+  const taken = new Set()
+  const sorted = [...riders]
+    .map(r => ({ ...r, stats: props.riderStats.riders[r.id] || {} }))
+    .sort((a, b) => (a.stats.place || 99) - (b.stats.place || 99))
+
+  const yellow = sorted[0]?.id
+  if (yellow) taken.add(yellow)
+  if (riderId === yellow) return '🟡'
+
+  let green = null
+  const sprintSorted = [...riders].sort((a, b) =>
+    (pts[b.id]?.sprintPoints || 0) - (pts[a.id]?.sprintPoints || 0)
+  )
+  for (const r of sprintSorted) {
+    if ((pts[r.id]?.sprintPoints || 0) > 0 && !taken.has(r.id)) {
+      green = r.id; taken.add(r.id); break
+    }
+  }
+  if (riderId === green) return '🟢'
+
+  let polkaDot = null
+  const climbSorted = [...riders].sort((a, b) =>
+    (pts[b.id]?.climbPoints || 0) - (pts[a.id]?.climbPoints || 0)
+  )
+  for (const r of climbSorted) {
+    if ((pts[r.id]?.climbPoints || 0) > 0 && !taken.has(r.id)) {
+      polkaDot = r.id; taken.add(r.id); break
+    }
+  }
+  if (riderId === polkaDot) return '🔴'
+
+  const red = sorted.length > 1 ? sorted[sorted.length - 1]?.id : null
+  if (riderId === red && !taken.has(red)) return '🔻'
+
+  return ''
+}
+
 function buildRiderAnnotations() {
   if (!props.riderStats?.riders || !props.riderConfig?.riders || !props.elevationData) return {}
 
@@ -283,6 +327,9 @@ function buildRiderAnnotations() {
       if (d < bestDist) { bestDist = d; bestIdx = i }
     }
 
+    const jersey = getJerseyEmoji(rider.id)
+    const labelText = jersey ? `${jersey} ${rider.name}` : rider.name
+
     annotations[`rider-${rider.id}`] = {
       type: 'line',
       xMin: bestIdx,
@@ -292,7 +339,7 @@ function buildRiderAnnotations() {
       borderDash: [4, 2],
       label: {
         display: true,
-        content: rider.name,
+        content: labelText,
         position: 'start',
         backgroundColor: rider.color,
         color: 'white',

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -19,7 +19,7 @@
       class="mb-8"
     />
 
-    <ElevationChart :elevation-data="elevationData" :segments="segments" :current-segment="page.segment" :rider-stats="riderSnapshot?.stats || riderStats" :rider-config="riderConfig" class="mb-8" />
+    <ElevationChart :elevation-data="elevationData" :segments="segments" :current-segment="page.segment" :rider-stats="riderSnapshot?.stats || riderStats" :rider-config="riderConfig" :rider-points="riderSnapshot?.points || null" class="mb-8" />
 
     <PowerStats :elevation-data="elevationData" class="mb-8" />
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -54,7 +54,7 @@
             Full 185km route. Use layer controls for topo, cycling, and satellite views.
           </p>
           <ClientOnly>
-            <ElevationChart :elevation-data="overviewElevation" :segments="segments" :current-segment="0" :rider-stats="riderStats" :rider-config="riderConfig" class="mt-6" />
+            <ElevationChart :elevation-data="overviewElevation" :segments="segments" :current-segment="0" :rider-stats="riderStats" :rider-config="riderConfig" :rider-points="riderPointsData" class="mt-6" />
           </ClientOnly>
         </section>
 
@@ -101,11 +101,18 @@ const townCoords = townCoordsJson
 const riderConfig = riderConfigJson
 
 const riderStats = ref(null)
+const riderPointsData = ref(null)
 try {
   const data = await import('~/data/riders/stats.json')
   riderStats.value = data.default || data
 } catch {
   riderStats.value = null
+}
+try {
+  const data = await import('~/data/riders/points.json')
+  riderPointsData.value = data.default || data
+} catch {
+  // points.json may not exist yet
 }
 
 const overviewElevation = ref(null)


### PR DESCRIPTION
## Summary

Rider position labels on the elevation profile now include a jersey emoji indicating which jersey they hold:

- 🟡 Yellow (GC leader)
- 🟢 Green (sprint leader)
- 🔴 Polka dot (KOM leader)
- 🔻 Lanterne rouge (last place)

Uses the same precedence rules as the dashboard (yellow > green > polka dot > red). New `riderPoints` prop passed from entry pages (via snapshot) and homepage (via live points.json).

Closes #237

## Test plan

- [x] ESLint clean, all tests pass
- [x] CI passes
- [x] Jersey emojis visible next to rider names on elevation profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)