### PR TITLE
Rescue segment 4 narrative into git

### DIFF
--- a/content/entries/04-the-meyssac-fault.md
+++ b/content/entries/04-the-meyssac-fault.md
@@ -1,17 +1,62 @@
 ---
 segment: 4
 title: "The Meyssac Fault"
-subtitle: "Km 22-28: Across the fault line and up through the chestnuts"
+subtitle: "Km 22-28: Red stone to white, Bourrue to Marigoule"
 publishDate: 2026-04-15
+dataCutoff: 2026-04-14
 kmStart: 22
 kmEnd: 28
 gpxFile: /gpx/segment-04.gpx
 elevationData: /data/elevation/segment-04.json
-images: [{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Collonges-la-Rouge%2C_sous_la_pluie_-_panoramio.jpg/960px-Collonges-la-Rouge%2C_sous_la_pluie_-_panoramio.jpg","alt":"Collonges-la-Rouge, sous la pluie","author":"Gilles Guillamot","authorUrl":"https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge,_sous_la_pluie_-_panoramio.jpg","license":"CC BY-SA 3.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge,_sous_la_pluie_-_panoramio.jpg"},{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Correze_Collonges-La-Rouge_Castel_De_Maussac_28052012_-_panoramio.jpg/960px-Correze_Collonges-La-Rouge_Castel_De_Maussac_28052012_-_panoramio.jpg","alt":"Correze Collonges-La-Rouge Castel De Maussac 28052012","author":"rene boulay","authorUrl":"https://commons.wikimedia.org/wiki/File:Correze_Collonges-La-Rouge_Castel_De_Maussac_28052012_-_panoramio.jpg","license":"CC BY-SA 3.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Correze_Collonges-La-Rouge_Castel_De_Maussac_28052012_-_panoramio.jpg"},{"src":"https://upload.wikimedia.org/wikipedia/commons/b/bc/Croquis_aquarell%C3%A9-_Collonges_la_Rouge_-_France_%285893019665%29.jpg","alt":"croquis stylo à bille aquarellé d'après photo perso  /  ballpoint watercoloured sketch from a personal photo\nCollonges la Rouge est un très joli village constitué de très belles maisons multicenten","author":"Guy MOLL from Faro, Portugal","authorUrl":"https://commons.wikimedia.org/wiki/File:Croquis_aquarell%C3%A9-_Collonges_la_Rouge_-_France_(5893019665).jpg","license":"CC BY 2.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Croquis_aquarell%C3%A9-_Collonges_la_Rouge_-_France_(5893019665).jpg"}]
-weather: null
-draft: true
+images: [{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Meyssac_-_%C3%89glise_03.jpg/960px-Meyssac_-_%C3%89glise_03.jpg","alt":"Église Saint-Vincent de Meyssac","author":"A1AA1A","authorUrl":"https://commons.wikimedia.org/wiki/File:Meyssac_-_%C3%89glise_03.jpg","license":"CC BY-SA 4.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Meyssac_-_%C3%89glise_03.jpg"},{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Pan%C3%A8l_Mai%C3%A7ac.jpg/960px-Pan%C3%A8l_Mai%C3%A7ac.jpg","alt":"Panèl d'intrada de Maiçac.","author":"GosGroc","authorUrl":"https://commons.wikimedia.org/wiki/File:Pan%C3%A8l_Mai%C3%A7ac.jpg","license":"CC0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Pan%C3%A8l_Mai%C3%A7ac.jpg"},{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg/960px-Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg","alt":"Boîte à livres à Meyssac","author":"NATHALIE FOURNIER","authorUrl":"https://commons.wikimedia.org/wiki/File:Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg","license":"CC BY-SA 4.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/4.0/","sourceUrl":"https://commons.wikimedia.org/wiki/File:Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg"}]
+weather: {"fetchedAt": "2026-04-15", "current": {"temp": 11, "conditions": "Scattered clouds", "wind": "5 km/h N"}, "forecast": null}
+draft: false
 ---
 
 # The Meyssac Fault
 
-*Content coming soon.*
+
+The red drains from the walls within the first half-kilometre. The route drops steeply out of Collonges, forty metres in six hundred, the sharpest descent the stage has produced so far, and by the time the road levels in the valley, the sandstone has given way to something paler and older in a different direction. The cyclist who registered the red and nothing else now watches it give way to white, and realises they have crossed to the other side of a boundary that geologists have been arguing about for a century.
+
+## The fault
+
+The Meyssac fault runs roughly north-south through the communes of Collonges, Meyssac, and Noailhac, and what it separates is not merely two kinds of stone but two intervals of deep time that have no business being neighbours. To the west lie the red sandstones of the Brive basin, Permian and Triassic sediments deposited between three hundred and two hundred and thirty million years ago as the eroding Massif Central shed its debris into a hot, semi-arid lowland; the iron oxides that give the stone its colour are, in effect, the chemical residue of a climate that ceased to exist before the first dinosaur. To the east lie Jurassic limestones, seventy to eighty million years younger, from a period when a shallow sea covered the same ground. The fault, whatever its precise tectonic origins (these remain disputed, which is the geologists' way of saying that nobody has a theory the others will accept), puts these two worlds side by side with the neatness of a museum display and none of the explanatory labelling.
+
+What makes the Meyssac fault unusual is not the geology but the legibility. The boundary is readable in the built environment. West of the fault the villages are red; east of it they are white; and at Meyssac itself, standing directly on the line, both colours appear in the same walls, which is the sort of detail one might invent for a lecture and which happens, in this case, to be true.
+
+## The grain hall
+
+![Meyssac Halle aux grains](https://upload.wikimedia.org/wikipedia/commons/thumb/6/62/Halle-%C3%A0-grains-%C3%A0-Meyssac-DSC_0817.jpg/1920px-Halle-%C3%A0-grains-%C3%A0-Meyssac-DSC_0817.jpg)
+
+The halle aux grains in the centre of Meyssac is the building where the fault becomes, quite literally, architecture. Red sandstone columns, quarried from the Puy de Valege to the west, support a roof of dark Travassac slate on a frame of chestnut timber. Three materials from three geological zones, joined in a single eighteenth-century market building that was designed to store grain and stores, without any evident intention to do so, a lesson in the relationship between what lies underfoot and what gets built on top of it.
+
+The church of Saint-Vincent stands nearby, its bell tower red sandstone and its tympanum carved in white limestone, as though the masons had wished to make the fault legible even to the faithful. The patron saint of winegrowers presides over a town that lost its vineyards to phylloxera in the 1880s and never replanted, which gives the dedication a retrospective irony that the twelfth century could not have foreseen. Meyssac is not Collonges. It is not a museum village or a candidate for anybody's list of the most beautiful anything. It is a working market town where the cattle fair still runs in the square beneath the hall, and where the architecture tells the truth about the ground because nobody saw any reason to make it do otherwise.
+
+## Puy Boubou
+
+Beyond Meyssac the road begins to climb, and it does not stop. One hundred and ninety-four metres of elevation gain over four kilometres, at gradients that average four and a half per cent with occasional pitches above seven. This is Puy Boubou, the first categorised climb of the stage, and the landscape changes with the altitude in a manner that is by now predictable in its essentials if not in its details. The open causse gives way to chestnut forest. The walls close in. The light, which has been generous since Collonges, begins to ration itself.
+
+
+![Eglise Saint Pierre](https://upload.wikimedia.org/wikipedia/commons/6/69/Noailhac%2C_Corr%C3%A8ze%2C_%C3%A9glise_Saint-Pierre-%C3%A8s-Liens-PM_18573.jpg)
+
+The chestnuts mark the granite. They grow where the soil turns acid, where the limestone ends and the crystalline basement of the Massif Central begins, and their presence on these slopes constitutes the third geological transition the cyclist has crossed in six kilometres: red sandstone to white limestone to granite and chestnut. It is a great deal of earth history for a short afternoon. The chestnut was once the staple crop of this country, l'arbre a pain, the bread tree. By the early eighteenth century, forty per cent of Limousin land was under chestnut forest; the nuts fed the poor when the grain harvest failed, the wood built the roof frames, the husks yielded the iodine.
+
+The old trees were Castanea sativa, the European sweet chestnut, and the varieties had local names: Bourrue, Jalade, Grosse Rouge, Vire-Vent. They grew wild or half-wild, unirrigated, on slopes that suited nothing else, and their flavour was, by all contemporary accounts, very good. What replaced them, after the ink disease and the decades of abandonment, were grafted orchards of a different character entirely. Marigoule, the most widely planted hybrid in France, is a cross between European and Japanese chestnut selected in 1986 from an orchard at Ussac, a few kilometres from the stage start at Malemort. Bouche de Betizac, its commercial partner, was bred at the INRA station at Malemort itself in 1962. Both are grafted onto ink-resistant rootstock. Bouche de Betizac is pollen-sterile, which means a Marigoule must stand nearby in every orchard to do the pollinating, and a Correze chestnut orchard is therefore a collaboration between two varieties that were both invented within sight of the departure line. The old Bourrues and Jalades are still grown, still celebrated at the chestnut festival in Beynat a few kilometres ahead, but the commercial weight has shifted to the hybrids, and the slopes the cyclist climbs through are as much laboratory as landscape.
+
+
+![Châtaignier greffé pour produire des châtaignier Vernaise. (grafted chestnut tree)](https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Ch%C3%A2taignier_greff%C3%A9.jpg/960px-Ch%C3%A2taignier_greff%C3%A9.jpg?_=20190717081958)
+
+The riders climb through the commune of Collonges-la-Rouge without seeing the village. The administrative boundary extends over this ridge, which means that the most famous red-sandstone village in France technically contains a hillside of chestnut forest and a categorised climb. A medieval viscount would have understood the arrangement perfectly. The land belongs to whoever holds the high ground above it.
+
+## The bougnats
+
+
+![Bougnat de Paris](https://upload.wikimedia.org/wikipedia/commons/0/0c/Bougnat_de_Paris.JPG)
+
+The chestnuts did not last. In the 1880s, the decade that had already taken the vines, a fungal disease called ink disease arrived from the south and began killing the trees. Phytophthora cinnamomi turns the sap black and rots the roots; twenty thousand hectares of chestnut forest were lost within fifty years. The vines and the chestnuts collapsed together, which left the young men of the Correze with a landscape that could no longer feed them and a railway that could take them somewhere else.
+
+They went to Paris. They carried water first, then delivered coal, then sold wine from the same premises, Vins et Charbon painted above the door, the husband hauling sacks up six flights while the wife poured glasses below. The word for them was bougnat, a contraction variously attributed to charbonnier and Auvergnat, though the etymology is contested and in any case the name stuck to people from across the Massif Central, not merely those from the Auvergne. By the middle of the twentieth century the bougnats and their descendants owned more than eighty per cent of the cafes and tabacs in Paris. Les Deux Magots, where Sartre held court. La Coupole, where Hemingway drank. Le Flore, where Beauvoir argued. The literary cafes of the Left Bank were bougnat houses, founded and run by families who had looked at precisely this landscape, these chestnut slopes, these limestone valleys, and concluded that whatever life remained in the country was not enough to hold them. That the Correze thereby furnished Paris with its intellectual infrastructure is an irony the department has learned to bear with a certain wry patience.
+
+## The summit
+
+The road crests at three hundred and eighty-one metres and the country opens. The chestnut forest thins. The sky, which has been screened by branches for the better part of an hour, reasserts itself. Below and behind, the red-and-white corridor of the fault is already invisible, folded into the valley the cyclist has climbed out of. Ahead the terrain is higher, emptier, and less forgiving. The lowlands are finished. What comes next will ask more of the legs than anything the route has asked so far, and the legs, at this point, have not been asked very much.

--- a/data/image-suggestions/segment-04.json
+++ b/data/image-suggestions/segment-04.json
@@ -1,9 +1,11 @@
 {
   "segment": 4,
   "towns": [
-    "Collonges-la-Rouge"
+    "Meyssac"
   ],
-  "climbs": [],
+  "climbs": [
+    "Puy Boubou"
+  ],
   "image_count": 50,
   "images": [
     {
@@ -128,17 +130,6 @@
       "description": "<p>Collonges-la-Rouge (Corrèze).\n</p><p>La maison de Maussac.\n</p><p>En 1415, Aymar de Chaunac aurait rendu hommage au vicomte pour son hôtel de Maussac à Collonges. En fait, il semble qu'\"il s'agisse"
     },
     {
-      "title": "File:Collonges-la-Rouge (Corrèze). (28433420170).jpg",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg",
-      "full_url": "https://upload.wikimedia.org/wikipedia/commons/0/0b/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg",
-      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(28433420170).jpg",
-      "width": 4928,
-      "height": 3264,
-      "license": "CC BY 2.0",
-      "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
-      "description": "<p>Collonges-la-Rouge (Corrèze).\n</p><p>L'église Saint-Pierre.\n</p><p>Collonges aurait d'abord été un petit prieuré de l'abbaye de Charroux (\"Curia Coloniense\" citée dans le cartulaire de Charroux au "
-    },
-    {
       "title": "File:Collonges-la-Rouge (Corrèze). (29068808503).jpg",
       "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829068808503%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829068808503%29.jpg",
       "full_url": "https://upload.wikimedia.org/wikipedia/commons/1/12/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829068808503%29.jpg",
@@ -148,6 +139,17 @@
       "license": "CC BY 2.0",
       "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
       "description": "<p>Collonges-la-Rouge (Corrèze).\n</p><p>La maison de Maussac.\n</p><p>En 1415, Aymar de Chaunac aurait rendu hommage au vicomte pour son hôtel de Maussac à Collonges. En fait, il semble qu'\"il s'agisse"
+    },
+    {
+      "title": "File:Collonges-la-Rouge (Corrèze). (28433420170).jpg",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg",
+      "full_url": "https://upload.wikimedia.org/wikipedia/commons/0/0b/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828433420170%29.jpg",
+      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(28433420170).jpg",
+      "width": 4928,
+      "height": 3264,
+      "license": "CC BY 2.0",
+      "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
+      "description": "<p>Collonges-la-Rouge (Corrèze).\n</p><p>L'église Saint-Pierre.\n</p><p>Collonges aurait d'abord été un petit prieuré de l'abbaye de Charroux (\"Curia Coloniense\" citée dans le cartulaire de Charroux au "
     },
     {
       "title": "File:Collonges-la-Rouge (Corrèze). (29657961246).jpg",
@@ -183,15 +185,37 @@
       "description": "<p>Collonges-la-Rouge (Corrèze)\n</p><p>Ruelles. \n</p><p>Le grés rouge, caractéristique de Collonges, provient de la faille de Meyssac (que suit la départementale 38). Les carrières s'étendaient de Mey"
     },
     {
-      "title": "File:Collonges-la-Rouge (Corrèze). (28840808441).jpg",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828840808441%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828840808441%29.jpg",
-      "full_url": "https://upload.wikimedia.org/wikipedia/commons/b/b6/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828840808441%29.jpg",
-      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(28840808441).jpg",
+      "title": "File:Collonges-la-Rouge (Corrèze). (29096384102).jpg",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829096384102%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829096384102%29.jpg",
+      "full_url": "https://upload.wikimedia.org/wikipedia/commons/8/80/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829096384102%29.jpg",
+      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(29096384102).jpg",
       "width": 4928,
       "height": 3264,
       "license": "CC BY 2.0",
       "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
-      "description": "<p>Collonges-la-Rouge (Corrèze)\n</p><p>Ruelles. \n</p><p>Le grés rouge, caractéristique de Collonges, provient de la faille de Meyssac (que suit la départementale 38). Les carrières s'étendaient de Mey"
+      "description": "<p>Collonges-la-Rouge (Corrèze)\n</p><p>Château de Vassignac ou Vassinhac.\n</p><p>Le Castel de Vassinhac fut construit en 1583 par la plus puissante famille de Collonges, les Vassinhac. C'est un grand "
+    },
+    {
+      "title": "File:Collonges-la-Rouge (Corrèze). (29125330871).jpg",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829125330871%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829125330871%29.jpg",
+      "full_url": "https://upload.wikimedia.org/wikipedia/commons/1/18/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829125330871%29.jpg",
+      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(29125330871).jpg",
+      "width": 4928,
+      "height": 3264,
+      "license": "CC BY 2.0",
+      "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
+      "description": "<p>Collonges-la-Rouge (Corrèze)\n</p><p>Château de Vassignac ou Vassinhac.\n</p><p>Le Castel de Vassinhac fut construit en 1583 par la plus puissante famille de Collonges, les Vassinhac. C'est un grand "
+    },
+    {
+      "title": "File:Collonges-la-Rouge (Corrèze). (29169593886).jpg",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829169593886%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829169593886%29.jpg",
+      "full_url": "https://upload.wikimedia.org/wikipedia/commons/8/83/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2829169593886%29.jpg",
+      "description_url": "https://commons.wikimedia.org/wiki/File:Collonges-la-Rouge_(Corr%C3%A8ze)._(29169593886).jpg",
+      "width": 4928,
+      "height": 3264,
+      "license": "CC BY 2.0",
+      "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://www.flickr.com/people/26082117@N07\">Daniel Jolivet</a>",
+      "description": "<p>Collonges-la-Rouge (Corrèze)\n</p><p>Château de Vassignac ou Vassinhac.\n</p><p>Le Castel de Vassinhac fut construit en 1583 par la plus puissante famille de Collonges, les Vassinhac. C'est un grand "
     },
     {
       "title": "File:Collonges-la-Rouge Château de Vassinhac.jpg",
@@ -403,17 +427,6 @@
       "description": "Cascade entourée de mousses, fougères et de rameaux de lierre pendants, s'écoulant sur un lit de pierres de gré rouge"
     },
     {
-      "title": "File:Église de la Nativité-de-Notre-Dame de Lagleygeolle.jpg",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/%C3%89glise_de_la_Nativit%C3%A9-de-Notre-Dame_de_Lagleygeolle.jpg/960px-%C3%89glise_de_la_Nativit%C3%A9-de-Notre-Dame_de_Lagleygeolle.jpg",
-      "full_url": "https://upload.wikimedia.org/wikipedia/commons/a/a2/%C3%89glise_de_la_Nativit%C3%A9-de-Notre-Dame_de_Lagleygeolle.jpg",
-      "description_url": "https://commons.wikimedia.org/wiki/File:%C3%89glise_de_la_Nativit%C3%A9-de-Notre-Dame_de_Lagleygeolle.jpg",
-      "width": 1976,
-      "height": 4608,
-      "license": "CC BY-SA 4.0",
-      "artist": "<a href=\"//commons.wikimedia.org/wiki/User:Conlinp\" title=\"User:Conlinp\">Conlinp</a>",
-      "description": "Église de la Nativité-de-Notre-Dame de Lagleygeolle"
-    },
-    {
       "title": "File:Meyssac - Place de la Halle - boîte à livres.jpg",
       "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg/960px-Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg",
       "full_url": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Meyssac_-_Place_de_la_Halle_-_bo%C3%AEte_%C3%A0_livres.jpg",
@@ -422,6 +435,17 @@
       "height": 2500,
       "license": "CC BY-SA 4.0",
       "artist": "NATHALIE FOURNIER",
+      "description": "Boîte à livres à Meyssac"
+    },
+    {
+      "title": "File:Meyssac - pump track - boîte à livres.jpg",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg/960px-Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
+      "full_url": "https://upload.wikimedia.org/wikipedia/commons/5/59/Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
+      "description_url": "https://commons.wikimedia.org/wiki/File:Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
+      "width": 1875,
+      "height": 2500,
+      "license": "CC BY-SA 4.0",
+      "artist": "Sabichouquette",
       "description": "Boîte à livres à Meyssac"
     },
     {
@@ -434,17 +458,6 @@
       "license": "CC BY-SA 4.0",
       "artist": "Sabichouquette",
       "description": "Boîte à livres à Collonges-la-Rouge"
-    },
-    {
-      "title": "File:Meyssac - pump track - boîte à livres.jpg",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg/960px-Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
-      "full_url": "https://upload.wikimedia.org/wikipedia/commons/5/59/Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
-      "description_url": "https://commons.wikimedia.org/wiki/File:Meyssac_-_pump_track_-_bo%C3%AEte_%C3%A0_livres.jpg",
-      "width": 1875,
-      "height": 2500,
-      "license": "CC BY-SA 4.0",
-      "artist": "Sabichouquette",
-      "description": "Boîte à livres à Meyssac"
     },
     {
       "title": "File:Correze Collonges-La-Rouge Castel De Maussac 28052012 - panoramio.jpg",
@@ -478,17 +491,6 @@
       "license": "CC BY-SA 3.0",
       "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://web.archive.org/web/20161103124300/http://www.panoramio.com/user/7081175?with_photo_id=132113636\">rene boulay</a>",
       "description": "Correze Collonges-La-Rouge Castel De Maussac Vue Sur La Ville 28052012"
-    },
-    {
-      "title": "File:Correze Collonges-La-Rouge Rue Noire 28052012 - panoramio.jpg",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Correze_Collonges-La-Rouge_Rue_Noire_28052012_-_panoramio.jpg/960px-Correze_Collonges-La-Rouge_Rue_Noire_28052012_-_panoramio.jpg",
-      "full_url": "https://upload.wikimedia.org/wikipedia/commons/f/f9/Correze_Collonges-La-Rouge_Rue_Noire_28052012_-_panoramio.jpg",
-      "description_url": "https://commons.wikimedia.org/wiki/File:Correze_Collonges-La-Rouge_Rue_Noire_28052012_-_panoramio.jpg",
-      "width": 1600,
-      "height": 1200,
-      "license": "CC BY-SA 3.0",
-      "artist": "<a rel=\"nofollow\" class=\"external text\" href=\"https://web.archive.org/web/20161103124325/http://www.panoramio.com/user/7081175?with_photo_id=132113638\">rene boulay</a>",
-      "description": "Correze Collonges-La-Rouge Rue Noire 28052012"
     },
     {
       "title": "File:Strange Fly 1 (3837330243).jpg",


### PR DESCRIPTION
## Summary

- The segment 4 entry "The Meyssac Fault" was committed to main as \`0133d3d\` on 2026-04-12 at 18:26 and lost three hours later when \`git reset --hard origin/main\` was used to resolve divergence with dependabot PR #324.
- The text was recovered from conversation context and deployed to production on Wed 2026-04-15 on schedule, but the commit itself was never restored to git.
- Production and main have been diverged since then: production serves the full narrative (last-modified 2026-04-15 21:30 GMT) while main still carries the \`Content coming soon\` stub with \`draft: true\`.
- This PR restores the narrative so that main matches production, and brings in the matching \`data/image-suggestions/segment-04.json\` update (towns: Meyssac, climbs: Puy Boubou, Meyssac images swapped in).

## Why a feature branch this time

The v1.4.2 planning notes (2026-04-15) flagged the lost commit as a process issue and raised the question: should content commits always go through a feature branch + PR so they survive force-resets? This PR is the incident's own answer — content never lives only in the working tree, and never sits on main as an uncommitted working copy.

Worth a retro discussion to decide whether this becomes a durable rule.

## Test plan

- [ ] \`git diff main...\` shows only two files modified: the segment 4 entry and its image suggestions
- [ ] Pulling merged main and running \`npx nuxt generate\` produces output matching current production for \`/entries/04-the-meyssac-fault/\`
- [ ] \`curl -sL https://tour26.iamsosmrt.com/entries/04-the-meyssac-fault/\` continues to serve the full narrative after the next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)