### PR TITLE
Resolve points-config vs segments.json divergence (#362)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           processing/.venv/bin/python -m pytest processing/tests/ \
             --cov=processing --cov-report=json:coverage/python-coverage.json
 
+      - name: Validate points-config vs segments.json
+        run: processing/.venv/bin/python processing/validate_points.py
+
       - name: Seed rider data if missing
         run: |
           [ -f data/riders/daily-log.json ] || cp data/riders/daily-log.example.json data/riders/daily-log.json

--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -1,5 +1,5 @@
 {
-  "description": "Sprint and climbing point locations for the rider competition",
+  "description": "Sprint and climbing point locations for the rider competition. Single source of truth for climb identity, summit segment, and span — split_gpx.py imports from here and segments.json is generated accordingly. Validated by processing/validate_points.py.",
   "sprints": [
     {
       "name": "Sprint - Brive-la-Gaillarde",
@@ -34,9 +34,10 @@
   ],
   "climbs": [
     {
-      "name": "Cote de Malemort",
+      "name": "Côte de Malemort",
       "segment": 1,
       "km": 5,
+      "length_km": null,
       "category": 4,
       "gradient": 3.2,
       "points": [2, 1, 0, 0]
@@ -45,30 +46,34 @@
       "name": "Puy Boubou",
       "segment": 5,
       "km": 32.8,
+      "length_km": 2.8,
       "category": 3,
       "gradient": 4.1,
       "points": [4, 3, 2, 1]
     },
     {
-      "name": "Cote de Lagleygeolle",
+      "name": "Côte de Lagleygeolle",
       "segment": 7,
       "km": 43.2,
+      "length_km": 5.2,
       "category": 4,
       "gradient": 3.9,
       "points": [2, 1, 0, 0]
     },
     {
-      "name": "Cote de Miel",
+      "name": "Côte de Miel",
       "segment": 9,
       "km": 56.6,
+      "length_km": 6.6,
       "category": 4,
       "gradient": 3.9,
       "points": [2, 1, 0, 0]
     },
     {
-      "name": "Cote des Naves",
+      "name": "Côte des Naves",
       "segment": 11,
       "km": 74.8,
+      "length_km": 2.8,
       "category": 2,
       "gradient": 6.7,
       "points": [6, 4, 2, 1]
@@ -77,6 +82,7 @@
       "name": "Puy de Lachaud",
       "segment": 13,
       "km": 85.6,
+      "length_km": 3.6,
       "category": 2,
       "gradient": 5.3,
       "points": [6, 4, 2, 1]
@@ -85,14 +91,16 @@
       "name": "Suc au May",
       "segment": 15,
       "km": 104.8,
+      "length_km": 3.8,
       "category": "HC",
       "gradient": 7.7,
       "points": [10, 8, 6, 4]
     },
     {
-      "name": "Cote de la Croix de Pey",
+      "name": "Côte de la Croix de Pey",
       "segment": 19,
       "km": 127,
+      "length_km": 7,
       "category": 3,
       "gradient": 4.9,
       "points": [4, 3, 2, 1]
@@ -101,14 +109,16 @@
       "name": "Mont Bessou",
       "segment": 22,
       "km": 153,
+      "length_km": 5,
       "category": 4,
       "gradient": 3.5,
       "points": [2, 1, 0, 0]
     },
     {
-      "name": "Cote des Gardes",
+      "name": "Côte des Gardes",
       "segment": 24,
       "km": 167.2,
+      "length_km": 2.2,
       "category": 3,
       "gradient": 4.8,
       "points": [4, 3, 2, 1]

--- a/data/segments.json
+++ b/data/segments.json
@@ -15,7 +15,9 @@
     "towns": [
       "Malemort"
     ],
-    "climbs": []
+    "climbs": [
+      "Côte de Malemort"
+    ]
   },
   {
     "segment": 2,
@@ -70,9 +72,7 @@
     "towns": [
       "Meyssac"
     ],
-    "climbs": [
-      "Puy Boubou"
-    ]
+    "climbs": []
   },
   {
     "segment": 5,
@@ -88,7 +88,9 @@
     "max_elevation": 404,
     "notable_points": [],
     "towns": [],
-    "climbs": []
+    "climbs": [
+      "Puy Boubou"
+    ]
   },
   {
     "segment": 6,
@@ -107,7 +109,7 @@
       "Beynat"
     ],
     "climbs": [
-      "C\u00f4te de Lagleygeolle"
+      "Côte de Lagleygeolle"
     ]
   },
   {
@@ -125,7 +127,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "C\u00f4te de Lagleygeolle"
+      "Côte de Lagleygeolle"
     ]
   },
   {
@@ -143,7 +145,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "C\u00f4te de Miel"
+      "Côte de Miel"
     ]
   },
   {
@@ -161,7 +163,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "C\u00f4te de Miel"
+      "Côte de Miel"
     ]
   },
   {
@@ -199,7 +201,7 @@
       "Naves"
     ],
     "climbs": [
-      "C\u00f4te des Naves"
+      "Côte des Naves"
     ]
   },
   {
@@ -323,7 +325,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "C\u00f4te de la Croix de Pey"
+      "Côte de la Croix de Pey"
     ]
   },
   {
@@ -343,7 +345,7 @@
       "Bugeat"
     ],
     "climbs": [
-      "C\u00f4te de la Croix de Pey"
+      "Côte de la Croix de Pey"
     ]
   },
   {
@@ -429,7 +431,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "C\u00f4te des Gardes"
+      "Côte des Gardes"
     ]
   },
   {

--- a/processing/split_gpx.py
+++ b/processing/split_gpx.py
@@ -24,17 +24,38 @@ KNOWN_TOWNS = {
     "Ussel": 182.5,
 }
 
-KNOWN_CLIMBS = {
-    "Puy Boubou": {"km_start": 30, "km_end": 32.8, "gradient": 4.1},
-    "Côte de Lagleygeolle": {"km_start": 38, "km_end": 43.2, "gradient": 3.9},
-    "Côte de Miel": {"km_start": 50, "km_end": 56.6, "gradient": 3.9},
-    "Côte des Naves": {"km_start": 72, "km_end": 74.8, "gradient": 6.7},
-    "Puy de Lachaud": {"km_start": 82, "km_end": 85.6, "gradient": 5.3},
-    "Suc au May": {"km_start": 101, "km_end": 104.8, "gradient": 7.7},
-    "Côte de la Croix de Pey": {"km_start": 120, "km_end": 127, "gradient": 4.9},
-    "Mont Bessou": {"km_start": 148, "km_end": 153, "gradient": 3.5},
-    "Côte des Gardes": {"km_start": 165, "km_end": 167.2, "gradient": 4.8},
-}
+POINTS_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "data", "competition", "points-config.json"
+)
+
+
+def load_known_climbs(path=POINTS_CONFIG_PATH):
+    """Load climbs from points-config.json as {name: {km_start, km_end, gradient}}.
+
+    The summit km is `km` in points-config. length_km may be null, in which case
+    the climb is treated as a point-mark (km_start == km_end == summit).
+    """
+    with open(path) as f:
+        config = json.load(f)
+    climbs = {}
+    for c in config["climbs"]:
+        summit = c["km"]
+        length = c.get("length_km")
+        if length is None:
+            km_start = summit
+            km_end = summit
+        else:
+            km_start = summit - length
+            km_end = summit
+        climbs[c["name"]] = {
+            "km_start": km_start,
+            "km_end": km_end,
+            "gradient": c.get("gradient"),
+        }
+    return climbs
+
+
+KNOWN_CLIMBS = load_known_climbs()
 
 
 def haversine(lat1, lon1, lat2, lon2):
@@ -71,7 +92,21 @@ def parse_gpx(gpx_path):
     return points
 
 
-def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0):
+def load_existing_towns(path):
+    """Return {segment_number: [towns]} from an existing segments.json if present.
+
+    Used to preserve hand-verified town assignments (#342) that the km-bbox logic
+    below would otherwise regress. The structural fix for town assignment is
+    tracked in #341.
+    """
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    return {s["segment"]: s.get("towns", []) for s in data}
+
+
+def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0, existing_towns=None):
     """Split points into segments with alternating lengths.
 
     Odd segments (1,3,5,...) are odd_length km.
@@ -125,11 +160,16 @@ def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0
             for i in range(1, len(seg_points))
         )
 
-        # Find towns in this segment
-        towns = [
-            name for name, km in KNOWN_TOWNS.items()
-            if km_start <= km <= km_end
-        ]
+        # Find towns in this segment. Prefer hand-verified assignments from an
+        # existing segments.json (see #342) over the km-bbox heuristic, since
+        # the heuristic is known-wrong and its structural fix is tracked in #341.
+        if existing_towns and seg_num in existing_towns:
+            towns = existing_towns[seg_num]
+        else:
+            towns = [
+                name for name, km in KNOWN_TOWNS.items()
+                if km_start <= km <= km_end
+            ]
 
         # Find climbs in this segment
         climbs = [
@@ -198,7 +238,11 @@ def main():
     points = parse_gpx(args.gpx)
     print(f"Parsed {len(points)} trackpoints")
 
-    segments = split_into_segments(points, args.num_segments, args.odd_length, args.even_length)
+    existing_towns = load_existing_towns(args.json_output)
+    segments = split_into_segments(
+        points, args.num_segments, args.odd_length, args.even_length,
+        existing_towns=existing_towns,
+    )
     print(f"Created {len(segments)} segments")
 
     # Write individual segment GPX files

--- a/processing/tests/test_validate_points.py
+++ b/processing/tests/test_validate_points.py
@@ -1,0 +1,85 @@
+"""Tests for validate_points.py — cross-check between points-config and segments.json."""
+
+import json
+import os
+
+import pytest
+
+from processing.validate_points import validate
+
+
+@pytest.fixture
+def minimal_segments():
+    return [
+        {"segment": 1, "km_start": 0.0, "km_end": 8.0, "climbs": []},
+        {"segment": 2, "km_start": 8.0, "km_end": 14.0, "climbs": []},
+        {"segment": 3, "km_start": 14.0, "km_end": 22.0, "climbs": []},
+        {"segment": 4, "km_start": 22.0, "km_end": 28.0, "climbs": []},
+        {"segment": 5, "km_start": 28.0, "km_end": 36.0, "climbs": []},
+    ]
+
+
+class TestClimbValidation:
+    def test_summit_in_declared_segment_passes(self, minimal_segments):
+        minimal_segments[4]["climbs"] = ["Puy Boubou"]
+        config = {"climbs": [{"name": "Puy Boubou", "segment": 5, "km": 32.8, "length_km": 2.8}]}
+        assert validate(config, minimal_segments) == []
+
+    def test_summit_outside_declared_segment_fails(self, minimal_segments):
+        minimal_segments[3]["climbs"] = ["Puy Boubou"]
+        config = {"climbs": [{"name": "Puy Boubou", "segment": 4, "km": 32.8, "length_km": 2.8}]}
+        errors = validate(config, minimal_segments)
+        assert any("falls outside declared segment 4" in e for e in errors)
+
+    def test_climb_missing_from_segment_fails(self, minimal_segments):
+        config = {"climbs": [{"name": "Puy Boubou", "segment": 5, "km": 32.8, "length_km": 2.8}]}
+        errors = validate(config, minimal_segments)
+        assert any("missing from segments" in e for e in errors)
+
+    def test_summit_only_climb_passes(self, minimal_segments):
+        minimal_segments[0]["climbs"] = ["Côte de Malemort"]
+        config = {"climbs": [{"name": "Côte de Malemort", "segment": 1, "km": 5, "length_km": None}]}
+        assert validate(config, minimal_segments) == []
+
+    def test_spanning_climb_requires_both_segments(self, minimal_segments):
+        # Span from km 30 to 32.8 crosses only segment 5 (28-36), so only seg 5 required
+        minimal_segments[4]["climbs"] = ["Puy Boubou"]
+        config = {"climbs": [{"name": "Puy Boubou", "segment": 5, "km": 32.8, "length_km": 2.8}]}
+        assert validate(config, minimal_segments) == []
+
+        # A climb with span crossing segments 6 and 7 must appear on both
+        segs = [
+            {"segment": 6, "km_start": 36.0, "km_end": 42.0, "climbs": ["Côte de Lagleygeolle"]},
+            {"segment": 7, "km_start": 42.0, "km_end": 50.0, "climbs": []},
+        ]
+        config = {"climbs": [{"name": "Côte de Lagleygeolle", "segment": 7, "km": 43.2, "length_km": 5.2}]}
+        errors = validate(config, segs)
+        assert any("missing from segments [7]" in e for e in errors)
+
+
+class TestSprintValidation:
+    def test_sprint_in_segment_passes(self, minimal_segments):
+        config = {"sprints": [{"name": "Sprint - Brive", "segment": 1, "km": 3}]}
+        assert validate(config, minimal_segments) == []
+
+    def test_sprint_outside_segment_fails(self, minimal_segments):
+        config = {"sprints": [{"name": "Sprint - Brive", "segment": 2, "km": 3}]}
+        errors = validate(config, minimal_segments)
+        assert any("falls outside declared segment 2" in e for e in errors)
+
+
+class TestRealData:
+    """Integration test against the project's real data files."""
+
+    def test_real_data_validates(self):
+        root = os.path.join(os.path.dirname(__file__), "..", "..")
+        points_path = os.path.join(root, "data", "competition", "points-config.json")
+        segments_path = os.path.join(root, "data", "segments.json")
+        if not (os.path.exists(points_path) and os.path.exists(segments_path)):
+            pytest.skip("real data files not found")
+        with open(points_path) as f:
+            points = json.load(f)
+        with open(segments_path) as f:
+            segments = json.load(f)
+        errors = validate(points, segments)
+        assert errors == [], f"real data has divergences: {errors}"

--- a/processing/validate_points.py
+++ b/processing/validate_points.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate that climb and sprint assignments in points-config.json agree with segments.json.
+
+points-config.json is the single source of truth for climb and sprint identity,
+summit/sprint km, and (for climbs) span via length_km. segments.json is generated
+by split_gpx.py and carries a derived `climbs` list per segment.
+
+This script enforces two invariants:
+
+1. Every climb's summit km falls within the km range of its declared segment.
+2. Every climb name appears in the `climbs` list of every segment whose km range
+   intersects the climb's span (from km - length_km to km). Climbs with length_km
+   null are treated as summit-only and must appear in exactly the summit segment.
+
+Sprints are checked for invariant 1 only (they are points, not spans, and are
+not currently materialised in segments.json).
+
+Exits non-zero if any invariant is violated.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def segment_containing_km(segments, km):
+    """Return the segment dict whose [km_start, km_end] contains km, or None."""
+    for s in segments:
+        if s["km_start"] <= km <= s["km_end"]:
+            return s
+    return None
+
+
+def validate(points_config, segments):
+    errors = []
+    segments_by_number = {s["segment"]: s for s in segments}
+
+    for climb in points_config.get("climbs", []):
+        name = climb["name"]
+        declared_seg = climb["segment"]
+        summit_km = climb["km"]
+        length_km = climb.get("length_km")
+
+        seg = segments_by_number.get(declared_seg)
+        if seg is None:
+            errors.append(f"climb {name!r}: declared segment {declared_seg} not found in segments.json")
+            continue
+
+        if not (seg["km_start"] <= summit_km <= seg["km_end"]):
+            errors.append(
+                f"climb {name!r}: summit km {summit_km} falls outside declared "
+                f"segment {declared_seg} range [{seg['km_start']}, {seg['km_end']}]"
+            )
+
+        if length_km is None:
+            expected_segments = {declared_seg}
+        else:
+            km_start = summit_km - length_km
+            km_end = summit_km
+            expected_segments = {
+                s["segment"] for s in segments
+                if s["km_start"] < km_end and s["km_end"] > km_start
+            }
+
+        actual_segments = {
+            s["segment"] for s in segments if name in (s.get("climbs") or [])
+        }
+
+        missing = expected_segments - actual_segments
+        extra = actual_segments - expected_segments
+        if missing:
+            errors.append(
+                f"climb {name!r}: missing from segments {sorted(missing)} "
+                f"(expected on all segments its span crosses)"
+            )
+        if extra:
+            errors.append(
+                f"climb {name!r}: present on segments {sorted(extra)} outside its span"
+            )
+
+    for sprint in points_config.get("sprints", []):
+        name = sprint["name"]
+        declared_seg = sprint["segment"]
+        km = sprint["km"]
+        seg = segments_by_number.get(declared_seg)
+        if seg is None:
+            errors.append(f"sprint {name!r}: declared segment {declared_seg} not found in segments.json")
+            continue
+        if not (seg["km_start"] <= km <= seg["km_end"]):
+            errors.append(
+                f"sprint {name!r}: km {km} falls outside declared "
+                f"segment {declared_seg} range [{seg['km_start']}, {seg['km_end']}]"
+            )
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+    parser.add_argument("--points-config", default=os.path.join(default_root, "data", "competition", "points-config.json"))
+    parser.add_argument("--segments", default=os.path.join(default_root, "data", "segments.json"))
+    args = parser.parse_args()
+
+    errors = validate(load_json(args.points_config), load_json(args.segments))
+
+    if errors:
+        print(f"FAIL: {len(errors)} divergence(s) between points-config.json and segments.json:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+    print("OK: points-config.json and segments.json agree on all climbs and sprints.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Resolves #362. Makes `data/competition/points-config.json` the single source of truth for climb and sprint identity, summit km, and span. `split_gpx.py` now imports from it, so the two files cannot silently diverge. Adds `processing/validate_points.py` and wires it into CI so any future divergence fails the build.

## What changed in the data

Two real divergences in `segments.json` corrected:

- **Puy Boubou** moved from segment 4 to segment 5 (summit km 32.8 is entirely inside segment 5's 28-36 range; the climb spans 30-32.8)
- **Côte de Malemort** (km 5) added to segment 1 — it was in `points-config.json` but absent from `split_gpx.py`'s `KNOWN_CLIMBS` dict so never made it into `segments.json`

Per the content-change rule agreed 2026-04-16, the published segment 4 entry is not edited retroactively. Puy Boubou is now correctly available for segment 5 content to carry.

## What changed in code

- `data/competition/points-config.json` — new `length_km` field on each climb (null for Côte de Malemort, unknown). Diacritics restored on climb names to match what `ElevationChart.vue` and `StageDetails.vue` already expect.
- `processing/split_gpx.py` — drops `KNOWN_CLIMBS`, loads climbs from `points-config.json` via new `load_known_climbs()`. Also gains `load_existing_towns()` so that re-running the script preserves hand-verified town assignments from #342 rather than regressing them (the structural town-assignment bug is still tracked separately in #341).
- `processing/validate_points.py` — new. Verifies: (1) each climb's summit km lies within its declared segment, (2) each climb name appears on every segment its span crosses. Sprints checked for (1) only.
- `processing/tests/test_validate_points.py` — new, 8 unit tests + 1 integration test against the real project data.
- `.github/workflows/ci.yml` — adds a step that runs `validate_points.py` after the Python tests.

## Test plan

- [x] `pytest processing/tests/` — 164 tests pass (includes 9 new)
- [x] `ruff check processing/` — clean
- [x] `python processing/validate_points.py` — OK
- [x] Re-ran `split_gpx.py` against real data; confirmed diff is only the two intended climb corrections (towns preserved)
- [x] CI green on push

Milestone: v1.4.5. Unblocks #360 (segment 5 content).