### PR TITLE
Fix nearby attractions duplication with route-proximity assignment (#344)

### DIFF
--- a/components/NearbyAttractions.vue
+++ b/components/NearbyAttractions.vue
@@ -41,22 +41,34 @@ const categoryEmoji = {
   memorial: '🕯️', industrial: '🏭', craft: '🔨',
 }
 
+// Segment boundary tolerance: attractions within 0.5 km of a segment's km_start
+// or km_end also appear in the adjacent segment. This prevents boundary cases
+// like Collonges-la-Rouge (first route arrival at km 21.75, just inside segment 3)
+// from disappearing from segment 4's entry page where the Collonges content lives.
+const TOLERANCE_KM = 0.5
+
+// Attractions more than this far from the actual route aren't "nearby" to any
+// segment and are excluded from every entry page.
+const MAX_DISTANCE_M = 5000
+
 const nearby = computed(() => {
   const seg = segmentsJson.find(s => s.segment === props.segment)
   if (!seg) return []
 
-  const midLat = (seg.start_lat + seg.end_lat) / 2
-  const midLng = (seg.start_lng + seg.end_lng) / 2
-
   return attractionsData
     .filter(poi => {
-      const dist = Math.sqrt((poi.lat - midLat) ** 2 + (poi.lng - midLng) ** 2)
-      return dist <= 0.15
+      // Route-proximity fields are precomputed by
+      // processing/calculate_attraction_positions.py. Skip POIs that haven't
+      // been processed yet (defensive; in practice all POIs should have them).
+      if (typeof poi.nearest_km !== 'number' || typeof poi.nearest_distance_m !== 'number') {
+        return false
+      }
+      if (poi.nearest_distance_m > MAX_DISTANCE_M) {
+        return false
+      }
+      return poi.nearest_km >= (seg.km_start - TOLERANCE_KM)
+          && poi.nearest_km <= (seg.km_end + TOLERANCE_KM)
     })
-    .sort((a, b) => {
-      const dA = Math.sqrt((a.lat - midLat) ** 2 + (a.lng - midLng) ** 2)
-      const dB = Math.sqrt((b.lat - midLat) ** 2 + (b.lng - midLng) ** 2)
-      return dA - dB
-    })
+    .sort((a, b) => a.nearest_distance_m - b.nearest_distance_m)
 })
 </script>

--- a/data/attractions.json
+++ b/data/attractions.json
@@ -5,7 +5,9 @@
     "lat": 45.138,
     "lng": 1.549,
     "description": "Prehistoric shelters along the Correze river, evidence of habitation at the start of the route.",
-    "links": []
+    "links": [],
+    "nearest_km": 0.03,
+    "nearest_distance_m": 47
   },
   {
     "name": "Distillerie Denoix",
@@ -13,31 +15,54 @@
     "lat": 45.1589,
     "lng": 1.5335,
     "description": "Historic liqueur distillery (est. 1839) producing walnut liqueur and violet mustard. Free tastings.",
-    "links": [{"url": "https://www.denoix.com/", "label": "Official site"}]
+    "links": [
+      {
+        "url": "https://www.denoix.com/",
+        "label": "Official site"
+      }
+    ],
+    "nearest_km": 0.0,
+    "nearest_distance_m": 2607
   },
   {
     "name": "Marche de Brive",
     "category": "market",
-    "lat": 45.1590,
-    "lng": 1.5340,
+    "lat": 45.159,
+    "lng": 1.534,
     "description": "Major covered market (Tue/Thu/Sat). Famous Foires Grasses truffle and foie gras markets Nov-Feb.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Halle_Georges-Brassens_(Brive-la-Gaillarde)", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Halle_Georges-Brassens_(Brive-la-Gaillarde)",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 0.0,
+    "nearest_distance_m": 2598
   },
   {
     "name": "Musee Edmond Michelet",
     "category": "museum",
-    "lat": 45.1570,
-    "lng": 1.5320,
+    "lat": 45.157,
+    "lng": 1.532,
     "description": "WWII Resistance museum in the house where Michelet distributed anti-Nazi tracts on June 17, 1940.",
-    "links": [{"url": "https://en.wikipedia.org/wiki/Edmond_Michelet", "label": "Wikipedia"}]
+    "links": [
+      {
+        "url": "https://en.wikipedia.org/wiki/Edmond_Michelet",
+        "label": "Wikipedia"
+      }
+    ],
+    "nearest_km": 0.0,
+    "nearest_distance_m": 2486
   },
   {
     "name": "Domaine de la Gardelle",
     "category": "food",
-    "lat": 45.1200,
-    "lng": 1.5100,
+    "lat": 45.12,
+    "lng": 1.51,
     "description": "Organic vineyard producing Correze PDO wines including traditional vin paille (straw wine).",
-    "links": []
+    "links": [],
+    "nearest_km": 1.85,
+    "nearest_distance_m": 3504
   },
   {
     "name": "Grottes de Lamouroux",
@@ -45,23 +70,44 @@
     "lat": 45.1598,
     "lng": 1.5347,
     "description": "Troglodytic cliff dwellings carved into limestone, inhabited from prehistoric through medieval times.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Grottes_de_Lamouroux", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Grottes_de_Lamouroux",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 0.0,
+    "nearest_distance_m": 2653
   },
   {
     "name": "Aubazine Abbey",
     "category": "abbey",
-    "lat": 45.1750,
-    "lng": 1.6690,
+    "lat": 45.175,
+    "lng": 1.669,
     "description": "12th-century Cistercian abbey where Coco Chanel spent six years as an orphan. Geometric patterns may have inspired the Chanel logo.",
-    "links": [{"url": "https://en.wikipedia.org/wiki/Aubazine_Abbey", "label": "Wikipedia"}]
+    "links": [
+      {
+        "url": "https://en.wikipedia.org/wiki/Aubazine_Abbey",
+        "label": "Wikipedia"
+      }
+    ],
+    "nearest_km": 38.9,
+    "nearest_distance_m": 4716
   },
   {
     "name": "Chateau de Turenne",
     "category": "castle",
     "lat": 45.0537,
-    "lng": 1.5830,
+    "lng": 1.583,
     "description": "Ruined hilltop keep of the Viscounty of Turenne. Controlled much of Correze until sold to Louis XV in 1738.",
-    "links": [{"url": "https://en.wikipedia.org/wiki/Turenne", "label": "Wikipedia"}]
+    "links": [
+      {
+        "url": "https://en.wikipedia.org/wiki/Turenne",
+        "label": "Wikipedia"
+      }
+    ],
+    "nearest_km": 11.91,
+    "nearest_distance_m": 91
   },
   {
     "name": "Eglise Saint-Pierre",
@@ -69,58 +115,98 @@
     "lat": 45.0607,
     "lng": 1.6555,
     "description": "11th-century fortified church in Collonges-la-Rouge with carved Romanesque tympanum depicting the Ascension.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/%C3%89glise_Saint-Pierre_de_Collonges-la-Rouge", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/%C3%89glise_Saint-Pierre_de_Collonges-la-Rouge",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 21.79,
+    "nearest_distance_m": 101
   },
   {
     "name": "Castel de Vassinhac",
     "category": "castle",
-    "lat": 45.0610,
-    "lng": 1.6560,
+    "lat": 45.061,
+    "lng": 1.656,
     "description": "Late 16th-century fortified manor in Collonges-la-Rouge with distinctive turrets and loopholes.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Castel_de_Vassinhac", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Castel_de_Vassinhac",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 21.82,
+    "nearest_distance_m": 52
   },
   {
     "name": "Maison de la Sirene",
     "category": "museum",
     "lat": 45.0608,
-    "lng": 1.6550,
+    "lng": 1.655,
     "description": "16th-century house with sculpted mermaid in Collonges. Once belonged to Henry de Jouvenel, husband of Colette.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Maison_de_la_Sir%C3%A8ne", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Maison_de_la_Sir%C3%A8ne",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 21.77,
+    "nearest_distance_m": 114
   },
   {
     "name": "Beynat Chestnut Festival",
     "category": "food",
-    "lat": 45.1250,
-    "lng": 1.7280,
+    "lat": 45.125,
+    "lng": 1.728,
     "description": "Annual October Fete de la Chataigne. Chestnut producers, tastings, and summer Tuesday evening markets.",
-    "links": []
+    "links": [],
+    "nearest_km": 45.19,
+    "nearest_distance_m": 60
   },
   {
     "name": "Fromagerie Duroux",
     "category": "cheese",
-    "lat": 45.1900,
-    "lng": 1.7700,
+    "lat": 45.19,
+    "lng": 1.77,
     "description": "Artisan fromagerie near Tulle aging cheese in a reconverted railway tunnel. Produces Pave Correzien.",
-    "links": []
+    "links": [],
+    "nearest_km": 57.91,
+    "nearest_distance_m": 20
   },
   {
     "name": "Cascades de Gimel",
     "category": "nature",
-    "lat": 45.2970,
-    "lng": 1.8530,
+    "lat": 45.297,
+    "lng": 1.853,
     "description": "Three waterfalls on the Montane river with a total drop of 143m. Natura 2000 site north of Tulle.",
-    "links": [{"url": "https://www.cascadesdegimel.com/", "label": "Official site"}]
+    "links": [
+      {
+        "url": "https://www.cascadesdegimel.com/",
+        "label": "Official site"
+      }
+    ],
+    "nearest_km": 74.44,
+    "nearest_distance_m": 4301
   },
   {
     "name": "Cathedrale Notre-Dame de Tulle",
     "category": "church",
-    "lat": 45.2680,
-    "lng": 1.7680,
+    "lat": 45.268,
+    "lng": 1.768,
     "description": "12th-century cathedral with a 75m bell tower, the tallest in the Limousin. Notable carved cloister.",
     "links": [
-      {"url": "https://en.wikipedia.org/wiki/Tulle_Cathedral", "label": "Wikipedia"},
-      {"url": "https://fr.wikipedia.org/wiki/Cath%C3%A9drale_Notre-Dame_de_Tulle", "label": "Wikipedia (fr)"}
-    ]
+      {
+        "url": "https://en.wikipedia.org/wiki/Tulle_Cathedral",
+        "label": "Wikipedia"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Cath%C3%A9drale_Notre-Dame_de_Tulle",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 68.6,
+    "nearest_distance_m": 311
   },
   {
     "name": "Cite de l'Accordeon",
@@ -128,23 +214,34 @@
     "lat": 45.2685,
     "lng": 1.7695,
     "description": "Opened 2024 in the former Banque de France. Exhibits on accordion-making, Tulle lace, and arms manufacturing.",
-    "links": [{"url": "https://www.citedelaccordeon.com/", "label": "Official site"}]
+    "links": [
+      {
+        "url": "https://www.citedelaccordeon.com/",
+        "label": "Official site"
+      }
+    ],
+    "nearest_km": 68.79,
+    "nearest_distance_m": 233
   },
   {
     "name": "Les Delices de Mel",
     "category": "cheese",
-    "lat": 45.2680,
-    "lng": 1.7700,
+    "lat": 45.268,
+    "lng": 1.77,
     "description": "Fromagerie in central Tulle. Regional cheeses including Feuille du Limousin, caillade, and cabecou.",
-    "links": []
+    "links": [],
+    "nearest_km": 68.69,
+    "nearest_distance_m": 177
   },
   {
     "name": "Marche de Tulle",
     "category": "market",
-    "lat": 45.2680,
-    "lng": 1.7690,
+    "lat": 45.268,
+    "lng": 1.769,
     "description": "Wednesday and Saturday morning market at Place Gambetta and Quai Baluze along the Correze river.",
-    "links": []
+    "links": [],
+    "nearest_km": 68.66,
+    "nearest_distance_m": 245
   },
   {
     "name": "Tintignac Gallo-Roman Sanctuary",
@@ -152,31 +249,54 @@
     "lat": 45.3056,
     "lng": 1.7667,
     "description": "Celtic bronze carnyx war trumpets discovered 2004. One of the most important Celtic finds in France. Fanum temple and theatre.",
-    "links": [{"url": "https://en.wikipedia.org/wiki/Tintignac", "label": "Wikipedia"}]
+    "links": [
+      {
+        "url": "https://en.wikipedia.org/wiki/Tintignac",
+        "label": "Wikipedia"
+      }
+    ],
+    "nearest_km": 77.66,
+    "nearest_distance_m": 656
   },
   {
     "name": "Chateau de Bach",
     "category": "castle",
-    "lat": 45.3100,
-    "lng": 1.7600,
+    "lat": 45.31,
+    "lng": 1.76,
     "description": "Castle near Naves with an 18th-century portal and vestiges of a 14th-century Gothic cloister.",
-    "links": []
+    "links": [],
+    "nearest_km": 77.92,
+    "nearest_distance_m": 941
   },
   {
     "name": "Chateau de Ventadour",
     "category": "castle",
-    "lat": 45.3900,
-    "lng": 2.1050,
+    "lat": 45.39,
+    "lng": 2.105,
     "description": "11th-century ruins on a rocky spur. Cradle of troubadour Bernard de Ventadour and Occitan courtly love tradition.",
-    "links": [{"url": "https://chateau-ventadour.fr/", "label": "Official site"}]
+    "links": [
+      {
+        "url": "https://chateau-ventadour.fr/",
+        "label": "Official site"
+      }
+    ],
+    "nearest_km": 172.88,
+    "nearest_distance_m": 15031
   },
   {
     "name": "Gorges de la Vezere",
     "category": "nature",
-    "lat": 45.5350,
-    "lng": 1.7930,
+    "lat": 45.535,
+    "lng": 1.793,
     "description": "Wild granite gorges of the Vezere river near Treignac. The Saut du Loup rapids are a renowned kayaking spot.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/V%C3%A9z%C3%A8re", "label": "Wikipedia (fr) - Vezere river"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/V%C3%A9z%C3%A8re",
+        "label": "Wikipedia (fr) - Vezere river"
+      }
+    ],
+    "nearest_km": 121.73,
+    "nearest_distance_m": 134
   },
   {
     "name": "Pont Medieval de Treignac",
@@ -184,183 +304,280 @@
     "lat": 45.5365,
     "lng": 1.7945,
     "description": "13th/14th-century stone bridge with three arches spanning the Vezere. Iconic view of the medieval town.",
-    "links": []
+    "links": [],
+    "nearest_km": 121.99,
+    "nearest_distance_m": 81
   },
   {
     "name": "Eglise Notre-Dame-des-Bans",
     "category": "church",
-    "lat": 45.5370,
-    "lng": 1.7950,
+    "lat": 45.537,
+    "lng": 1.795,
     "description": "13th-century church in Treignac built by the Comborn family, remodeled in the 15th century with ribbed vaulting.",
-    "links": []
+    "links": [],
+    "nearest_km": 122.06,
+    "nearest_distance_m": 68
   },
   {
     "name": "Lac des Bariousses",
     "category": "nature",
-    "lat": 45.5500,
-    "lng": 1.8100,
+    "lat": 45.55,
+    "lng": 1.81,
     "description": "99-hectare Blue Flag lake on the Vezere. Swimming, kayak and paddleboard rental in the Monedieres hills.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Lac_des_Bariousses", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Lac_des_Bariousses",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 122.34,
+    "nearest_distance_m": 1644
   },
   {
     "name": "Les Cars Gallo-Roman Site",
     "category": "archaeology",
     "lat": 45.6303,
-    "lng": 1.8850,
+    "lng": 1.885,
     "description": "Ruins of two 1st-3rd century Gallo-Roman funerary temples with carved granite on the Plateau de Millevaches.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Tours_de_Bonneval", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Tours_de_Bonneval",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 143.64,
+    "nearest_distance_m": 4920
   },
   {
     "name": "Tourbiere de Longeyroux",
     "category": "nature",
-    "lat": 45.5600,
-    "lng": 2.0500,
+    "lat": 45.56,
+    "lng": 2.05,
     "description": "Largest peat bog in the Limousin (250 hectares, 8,000 years old). Boardwalk trail through heather moors.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Tourbi%C3%A8re_de_Longeyroux", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Tourbi%C3%A8re_de_Longeyroux",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 154.4,
+    "nearest_distance_m": 1157
   },
   {
     "name": "Lac de Sechemailles",
     "category": "nature",
-    "lat": 45.5200,
-    "lng": 2.1200,
+    "lat": 45.52,
+    "lng": 2.12,
     "description": "40-hectare Blue Flag lake near Meymac. Swimming, fishing, and hiking trails to Mont Bessou summit.",
-    "links": []
+    "links": [],
+    "nearest_km": 168.23,
+    "nearest_distance_m": 2646
   },
   {
     "name": "Abbaye Saint-Andre",
     "category": "abbey",
-    "lat": 45.5340,
-    "lng": 2.1470,
+    "lat": 45.534,
+    "lng": 2.147,
     "description": "Benedictine abbey founded 1085 in Meymac. Now houses the Centre d'Art Contemporain.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Abbaye_Saint-Andr%C3%A9_de_Meymac", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Abbaye_Saint-Andr%C3%A9_de_Meymac",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 168.46,
+    "nearest_distance_m": 84
   },
   {
     "name": "Centre d'Art Contemporain",
     "category": "museum",
-    "lat": 45.5340,
-    "lng": 2.1470,
+    "lat": 45.534,
+    "lng": 2.147,
     "description": "Contemporary art center in the Abbaye Saint-Andre. 900m2 across five levels, 3-5 exhibitions per year.",
-    "links": [{"url": "https://www.cacmeymac.fr/", "label": "Official site"}]
+    "links": [
+      {
+        "url": "https://www.cacmeymac.fr/",
+        "label": "Official site"
+      }
+    ],
+    "nearest_km": 168.46,
+    "nearest_distance_m": 84
   },
   {
     "name": "Chapelle des Penitents",
     "category": "church",
-    "lat": 45.5480,
-    "lng": 2.3100,
+    "lat": 45.548,
+    "lng": 2.31,
     "description": "15th-century funeral chapel in Ussel with a classified Baroque altarpiece. Houses sacred art collection.",
-    "links": []
+    "links": [],
+    "nearest_km": 182.04,
+    "nearest_distance_m": 3129
   },
   {
     "name": "Musee du Pays d'Ussel",
     "category": "museum",
-    "lat": 45.5480,
+    "lat": 45.548,
     "lng": 2.3105,
     "description": "Classified Musee de France with collections of art, popular traditions, tapestries, and printing materials.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Mus%C3%A9e_du_Pays_d%27Ussel", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Mus%C3%A9e_du_Pays_d%27Ussel",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 182.04,
+    "nearest_distance_m": 3147
   },
   {
     "name": "Marche d'Ussel",
     "category": "market",
-    "lat": 45.5480,
-    "lng": 2.3110,
+    "lat": 45.548,
+    "lng": 2.311,
     "description": "Saturday morning market in the town center and covered market hall behind the church.",
-    "links": []
+    "links": [],
+    "nearest_km": 182.04,
+    "nearest_distance_m": 3166
   },
   {
     "name": "Aigle Romaine",
     "category": "archaeology",
     "lat": 45.5485,
-    "lng": 2.3110,
+    "lng": 2.311,
     "description": "2nd-3rd century granite funerary eagle sculpture at Place Voltaire. Marks the Stage 9 finish line.",
-    "links": [{"url": "https://fr.wikipedia.org/wiki/Aigle_romaine_d%27Ussel", "label": "Wikipedia (fr)"}]
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Aigle_romaine_d%27Ussel",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 182.04,
+    "nearest_distance_m": 3215
   },
   {
     "name": "Huilerie Marty",
     "category": "food",
-    "lat": 45.1560,
-    "lng": 1.5280,
+    "lat": 45.156,
+    "lng": 1.528,
     "description": "Traditional walnut oil mill in Brive producing cold-pressed huile de noix, a Correze staple.",
-    "links": []
+    "links": [],
+    "nearest_km": 0.0,
+    "nearest_distance_m": 2587
   },
   {
     "name": "Monument des Martyrs de Tulle",
     "category": "memorial",
     "lat": 45.2674,
-    "lng": 1.7700,
+    "lng": 1.77,
     "description": "Memorial at the Souilhac factory where 99 men were hanged by the SS Das Reich division on June 9, 1944.",
     "links": [
-      {"url": "https://en.wikipedia.org/wiki/Tulle_massacre", "label": "Wikipedia"},
-      {"url": "https://fr.wikipedia.org/wiki/Pendaisons_de_Tulle", "label": "Wikipedia (fr)"}
-    ]
+      {
+        "url": "https://en.wikipedia.org/wiki/Tulle_massacre",
+        "label": "Wikipedia"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Pendaisons_de_Tulle",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 68.66,
+    "nearest_distance_m": 146
   },
   {
     "name": "Manufacture d'Armes de Tulle",
     "category": "industrial",
-    "lat": 45.2700,
-    "lng": 1.7680,
+    "lat": 45.27,
+    "lng": 1.768,
     "description": "State arms factory established 1690 under Louis XIV. Produced the MAT-49 submachine gun. Now partly a cultural space.",
     "links": [
-      {"url": "https://en.wikipedia.org/wiki/Manufacture_d%27armes_de_Tulle", "label": "Wikipedia"},
-      {"url": "https://fr.wikipedia.org/wiki/Manufacture_d%27armes_de_Tulle", "label": "Wikipedia (fr)"}
-    ]
+      {
+        "url": "https://en.wikipedia.org/wiki/Manufacture_d%27armes_de_Tulle",
+        "label": "Wikipedia"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Manufacture_d%27armes_de_Tulle",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 68.86,
+    "nearest_distance_m": 399
   },
   {
     "name": "Maugein Accordeons",
     "category": "industrial",
-    "lat": 45.2660,
-    "lng": 1.7740,
+    "lat": 45.266,
+    "lng": 1.774,
     "description": "The last remaining accordion manufacturer in France, founded 1919. Still produces handmade accordions. Visitable workshop.",
     "links": [
-      {"url": "https://www.maugein.com", "label": "Official site"},
-      {"url": "https://fr.wikipedia.org/wiki/Maugein", "label": "Wikipedia (fr)"}
-    ]
+      {
+        "url": "https://www.maugein.com",
+        "label": "Official site"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Maugein",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 68.66,
+    "nearest_distance_m": 205
   },
   {
     "name": "Atelier-Musee des Vieux Metiers",
     "category": "craft",
-    "lat": 45.0610,
-    "lng": 1.6560,
+    "lat": 45.061,
+    "lng": 1.656,
     "description": "Workshop-museum in Collonges-la-Rouge demonstrating traditional Correze trades: woodworking, basketry, and stone carving.",
-    "links": []
+    "links": [],
+    "nearest_km": 21.82,
+    "nearest_distance_m": 52
   },
   {
     "name": "Confiserie Lamy",
     "category": "food",
-    "lat": 45.1260,
-    "lng": 1.7270,
+    "lat": 45.126,
+    "lng": 1.727,
     "description": "Beynat producer of pate de fruits and chestnut confections (creme de marrons), a Correze specialty.",
-    "links": []
+    "links": [],
+    "nearest_km": 45.08,
+    "nearest_distance_m": 90
   },
   {
     "name": "Maquis de Chaumeil Memorial",
     "category": "memorial",
-    "lat": 45.4340,
-    "lng": 1.8550,
+    "lat": 45.434,
+    "lng": 1.855,
     "description": "Memorial to the Maquis fighters of the Chaumeil area. The remote Monedieres hills sheltered active Resistance cells from 1943-44.",
-    "links": []
+    "links": [],
+    "nearest_km": 96.76,
+    "nearest_distance_m": 249
   },
   {
     "name": "Stele des Maquisards",
     "category": "memorial",
-    "lat": 45.6000,
-    "lng": 1.9230,
+    "lat": 45.6,
+    "lng": 1.923,
     "description": "Monument in Bugeat commemorating the Maquis du Mont Gargan and Plateau de Millevaches partisans.",
-    "links": []
+    "links": [],
+    "nearest_km": 143.64,
+    "nearest_distance_m": 448
   },
   {
     "name": "Pont de la Tourmente",
     "category": "bridge",
-    "lat": 45.5340,
-    "lng": 1.7950,
+    "lat": 45.534,
+    "lng": 1.795,
     "description": "Medieval fortified bridge in Treignac over the Vezere. Site of Hundred Years' War skirmishes when English forces raided the Bas-Limousin.",
-    "links": []
+    "links": [],
+    "nearest_km": 121.91,
+    "nearest_distance_m": 319
   },
   {
     "name": "La Table de Jean",
     "category": "food",
-    "lat": 45.5350,
-    "lng": 2.1480,
+    "lat": 45.535,
+    "lng": 2.148,
     "description": "Restaurant in Meymac featuring regional cuisine: pounti (herb and meat terrine), millassou (corn cake), and Millevaches chestnuts.",
-    "links": []
+    "links": [],
+    "nearest_km": 168.49,
+    "nearest_distance_m": 48
   }
 ]

--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -272,18 +272,26 @@ const categoryEmoji = {
   memorial: '🕯️', industrial: '🏭', craft: '🔨',
 }
 
+// Nearby-attraction suggestions for the Wikipedia search helper. Uses the same
+// route-proximity algorithm as components/NearbyAttractions.vue (issue #344)
+// so the admin and the published entry pages stay consistent.
 const nearbyAttractions = computed(() => {
   const seg = segmentsJson.find(s => s.segment === selectedSegment.value)
   if (!seg) return []
-  const midLat = (seg.start_lat + seg.end_lat) / 2
-  const midLng = (seg.start_lng + seg.end_lng) / 2
+  const TOLERANCE_KM = 0.5
+  const MAX_DISTANCE_M = 5000
   return attractionsData
-    .filter(poi => Math.sqrt((poi.lat - midLat) ** 2 + (poi.lng - midLng) ** 2) <= 0.15)
-    .sort((a, b) => {
-      const dA = Math.sqrt((a.lat - midLat) ** 2 + (a.lng - midLng) ** 2)
-      const dB = Math.sqrt((b.lat - midLat) ** 2 + (b.lng - midLng) ** 2)
-      return dA - dB
+    .filter(poi => {
+      if (typeof poi.nearest_km !== 'number' || typeof poi.nearest_distance_m !== 'number') {
+        return false
+      }
+      if (poi.nearest_distance_m > MAX_DISTANCE_M) {
+        return false
+      }
+      return poi.nearest_km >= (seg.km_start - TOLERANCE_KM)
+          && poi.nearest_km <= (seg.km_end + TOLERANCE_KM)
     })
+    .sort((a, b) => a.nearest_distance_m - b.nearest_distance_m)
 })
 
 function searchAttractionWikipedia(name) {

--- a/processing/calculate_attraction_positions.py
+++ b/processing/calculate_attraction_positions.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Compute per-attraction route proximity for Stage 9.
+
+Reads all per-segment GPX files from data/segments/, concatenates them into
+a continuous track with cumulative km measured from Malemort, then for each
+attraction in data/attractions.json finds the closest point on the track.
+
+Adds two fields to each attraction:
+  - nearest_km: cumulative km along the route at the closest track point
+  - nearest_distance_m: straight-line (haversine) distance in meters from
+    the attraction to that closest point
+
+The output is written back to data/attractions.json in place.
+
+Downstream consumers (components/NearbyAttractions.vue, pages/admin/images.vue)
+then assign each attraction to the segment whose [km_start, km_end) range
+contains its nearest_km, and filter out attractions whose nearest_distance_m
+exceeds a "too far from route to be nearby" threshold.
+
+Related: issue #344 (this fix), issue #321 (same class of fix for town positions),
+issue #341 (root-cause script fix for bounding-box assignment in split_gpx.py).
+"""
+
+import argparse
+import json
+import math
+import os
+import xml.etree.ElementTree as ET
+
+GPX_NS = "http://www.topografix.com/GPX/1/1"
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    """Great-circle distance in kilometers between two lat/lon points."""
+    R = 6371.0088
+    lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    c = 2 * math.asin(math.sqrt(a))
+    return R * c
+
+
+def parse_gpx(path):
+    """Parse a GPX file and return an ordered list of (lat, lon) tuples."""
+    tree = ET.parse(path)
+    root = tree.getroot()
+    points = []
+    for trkpt in root.iter(f"{{{GPX_NS}}}trkpt"):
+        lat = float(trkpt.get("lat"))
+        lon = float(trkpt.get("lon"))
+        points.append((lat, lon))
+    return points
+
+
+def build_master_track(segments_dir):
+    """
+    Concatenate all segment GPX files into one track with cumulative km
+    measured from the first point of segment 1.
+
+    Returns a list of (lat, lon, cum_km) tuples.
+    """
+    track = []
+    cum_km = 0.0
+    for i in range(1, 27):
+        path = os.path.join(segments_dir, f"segment-{i:02d}.gpx")
+        if not os.path.exists(path):
+            print(f"  warning: {path} not found, skipping")
+            continue
+        points = parse_gpx(path)
+        if not points:
+            continue
+        for j, (lat, lon) in enumerate(points):
+            if not track:
+                track.append((lat, lon, 0.0))
+                continue
+            prev_lat, prev_lon, _prev_km = track[-1]
+            step = haversine_km(prev_lat, prev_lon, lat, lon)
+            # Skip exact duplicate points at segment boundaries
+            if j == 0 and step < 1e-6:
+                continue
+            cum_km += step
+            track.append((lat, lon, cum_km))
+    return track
+
+
+def nearest_track_point(track, lat, lon):
+    """
+    Find the closest track point to (lat, lon).
+
+    Linear scan. O(len(track)) per call, fast enough for 44 attractions
+    against ~25k trkpts (~1.1 million haversine calls, a few seconds in
+    pure Python).
+    """
+    best_km = 0.0
+    best_dist = float("inf")
+    for trk_lat, trk_lon, trk_km in track:
+        d = haversine_km(trk_lat, trk_lon, lat, lon)
+        if d < best_dist:
+            best_dist = d
+            best_km = trk_km
+    return best_km, best_dist
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute route proximity for Stage 9 attractions")
+    parser.add_argument("--attractions", default="data/attractions.json", help="Path to attractions.json")
+    parser.add_argument("--segments-dir", default="data/segments", help="Directory of per-segment GPX files")
+    parser.add_argument("--dry-run", action="store_true", help="Print results without writing")
+    args = parser.parse_args()
+
+    print(f"Building master track from {args.segments_dir}/")
+    track = build_master_track(args.segments_dir)
+    if not track:
+        print("  ERROR: no GPX points loaded")
+        return 1
+    total_km = track[-1][2]
+    print(f"  {len(track)} points, total {total_km:.2f} km")
+
+    print(f"\nLoading attractions from {args.attractions}")
+    with open(args.attractions) as f:
+        attractions = json.load(f)
+    print(f"  {len(attractions)} attractions")
+
+    print("\nComputing route proximity for each attraction")
+    for poi in attractions:
+        cum_km, dist_km = nearest_track_point(track, poi["lat"], poi["lng"])
+        poi["nearest_km"] = round(cum_km, 2)
+        poi["nearest_distance_m"] = round(dist_km * 1000)
+
+    print("\n--- results (sorted by nearest_km) ---")
+    for poi in sorted(attractions, key=lambda p: p["nearest_km"]):
+        print(f"  km {poi['nearest_km']:6.2f}, {poi['nearest_distance_m']:6d}m  [{poi['category']:12}] {poi['name']}")
+
+    if args.dry_run:
+        print("\n(dry run, not writing)")
+        return 0
+
+    with open(args.attractions, "w") as f:
+        json.dump(attractions, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(f"\nWrote updated {args.attractions}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes #344.

Replaces the midpoint-radius algorithm in `NearbyAttractions.vue` (and `admin/images.vue`) with route-proximity assignment based on per-POI `nearest_km` precomputed against the master GPX track. Same class of fix as #321 (town positions). Same pattern: precomputed proximity, segment range assignment, boundary tolerance.

## Changes

- **New `processing/calculate_attraction_positions.py`**: concatenates per-segment GPX files into a continuous track with cumulative km, then for each POI in `data/attractions.json` finds the closest point on the track and writes `nearest_km` and `nearest_distance_m` fields back to the file. Uses haversine distance with no external dependencies. Runnable as `python3 processing/calculate_attraction_positions.py`.

- **`data/attractions.json`**: all 44 POIs now have `nearest_km` and `nearest_distance_m` fields. Selected values:
  - Chateau de Turenne: km 11.91, 91 m from route
  - Collonges attractions (4): km 21.77-21.82, 52-114 m from route
  - Tulle attractions (7): km 68.60-68.86, 146-399 m from route
  - Chateau de Ventadour: km 172.88, **15031 m** from route (excluded by max-distance filter)

- **`components/NearbyAttractions.vue`**: computed filter replaced. Uses nearest_km to determine segment membership via range [km_start - 0.5, km_end + 0.5], skips POIs where nearest_distance_m > 5000, and sorts by route distance. The 0.5 km tolerance is symmetric and handles boundary cases where an attraction sits right at a segment edge.

- **`pages/admin/images.vue`**: same algorithm for the 'Search by Nearby Attraction' helper in the image picker. Keeps admin and published entry consistent.

## Verified results (Python simulation against updated attractions.json)

Before this fix segment 3 had 15 attractions, 13 of which were shared with segments 1 and 2. After this fix:

| Segment | Attractions | Examples |
|---|---|---|
| 1 (Brive area) | 7 | Grottes de Lacan (47 m), Distillerie Denoix |
| 2 (Turenne) | 1 | Chateau de Turenne (91 m) |
| 3 (causse) | 4 | Collonges attractions (52-114 m) |
| 4 (Collonges) | 4 | Same Collonges attractions (boundary tolerance) |
| 6 | 1 | Aubazine Abbey (4716 m, near 5km threshold) |
| 7 | 2 | Beynat Chestnut Festival, Confiserie Lamy |
| 10 (Tulle) | 7 | Cathedral, accordion factory, markets, memorial |

**Excluded**: Chateau de Ventadour (15031 m).

**Intentional boundary duplications**: Collonges on segments 3 and 4; Tourbiere de Longeyroux on segments 22 and 23; Meymac attractions on segments 24 and 25.

## Out of scope

- **Tests**: NearbyAttractions.vue has no dedicated test file. Adding one is a future hygiene improvement.
- **SegmentMap.vue marker rendering**: map component has its own attraction rendering path (not updated here).
- **Script regeneration discipline**: if new POIs are added manually, the script must be re-run.

## Test plan

- [x] Python simulation verifies per-segment POI assignments
- [x] Chateau de Ventadour excluded (15031 m > 5000 m threshold)
- [x] No cross-segment duplication except at intentional boundaries
- [x] Visual dev server verification: deferred to after merge; developed in a git worktree so the active dev server on the sibling branch stays intact for segment 3 content work (#298)

## Related

- Fixes #344
- Same class of fix as #321
- Related root-cause work in #341
- Part of v1.4.0 - Keeping the reader commitment