### PR TITLE
Show StageDetails in dev mode alongside PublishSchedule

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,7 +81,7 @@
         <RiderDashboard />
         <div class="mt-6">
           <PublishSchedule v-if="isDev" />
-          <StageDetails v-else :current-km="latestKmEnd" />
+          <StageDetails :current-km="latestKmEnd" />
         </div>
       </aside>
     </div>


### PR DESCRIPTION
## Summary

- Removes `v-else` from StageDetails so it renders in both dev and production mode
- PublishSchedule still only shows in dev mode
- Enables Vite hot reload for visual iteration on StageDetails

From [v1.1 retro](https://github.com/gneeek/tdf26/wiki/Retro-v1.1.0-v1.1.1) - production-only components block fast iteration.

Closes #287

## Test plan

- [x] CI green
- [x] Dev server shows both PublishSchedule and StageDetails on homepage
- [x] Production build still shows StageDetails (no PublishSchedule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)