### PR TITLE
Fix fullscreen rider standings not covering entire viewport

### DIFF
--- a/components/RiderDashboard.vue
+++ b/components/RiderDashboard.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     v-if="stats && Object.keys(stats.riders).length"
-    class="bg-white rounded-lg shadow-sm mt-8 relative"
-    :class="isFullscreen ? 'z-[9999] overflow-auto p-12 text-lg' : 'p-6 text-sm'"
-    :style="isFullscreen ? 'position:fixed;top:0;left:0;width:100vw;height:100vh' : ''"
+    class="bg-white rounded-lg shadow-sm relative"
+    :class="isFullscreen ? 'z-[9999] overflow-auto p-12 text-lg' : 'mt-8 p-6 text-sm'"
+    :style="isFullscreen ? 'position:fixed;top:0;left:0;width:100vw;height:100vh;margin:0' : ''"
   >
     <DayCounter v-if="isFullscreen" class="mb-4" />
     <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary

The mt-8 top margin was applied in both normal and fullscreen modes, causing a gap at the top of the fullscreen overlay. Moved margin to normal-mode-only.

Closes #272

## Test plan
- [x] ESLint clean, all tests pass
- [x] CI passes
- [x] Visual review: fullscreen fills entire viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)