### PR TITLE
Show rider progress and towns on map by default

### DIFF
--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -320,6 +320,8 @@ async function initMap(el) {
     'Attractions': attractionsGroup,
     'Rider Progress': riderGroup
   }
+  poiGroup.addTo(map)
+  riderGroup.addTo(map)
   L.control.layers(baseLayers, overlays, { position: 'topleft' }).addTo(map)
 
   // Full route


### PR DESCRIPTION
## Summary

Rider progress and towns/climbs layers now visible on map load without toggling the layer control. Readers see riders immediately.

Closes #261

## Test plan
- [x] CI passes
- [x] Map shows rider markers and town icons on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)