### PR TITLE
Add Node version check to ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,11 @@
 import { createConfigForNuxt } from '@nuxt/eslint-config'
 
+if (Number(process.versions.node.split('.')[0]) < 22) {
+  throw new Error(
+    `Node ${process.versions.node} detected - this project requires Node 22+. Run: nvm use`
+  )
+}
+
 export default createConfigForNuxt()
   .append({
     ignores: ['dist/', '.output/', '.nuxt/', 'node_modules/', 'coverage/', 'processing/'],


### PR DESCRIPTION
## Summary

- Adds a Node version check at the top of `eslint.config.mjs`
- Running ESLint with Node <22 now shows: "Node X detected - this project requires Node 22+. Run: nvm use"
- Previously failed with cryptic `TypeError: Object.groupBy is not a function`

Closes #289

## Test plan

- [x] CI green
- [x] `npx eslint .` passes with Node 22
- [x] `npx eslint .` shows clear error with Node 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)