### PR TITLE
Fix town positions to use verified GPX values (#321)

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -60,6 +60,7 @@ import {
   Tooltip
 } from 'chart.js'
 import annotationPlugin from 'chartjs-plugin-annotation'
+import { townKmPositions } from '~/data/town-positions'
 ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Filler, Tooltip, annotationPlugin)
 
 const zoomReady = ref(false)
@@ -220,13 +221,7 @@ const chartData = computed(() => {
   }
 })
 
-// Known positions along the route
-const townKmPositions = {
-  'Malemort': 0, 'Brive-la-Gaillarde': 4.5, 'Turenne': 17,
-  'Collonges-la-Rouge': 23.5, 'Beynat': 37.5, 'Tulle': 65.5,
-  'Naves': 73.5, 'Chaumeil': 90, 'Treignac': 116.5,
-  'Bugeat': 130, 'Meymac': 157.5, 'Ussel': 182.5,
-}
+// townKmPositions is imported from ~/data/town-positions (shared with StageDetails.vue)
 
 // Known climb summit positions (km_end from KNOWN_CLIMBS)
 const climbSummitKm = {

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -30,6 +30,7 @@
 
 <script setup>
 import segmentsJson from '~/data/segments.json'
+import { townKmPositions } from '~/data/town-positions'
 
 const props = defineProps({
   currentKm: { type: Number, default: 0 },
@@ -58,9 +59,10 @@ for (const seg of segmentsJson) {
   if (seg.towns?.length) {
     for (const town of seg.towns) {
       if (!townSet.has(town)) {
+        const km = townKmPositions[town] ?? seg.km_start
         townSet.set(town, {
           name: town,
-          km: seg.km_start.toFixed(0),
+          km: km.toFixed(0),
           elevation: seg.min_elevation
         })
       }

--- a/content/entries/02-south-of-brive.md
+++ b/content/entries/02-south-of-brive.md
@@ -1,7 +1,7 @@
 ---
 segment: 2
 title: "South of Brive"
-subtitle: "Km 8-14"
+subtitle: "Km 8-14: Walnut country and the walls of Turenne"
 publishDate: 2026-04-08
 kmStart: 8
 kmEnd: 14

--- a/data/segments.json
+++ b/data/segments.json
@@ -30,7 +30,9 @@
     "min_elevation": 176,
     "max_elevation": 337,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Turenne"
+    ],
     "climbs": []
   },
   {
@@ -47,7 +49,8 @@
     "max_elevation": 287,
     "notable_points": [],
     "towns": [
-      "Turenne"
+      "Ligneyrac",
+      "Collonges-la-Rouge"
     ],
     "climbs": []
   },
@@ -65,7 +68,8 @@
     "max_elevation": 381,
     "notable_points": [],
     "towns": [
-      "Collonges-la-Rouge"
+      "Collonges-la-Rouge",
+      "Meyssac"
     ],
     "climbs": []
   },
@@ -104,7 +108,7 @@
       "Beynat"
     ],
     "climbs": [
-      "Côte de Lagleygeolle"
+      "C\u00f4te de Lagleygeolle"
     ]
   },
   {
@@ -122,7 +126,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte de Lagleygeolle"
+      "C\u00f4te de Lagleygeolle"
     ]
   },
   {
@@ -140,7 +144,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte de Miel"
+      "C\u00f4te de Miel"
     ]
   },
   {
@@ -158,7 +162,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte de Miel"
+      "C\u00f4te de Miel"
     ]
   },
   {
@@ -196,7 +200,7 @@
       "Naves"
     ],
     "climbs": [
-      "Côte des Naves"
+      "C\u00f4te des Naves"
     ]
   },
   {
@@ -320,7 +324,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte de la Croix de Pey"
+      "C\u00f4te de la Croix de Pey"
     ]
   },
   {
@@ -340,7 +344,7 @@
       "Bugeat"
     ],
     "climbs": [
-      "Côte de la Croix de Pey"
+      "C\u00f4te de la Croix de Pey"
     ]
   },
   {
@@ -426,7 +430,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte des Gardes"
+      "C\u00f4te des Gardes"
     ]
   },
   {

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -1,0 +1,29 @@
+// Canonical km positions for towns along the Stage 9 route.
+//
+// Each value is the cumulative km along the route GPX track, measured from
+// the closest approach of the route to the town center. This is the authoritative
+// source for `town -> km` used by both ElevationChart.vue (for elevation chart labels)
+// and StageDetails.vue (for the stage details card town list).
+//
+// Values marked "verified" were measured by running the master GPX track against
+// the town coordinates during the investigation for issue #321 on 2026-04-11.
+// Other values are carried forward unchanged from the previous hardcoded table
+// in ElevationChart.vue and are approximate. A separate audit of those values
+// is tracked in issue #341 (processing/split_gpx.py root-cause fix).
+
+export const townKmPositions: Record<string, number> = {
+  'Malemort': 0,
+  'Brive-la-Gaillarde': 4.5,
+  'Turenne': 11.91,          // verified 2026-04-11, closest approach 91m from castle
+  'Ligneyrac': 17.11,        // verified 2026-04-11, 628m south of route
+  'Collonges-la-Rouge': 21.75, // verified 2026-04-11, first arrival (219m from village)
+  'Meyssac': 23.70,          // verified 2026-04-11, 277m from village
+  'Beynat': 37.5,
+  'Tulle': 65.5,
+  'Naves': 73.5,
+  'Chaumeil': 90,
+  'Treignac': 116.5,
+  'Bugeat': 130,
+  'Meymac': 157.5,
+  'Ussel': 182.5,
+}


### PR DESCRIPTION
## Summary

Fixes #321.

The Stage Details card showed Turenne at km 14 because `StageDetails.vue` used `seg.km_start.toFixed(0)` as the km for each town — which is only the start km of the containing segment, not the town's actual position on the route. Meanwhile, `data/segments.json` assigned Turenne to segment 3 based on bounding-box containment rather than route proximity. The castle is actually at **km 11.91**, inside segment 2, verified by running the master GPX against the known castle coordinates during segment 3 content research.

## Changes

- **New `data/town-positions.ts`**: shared canonical `town -> km` map, imported by both `StageDetails.vue` and `ElevationChart.vue`. Verified values for:
  - Turenne: 11.91 (castle closest approach, 91m)
  - Ligneyrac: 17.11 (628m south of route)
  - Collonges-la-Rouge: 21.75 (first arrival, 219m from village)
  - Meyssac: 23.70 (277m from village)
  
  Other town values are carried forward unchanged from the previous hardcoded table for later audit under a future release.

- **`data/segments.json`**: 
  - Segment 2 towns: `[] -> ['Turenne']`
  - Segment 3 towns: `['Turenne'] -> ['Ligneyrac', 'Collonges-la-Rouge']`
  - Segment 4 towns: `['Collonges-la-Rouge'] -> ['Collonges-la-Rouge', 'Meyssac']`

- **`components/StageDetails.vue`**: imports `townKmPositions` and uses it for each town's km value; falls back to `seg.km_start` only if a town has no entry in the shared map.

- **`components/ElevationChart.vue`**: removes the local hardcoded `townKmPositions` const (which had Turenne at the wrong km 17) and imports the shared module. This also reduces the route metadata duplication tracked in #326 by one copy.

- **`content/entries/02-south-of-brive.md`**: subtitle updated from `"Km 8-14"` to `"Km 8-14: Walnut country and the walls of Turenne"` to reflect that segment 2 is where the route physically passes the castle walls. Body text is unchanged; the segment 2 published narrative still describes the first-glimpse framing from km 8, which is now acknowledged to be approximate rather than distant.

## Out of scope

- **Root cause in `processing/split_gpx.py`**: the script uses bounding-box town assignment rather than route proximity. This PR corrects `segments.json` manually. The script fix is tracked as #341 for a future release.
- **Audit of other town km values**: only Turenne, Ligneyrac, Collonges-la-Rouge, and Meyssac have been GPX-verified in this PR. Beynat, Tulle, Naves, Chaumeil, Treignac, Bugeat, Meymac, and Ussel keep their previous hardcoded values, to be audited when their segments come up for content review.
- **Route metadata debt fully consolidated**: this PR shares `townKmPositions` between two components, reducing one copy of the duplication tracked in #326. Full consolidation (including `climbSummitKm` and the tables in `processing/split_gpx.py`) is still in #326.
- **Segment 4 visual verification**: segment 4's entry file is still `draft: true` with placeholder content, so its elevation chart couldn't be visually verified. The code path is shared with segment 2 (which was verified), so the risk is low. Will be confirmed properly when segment 4 content work lands.

## Test plan

- [x] `npx vitest run tests/components` — 49 tests pass across 9 files
- [x] Homepage Stage Details card — Turenne now shows at km 12 (between Malemort and Ligneyrac), Ligneyrac at 17, Collonges at 22, Meyssac at 24 (verified via curl + in-browser)
- [x] Segment 2 entry page — subtitle updated to "Km 8-14: Walnut country and the walls of Turenne" (verified in-browser)
- [ ] Segment 4 entry page — deferred to segment 4 content work

## Related

- Fixes #321 (the immediate display bug)
- Reduces one copy of route metadata duplication tracked in #326
- Root-cause script fix tracked as #341