### PR TITLE
Add dual licensing and copyright notice in footer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+NOTE: This project uses dual licensing.
+- Source code: Apache License 2.0 (this file)
+- Blog entry content (content/entries/): CC BY-SA 4.0 (see LICENSE-CONTENT.md)
 
                                  Apache License
                            Version 2.0, January 2004

--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,0 +1,21 @@
+# Content License
+
+The blog entry content in `content/entries/` is licensed under the
+**Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)**.
+
+This includes the narrative text, descriptions, and curated editorial content.
+Images within entries are subject to their individual licenses as noted in their attribution.
+
+You are free to:
+
+- **Share** - copy and redistribute the material in any medium or format
+- **Adapt** - remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+
+- **Attribution** - You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+- **ShareAlike** - If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
+
+Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+Copyright 2026 Justin Simpson

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -74,6 +74,11 @@
           <div>
             <p>Correze Travelogue - Malemort to Ussel, 185km</p>
             <p class="mt-1">Stage 9, Tour de France 2026 - Sunday, July 12</p>
+            <p class="mt-1 text-stone-500 text-xs">
+              &copy; 2026 Justin Simpson &middot;
+              Code: <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer" class="hover:text-white">Apache 2.0</a> &middot;
+              Content: <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer" class="hover:text-white">CC BY-SA 4.0</a>
+            </p>
           </div>
           <span class="text-stone-600 sm:border-l sm:border-stone-700 sm:pl-6">Designed in Maxwelltown, Dumfries</span>
         </div>


### PR DESCRIPTION
## Summary

- New `LICENSE-CONTENT.md` with CC BY-SA 4.0 for blog entry content
- Dual-license note added to top of existing `LICENSE` (Apache 2.0 for code)
- Footer now shows copyright and linked license info: "Code: Apache 2.0 | Content: CC BY-SA 4.0"

Closes #306

## Test plan

- [x] CI green
- [x] Footer shows copyright and license links on every page
- [x] License links open correct deeds in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)