### PR TITLE
docs: add Agent Ownership section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,17 @@ The project has four pillars:
 3. **Rider stats tracker** — 4 riders log daily distances; stats are calculated and displayed per entry
 4. **Publish-day pipeline** — weather data injection, rider stats update, site regeneration, deployment
 
+## Agent Ownership
+
+This project uses a two-agent ownership model for its repositories:
+
+- **Tully** owns `gneeek/tdf26` (this repo). Biased toward project-specific craft, voice, and publisher experience. Has tie-breaking authority on tdf26 decisions.
+- **Piers** owns `gneeek/unfold` (the portable-practices companion site, shipping in v1.3.5). Biased toward structure, distillation, and what travels across projects. Has tie-breaking authority on unfold decisions.
+
+Both voices contribute to any discussion. The owning voice's judgment is authoritative for its repo. When a proposed change fits one repo better than the other, the right answer is often "direct it to the other repo" rather than "force it in here."
+
+See `feedback_agent_ownership.md` in the memory system for the full model including push-back criteria and deference rules.
+
 ## Tech Stack
 
 - **Runtime:** Node.js 20+ (Nuxt/Vue), Python 3.11+ (data processing)


### PR DESCRIPTION
## Summary

Adds a short Agent Ownership section to `CLAUDE.md` between the Project Overview and Tech Stack sections. Names the two-agent ownership model (Tully owns tdf26, Piers owns unfold) and points at `feedback_agent_ownership.md` in the memory system for the full model.

Fixes #336.

## Context

This change was made during the harness-engineering planning conversation on 2026-04-10 when the project adopted the two-agent ownership model. The edit was staged in the working tree but not committed at the time. This PR formally lands it through the gitflow per the project's "feature branches to main via PR" rule.

The section is 11 lines. It does not duplicate the memory file content, it just names both agents, explains tie-breaking authority, and points at the memory for detail.

## Test plan

- [x] CLAUDE.md still reads cleanly on a Claude Code session start (agent ownership section does not conflict with surrounding content)
- [x] Memory file `feedback_agent_ownership.md` referenced in the new section exists and describes the full model
- [x] Section placement between "Project Overview" and "Tech Stack" reads naturally