### PR TITLE
Update marked from 17 to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-zoom": "^2.2.0",
         "leaflet": "^1.9.4",
-        "marked": "^17.0.5",
+        "marked": "^18.0.0",
         "nuxt": "^4.4.2",
         "vue-chartjs": "^5.3.0"
       },
@@ -11324,9 +11324,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
-      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chartjs-plugin-annotation": "^3.1.0",
     "chartjs-plugin-zoom": "^2.2.0",
     "leaflet": "^1.9.4",
-    "marked": "^17.0.5",
+    "marked": "^18.0.0",
     "nuxt": "^4.4.2",
     "vue-chartjs": "^5.3.0"
   },


### PR DESCRIPTION
## Summary

Major version update for marked (17.0.5 to 18.0.0). Breaking changes in v18 are:
- Trim trailing blank lines from block tokens (internal)
- TypeScript upgraded to v6 (build toolchain)

Our usage is `import { marked } from 'marked'` and `marked(string)` in the admin entry editor preview - unaffected by these changes.

Closes #303

## Test plan

- [x] CI green
- [x] Admin entry editor preview still renders markdown correctly (`/admin/edit/01-malemort-departure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)