### PR TITLE
Show upcoming points in next segment on entry pages

### DIFF
--- a/components/UpcomingPoints.vue
+++ b/components/UpcomingPoints.vue
@@ -1,0 +1,43 @@
+<template>
+  <div v-if="points.length" class="bg-white rounded-lg shadow-sm p-6 mt-8">
+    <h3 class="text-lg font-semibold text-stone-700 mb-3">Coming Up Next</h3>
+    <p class="text-sm text-stone-500 mb-4">Points available in the next segment:</p>
+    <div class="space-y-2">
+      <div v-for="pt in points" :key="pt.name" class="flex items-center justify-between text-sm">
+        <div class="flex items-center gap-2">
+          <span v-if="pt.type === 'sprint'" class="text-green-600 font-semibold">Sprint</span>
+          <span v-else class="text-red-600 font-semibold">{{ formatCategory(pt.category) }}</span>
+          <span class="text-stone-700">{{ pt.name }}</span>
+          <span class="text-stone-400 text-xs">km {{ pt.km }}</span>
+        </div>
+        <div class="font-mono text-stone-500">
+          {{ pt.points.filter(p => p > 0).join('/') }} pts
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+import pointsConfig from '~/data/competition/points-config.json'
+
+const props = defineProps({
+  segment: { type: Number, required: true },
+})
+
+function formatCategory(cat) {
+  if (cat === 'HC') return 'HC'
+  return `Cat ${cat}`
+}
+
+const nextSegment = computed(() => props.segment + 1)
+
+const points = computed(() => {
+  const sprints = pointsConfig.sprints.filter(s => s.segment === nextSegment.value)
+  const climbs = pointsConfig.climbs.filter(c => c.segment === nextSegment.value)
+  return [...sprints.map(s => ({ ...s, type: 'sprint' })), ...climbs.map(c => ({ ...c, type: 'climb' }))]
+    .sort((a, b) => a.km - b.km)
+})
+</script>

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -33,6 +33,8 @@
 
     <HistoricalContext :segment="page.segment" />
 
+    <UpcomingPoints :segment="page.segment" />
+
     <WeatherWidget :weather="page.weather" />
 
     <RiderDashboard :snapshot="riderSnapshot" />


### PR DESCRIPTION
## Summary

New UpcomingPoints component on entry pages showing sprint and climbing point opportunities in the next segment. Builds anticipation for what's coming.

- Sprint points shown in green with "Sprint" label
- Climbing points in red with category (HC, Cat 2, etc.)
- Shows km position and points available (e.g. "20/17/15/13 pts")
- Only renders when the next segment has point locations

Closes #252

## Test plan
- [x] ESLint clean, all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)