### PR TITLE
Fix map to use snapshot rider positions on entry pages

### DIFF
--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -14,7 +14,7 @@
       :segments="segments"
       :route-coords="routeCoords"
       :town-coords="townCoords"
-      :rider-stats="riderStats"
+      :rider-stats="riderSnapshot?.stats || riderStats"
       :rider-config="riderConfig"
       class="mb-8"
     />


### PR DESCRIPTION
## Summary

SegmentMap on entry pages now receives `riderSnapshot?.stats` instead of live `riderStats`, matching the existing ElevationChart behaviour. Rider positions on the map now reflect their position at publish time, not the current state.

One-line change on `pages/entries/[...slug].vue` line 17.

Closes #301

## Test plan

- [x] CI green
- [x] On segment 1 entry, rider map positions match the distances shown in rider stats table
- [x] On homepage (no snapshot), map still shows live positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)