### PR TITLE
Fix Collonges-la-Rouge positioning, display, and narrative (#351, #352, #353)

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -346,7 +346,8 @@ function buildRiderAnnotations() {
     if (!stats || stats.totalDistanceCapped == null) continue
 
     const riderKm = stats.totalDistanceCapped - kmOffset
-    if (riderKm < 0 || riderKm > distances[distances.length - 1]) continue
+    const upperBound = distances[distances.length - 1] + 0.5
+    if (riderKm < 0 || riderKm > upperBound) continue
 
     let bestIdx = 0
     let bestDist = Infinity
@@ -368,6 +369,8 @@ function buildRiderAnnotations() {
     const jersey = getJerseyEmoji(rp.rider.id)
     const labelText = jersey ? `${jersey} ${rp.rider.name}` : rp.rider.name
 
+    // Flip label direction when rider is near the right edge of the chart
+    const nearRightEdge = rp.bestIdx >= distances.length - 3
     annotations[`rider-${rp.rider.id}`] = {
       type: 'line',
       xMin: rp.bestIdx,
@@ -384,7 +387,7 @@ function buildRiderAnnotations() {
         font: { size: 10, weight: 'bold' },
         padding: { top: 2, bottom: 2, left: 4, right: 4 },
         borderRadius: 3,
-        xAdjust: 8,
+        xAdjust: nearRightEdge ? -8 : 8,
       }
     }
   })

--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -85,6 +85,14 @@ const labelPlugin = {
       if (elevation === undefined) continue
       const elevPixel = yScale.getPixelForValue(elevation)
 
+      // Determine text alignment based on proximity to chart edges
+      const chartLeft = chart.chartArea.left
+      const chartRight = chart.chartArea.right
+      const edgeMargin = 40
+      let textAlign = 'center'
+      if (xPixel - chartLeft < edgeMargin) textAlign = 'left'
+      else if (chartRight - xPixel < edgeMargin) textAlign = 'right'
+
       // Draw emoji centered on the elevation point
       const emojiY = label.type === 'climb'
         ? elevPixel - 8
@@ -99,6 +107,7 @@ const labelPlugin = {
         ? emojiY - 14
         : emojiY + 14 + (label.extraOffset || 0)
       ctx.font = '10px sans-serif'
+      ctx.textAlign = textAlign
       ctx.textBaseline = 'middle'
       ctx.fillStyle = label.color
       ctx.fillText(label.name, xPixel, nameY)

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -62,7 +62,7 @@ for (const seg of segmentsJson) {
         const km = townKmPositions[town] ?? seg.km_start
         townSet.set(town, {
           name: town,
-          km: km.toFixed(0),
+          km: km.toFixed(1),
           elevation: seg.min_elevation
         })
       }

--- a/content/entries/03-the-causse-between.md
+++ b/content/entries/03-the-causse-between.md
@@ -1,7 +1,7 @@
 ---
 segment: 3
 title: "The Causse Between"
-subtitle: "Km 14-22: Across the causse corrézien toward Collonges"
+subtitle: "Km 14-22: Across the causse corrézien to Collonges-la-Rouge"
 publishDate: 2026-04-12
 dataCutoff: 2026-04-11
 kmStart: 14
@@ -54,7 +54,9 @@ To the south the ground falls away toward Queyssac les Vignes and Branceilles, a
 
 There is also the vin de noix, which belongs to the other larder. The rule is the rule of forties: four litres of wine, one of eau-de-vie, forty green walnuts quartered, forty cubes of sugar, forty days. The walnuts must be cut at midsummer, while the shell is still soft enough that a kitchen knife goes through the whole nut like an apple. The fingers that quarter them will be black for a week, because the husk of a green walnut was once the cheap iodine of the Corrèze and the staining is what the iodine did. A jar of the stuff macerating on a kitchen windowsill on the Saint-Jean is less a recipe than an almanac; it tells the household, and whoever is passing, where it stands in the year.
 
-The cyclist, now crossing the ridge at its most modest, can see no vines and no walnuts. What the cyclist sees, a kilometre ahead and still only as a promise, is a cluster of roofs the wrong colour for limestone.
+The cyclist, now crossing the ridge at its most modest, can see no vines and no walnuts. What the cyclist sees, a kilometre ahead, is a cluster of roofs the wrong colour for limestone.
+
+Those roofs are Collonges-la-Rouge. The route clips the edge of the village at the very end of this segment, just long enough to register the red sandstone — iron oxide in the local grès, the same stuff that colours the soil after rain — before the road bends east and carries on. In July the peloton will pass through here at fifty kilometres an hour, which is time enough to notice the colour and nothing else. The carved tympanum, the Maison de la Sirène, the story of how a village mayor invented the Plus Beaux Villages de France — all of it will be behind them before the television cameras have finished panning. Some places are seen; Collonges, from a bicycle at speed, is only glimpsed.
 
 [^denoix]: Maison Denoix, https://www.denoix.com/en/violet-mustard
 [^must]: A Gardener's Table on making purple mustard from grape must, https://agardenerstable.com/purple-mustard-from-homemade-must/

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -19,7 +19,7 @@
       class="mb-8"
     />
 
-    <ElevationChart :elevation-data="elevationData" :segments="segments" :current-segment="page.segment" :rider-stats="riderSnapshot?.stats || riderStats" :rider-config="riderConfig" :rider-points="riderSnapshot?.points || null" class="mb-8" />
+    <ElevationChart :elevation-data="elevationData" :segments="segments" :current-segment="page.segment" :rider-stats="riderSnapshot?.stats || riderStats" :rider-config="riderConfig" :rider-points="riderSnapshot?.points || riderPoints" class="mb-8" />
 
     <PowerStats :elevation-data="elevationData" class="mb-8" />
 
@@ -103,6 +103,14 @@ try {
   riderStats.value = data.default || data
 } catch {
   riderStats.value = null
+}
+
+const riderPoints = ref(null)
+try {
+  const data = await import('~/data/riders/points.json')
+  riderPoints.value = data.default || data
+} catch {
+  riderPoints.value = null
 }
 
 // Load route coordinates


### PR DESCRIPTION
## Summary
- **#351** StageDetails town km: `.toFixed(0)` -> `.toFixed(1)` so Collonges shows as 21.8 not 22
- **#352** ElevationChart labels: detect proximity to chart edges and adjust text alignment (`left`/`right` instead of `center`) so long names are not clipped
- **#353** Segment 3 narrative: subtitle changed from "toward Collonges" to "to Collonges-la-Rouge"; tease ending replaced with arrival paragraph acknowledging the red sandstone and the speed at which the peloton will pass through
- **#355** Riders at exact segment endpoint (e.g., 22.0km) were filtered out because their relative position exceeded the last elevation data point (7.990 < 8.0). Added 0.5km tolerance and flipped rider label direction near right edge

## Test plan
- [x] 83/83 tests pass
- [x] Collonges-la-Rouge label visible on segment 3 elevation chart
- [x] Visual check: riders at 22km now appear on segment 3 elevation chart
- [x] Visual check: rider labels near right edge are not clipped
- [x] Visual check: StageDetails shows "km 21.8" for Collonges
- [x] Read the revised ending paragraph in context

Closes #351, #352, #353, #355