### PR TITLE
Grey out completed towns and climbs in stage details

### DIFF
--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -5,9 +5,9 @@
     <div class="mb-5">
       <h4 class="text-sm font-semibold text-stone-600 mb-2 bg-amber-100 -mx-6 px-6 py-1.5">Towns</h4>
       <div class="space-y-1">
-        <div v-for="town in towns" :key="town.name" class="flex justify-between text-sm">
-          <span class="text-stone-700">{{ town.name }}</span>
-          <span class="font-mono text-stone-400">km {{ town.km }} &middot; {{ town.elevation }}m</span>
+        <div v-for="town in towns" :key="town.name" class="flex justify-between text-sm" :class="isPassed(town.km) ? 'opacity-40' : ''">
+          <span :class="isPassed(town.km) ? 'text-stone-400' : 'text-stone-700'">{{ town.name }}</span>
+          <span class="font-mono" :class="isPassed(town.km) ? 'text-stone-300' : 'text-stone-400'">km {{ town.km }} &middot; {{ town.elevation }}m</span>
         </div>
       </div>
     </div>
@@ -15,9 +15,9 @@
     <div>
       <h4 class="text-sm font-semibold text-stone-600 mb-2 bg-amber-100 -mx-6 px-6 py-1.5">Climbs</h4>
       <div class="space-y-1">
-        <div v-for="climb in climbs" :key="climb.name" class="flex justify-between text-sm">
-          <span class="text-stone-700">{{ climb.name }}</span>
-          <span class="font-mono text-stone-400">km {{ climb.km }} &middot; {{ climb.gradient }}%</span>
+        <div v-for="climb in climbs" :key="climb.name" class="flex justify-between text-sm" :class="isPassed(climb.km) ? 'opacity-40' : ''">
+          <span :class="isPassed(climb.km) ? 'text-stone-400' : 'text-stone-700'">{{ climb.name }}</span>
+          <span class="font-mono" :class="isPassed(climb.km) ? 'text-stone-300' : 'text-stone-400'">km {{ climb.km }} &middot; {{ climb.gradient }}%</span>
         </div>
       </div>
     </div>
@@ -30,6 +30,14 @@
 
 <script setup>
 import segmentsJson from '~/data/segments.json'
+
+const props = defineProps({
+  currentKm: { type: Number, default: 0 },
+})
+
+function isPassed(km) {
+  return props.currentKm > 0 && Number(km) < props.currentKm
+}
 
 // Known climb details from CLAUDE.md
 const climbData = {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,7 +81,7 @@
         <RiderDashboard />
         <div class="mt-6">
           <PublishSchedule v-if="isDev" />
-          <StageDetails v-else />
+          <StageDetails v-else :current-km="latestKmEnd" />
         </div>
       </aside>
     </div>
@@ -140,6 +140,11 @@ const { data: entries } = await useAsyncData('entries', () =>
     .limit(5)
     .all()
 )
+
+const latestKmEnd = computed(() => {
+  const latest = entries.value?.[0]
+  return latest?.kmEnd || 0
+})
 
 function formatDate(dateStr) {
   if (!dateStr) return ''


### PR DESCRIPTION
## Summary

- StageDetails accepts a new `currentKm` prop (default 0)
- Towns/climbs where km < currentKm are visually muted (opacity-40, lighter text colors)
- Homepage computes `latestKmEnd` from the most recent published entry and passes it to StageDetails
- When no entries are published (currentKm = 0), all items show as upcoming

Closes #274

## Test plan

- [x] All 83 tests pass, CI green
- [x] On homepage, Malemort and Brive-la-Gaillarde (km 0, km 3) should appear muted since entry 01 covers km 0-8
- [x] Climbs and towns beyond km 8 should appear in normal styling
- [x] As more entries publish, more rows will grey out automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)