### PR TITLE
Fix Parcours dropdown: render subtitles and replace em-dashes (#343)

### DIFF
--- a/content/entries/01-malemort-departure.md
+++ b/content/entries/01-malemort-departure.md
@@ -1,6 +1,6 @@
 ---
 segment: 1
-title: "Malemort — Where Pain Meets Death"
+title: "Malemort - Where Pain Meets Death"
 subtitle: "Km 0-8: Departure from the Correze lowlands"
 publishDate: 2026-04-05
 dataCutoff: 2026-04-04
@@ -13,7 +13,7 @@ weather: {"fetchedAt": "2026-04-08", "current": {"temp": 13, "conditions": "Clea
 draft: false
 ---
 
-# Malemort — Where Pain Meets Death
+# Malemort - Where Pain Meets Death
 
 The name alone should give our four riders pause. *Malemort* — from the Occitan *mala mort*, the bad death. It is a name that predates the Tour de France by centuries, a name born from plague or battle or some long-forgotten catastrophe that scarred this bend of the Corrèze river so deeply that the wound became the place itself.
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -36,7 +36,10 @@
                     class="flex items-baseline justify-between gap-3 px-4 py-2 text-sm text-stone-700 hover:bg-amber-100 hover:text-correze-red transition-colors"
                     @click="parcoursOpen = false"
                   >
-                    <span>{{ entry.title }}</span>
+                    <div class="flex-1 min-w-0">
+                      <div class="truncate">{{ entry.title }}</div>
+                      <div v-if="entry.subtitle" class="text-xs text-stone-500 truncate mt-0.5">{{ entry.subtitle }}</div>
+                    </div>
                     <span class="text-xs text-stone-400 whitespace-nowrap">{{ formatDate(entry.publishDate) }}</span>
                   </NuxtLink>
                 </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
 
   app: {
     head: {
-      title: 'Corrèze Travelogue — Tour de France 2026 Stage 9',
+      title: 'Corrèze Travelogue - Tour de France 2026 Stage 9',
       meta: [
         { name: 'description', content: 'A cycling travelogue following the 185km route of Stage 9 of the 2026 Tour de France, from Malemort to Ussel through Corrèze.' }
       ],


### PR DESCRIPTION
## Summary

Fixes #343.

Two symptoms flagged during v1.4.0 review:
1. Segment 2's subtitle did not appear in the Parcours dropdown menu in the site header
2. Em-dashes visible in the dropdown and in the browser tab

## Diagnosis

The 'segment 2 subtitle missing' symptom turned out to be a **template bug affecting all entries, not a segment 2 data issue**. The Parcours dropdown in `layouts/default.vue` rendered only `entry.title` and `formatDate(entry.publishDate)` - no subtitle field was displayed at all. Segment 2 caught the user's eye because its title alone ('South of Brive') felt terse compared to segment 1's title + em-dash-separated descriptive phrase ('Malemort — Where Pain Meets Death'). Once I looked at the template, the fix was obvious: render the subtitle for every entry.

The em-dash symptom had three sources:
- Segment 1 frontmatter title and body H1: 'Malemort — Where Pain Meets Death'
- `nuxt.config.ts` site-wide page title: 'Corrèze Travelogue — Tour de France 2026 Stage 9'
- (Out of scope) segment 1 body narrative: 8+ em-dashes in published prose

## Changes

### `layouts/default.vue`

Parcours dropdown link template now stacks title and subtitle on the left, date still right-aligned:

```html
<NuxtLink ...>
  <div class='flex-1 min-w-0'>
    <div class='truncate'>{{ entry.title }}</div>
    <div v-if='entry.subtitle' class='text-xs text-stone-500 truncate mt-0.5'>{{ entry.subtitle }}</div>
  </div>
  <span class='text-xs text-stone-400 whitespace-nowrap'>{{ formatDate(entry.publishDate) }}</span>
</NuxtLink>
```

Every entry's subtitle now appears in the dropdown, consistent with the Latest Entries card list on the homepage.

### `content/entries/01-malemort-departure.md`

- Frontmatter title: 'Malemort — Where Pain Meets Death' → 'Malemort - Where Pain Meets Death'
- H1 heading on entry page: same change for consistency

Replacement character is a regular hyphen with spaces, matching the existing segment 0 preview pattern ('Correze - A Road Less Ridden').

### `nuxt.config.ts`

- `app.head.title`: 'Corrèze Travelogue — Tour de France 2026 Stage 9' → 'Corrèze Travelogue - Tour de France 2026 Stage 9'

The em-dash in the browser tab title was visible whenever anyone had the site open, and is the most high-traffic em-dash in the entire project.

## Out of scope

**Segment 1 body text still contains 8+ em-dashes** in narrative prose (e.g., 'a town that feels nothing like its name', '135 kilometers alone, holding off Coppi — Bobet — Bartali'). These are not visible in the dropdown, the Latest Entries list, or any hover state. They appear only when a reader opens segment 1's full entry page and scrolls through the body text. Fixing them:
- Revises shipped narrative content (segment 1 went live on 2026-04-05)
- Requires sensible replacement characters on each occurrence (some become commas, some periods, some parentheses)
- Is outside #343's dropdown-focused scope

Worth a separate small issue in a future release if the convention needs strict enforcement on shipped body text.

## Test plan

- [x] Latest Entries card list on homepage: no em-dashes, segment 2 subtitle visible, segment 1 title reads correctly with hyphen
- [x] Browser tab page title: no em-dash
- [x] Parcours dropdown template renders subtitle (visible after clicking Parcours in the header)
- [x] Visual browser check of the Parcours dropdown in the dev server (reviewer confirmation)
- [x] Confirm no test regressions

## Related

- Fixes #343
- Part of v1.4.0 - Keeping the reader commitment
- Segment 1 body em-dash cleanup is a separate potential follow-up