### PR TITLE
Add tests for JerseyIcon and UpcomingPoints components

### DIFF
--- a/tests/components/JerseyIcon.test.ts
+++ b/tests/components/JerseyIcon.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import JerseyIcon from '~/components/JerseyIcon.vue'
+
+describe('JerseyIcon', () => {
+  it('renders yellow jersey with correct fill and stroke', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'yellow' } })
+    const path = wrapper.find('path')
+    expect(path.attributes('fill')).toBe('#FFD100')
+    expect(path.attributes('stroke')).toBe('#B8960A')
+  })
+
+  it('renders green jersey with correct fill and stroke', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'green' } })
+    const path = wrapper.find('path')
+    expect(path.attributes('fill')).toBe('#22C55E')
+    expect(path.attributes('stroke')).toBe('#16A34A')
+  })
+
+  it('renders polka dot jersey with white fill and red stroke', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'polkaDot' } })
+    const path = wrapper.find('path')
+    expect(path.attributes('fill')).toBe('white')
+    expect(path.attributes('stroke')).toBe('#DC2626')
+  })
+
+  it('renders red jersey with correct fill and stroke', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'red' } })
+    const path = wrapper.find('path')
+    expect(path.attributes('fill')).toBe('#DC2626')
+    expect(path.attributes('stroke')).toBe('#991B1B')
+  })
+
+  it('renders polka dots only for polkaDot type', () => {
+    const polka = mount(JerseyIcon, { props: { type: 'polkaDot' } })
+    expect(polka.findAll('circle').length).toBe(5)
+
+    const yellow = mount(JerseyIcon, { props: { type: 'yellow' } })
+    expect(yellow.findAll('circle').length).toBe(0)
+  })
+
+  it('uses fallback fill and stroke for unknown type', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'unknown' } })
+    const path = wrapper.find('path')
+    expect(path.attributes('fill')).toBe('#999')
+    expect(path.attributes('stroke')).toBe('#666')
+  })
+
+  it('defaults to sm size class', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'yellow' } })
+    const svg = wrapper.find('svg')
+    expect(svg.classes()).toContain('w-5')
+    expect(svg.classes()).toContain('h-5')
+  })
+
+  it('applies xs size class', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'yellow', size: 'xs' } })
+    const svg = wrapper.find('svg')
+    expect(svg.classes()).toContain('w-4')
+    expect(svg.classes()).toContain('h-4')
+  })
+
+  it('applies lg size class', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'yellow', size: 'lg' } })
+    const svg = wrapper.find('svg')
+    expect(svg.classes()).toContain('w-8')
+    expect(svg.classes()).toContain('h-8')
+  })
+
+  it('sets title attribute on svg', () => {
+    const wrapper = mount(JerseyIcon, { props: { type: 'yellow', title: 'Race leader' } })
+    expect(wrapper.find('svg').attributes('title')).toBe('Race leader')
+  })
+})

--- a/tests/components/UpcomingPoints.test.ts
+++ b/tests/components/UpcomingPoints.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import UpcomingPoints from '~/components/UpcomingPoints.vue'
+
+vi.mock('~/data/competition/points-config.json', () => ({
+  default: {
+    sprints: [
+      { name: 'Sprint - Turenne', segment: 3, km: 17, points: [20, 17, 15, 13] },
+      { name: 'Sprint - Brive', segment: 1, km: 3, points: [5, 3, 2, 1] },
+    ],
+    climbs: [
+      { name: 'Puy Boubou', segment: 3, km: 19, category: 4, points: [3, 2, 1, 0] },
+      { name: 'Suc au May', segment: 15, km: 105, category: 1, points: [10, 8, 6, 4] },
+      { name: 'Col HC', segment: 3, km: 21, category: 'HC', points: [20, 15, 10, 5] },
+    ],
+  },
+}))
+
+describe('UpcomingPoints', () => {
+  it('renders nothing when next segment has no points', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 5 } })
+    expect(wrapper.find('div').exists()).toBe(false)
+  })
+
+  it('renders sprint points for next segment', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).toContain('Sprint')
+    expect(wrapper.text()).toContain('Sprint - Turenne')
+    expect(wrapper.text()).toContain('km 17')
+  })
+
+  it('renders climbing points with category formatting', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).toContain('Cat 4')
+    expect(wrapper.text()).toContain('Puy Boubou')
+  })
+
+  it('formats HC category correctly', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).toContain('HC')
+    expect(wrapper.text()).toContain('Col HC')
+  })
+
+  it('sorts points by km', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    const text = wrapper.text()
+    const turenne = text.indexOf('Turenne')
+    const boubou = text.indexOf('Puy Boubou')
+    const hc = text.indexOf('Col HC')
+    expect(turenne).toBeLessThan(boubou)
+    expect(boubou).toBeLessThan(hc)
+  })
+
+  it('filters to next segment only', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).not.toContain('Suc au May')
+    expect(wrapper.text()).not.toContain('Sprint - Brive')
+  })
+
+  it('shows points values excluding zeros', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).toContain('20/17/15/13 pts')
+    expect(wrapper.text()).toContain('3/2/1 pts')
+  })
+
+  it('shows Coming Up Next heading', () => {
+    const wrapper = mount(UpcomingPoints, { props: { segment: 2 } })
+    expect(wrapper.text()).toContain('Coming Up Next')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 10 tests for **JerseyIcon**: fill/stroke per jersey type, polka dot rendering, size variants, fallback for unknown types, title attribute
- Adds 8 tests for **UpcomingPoints**: filtering by next segment, sprint/climb rendering, HC/Cat formatting, km sort order, zero-point exclusion
- Component test coverage: 9/14 (up from 7/14)

Closes #276

## Test plan

- [x] All 18 new tests pass
- [x] Full test suite passes (83 tests)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)