### PR TITLE
Send a User-Agent to the Wikipedia API

### DIFF
--- a/server/api/wikipedia-images.post.ts
+++ b/server/api/wikipedia-images.post.ts
@@ -6,6 +6,11 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Missing query' })
   }
 
+  const wikiHeaders = {
+    'User-Agent': 'tdf26-travelogue/1.0 (https://tour26.iamsosmrt.com; gneeek@proton.me)',
+    'Accept': 'application/json',
+  }
+
   try {
     // Search for articles
     const searchParams = new URLSearchParams({
@@ -18,7 +23,7 @@ export default defineEventHandler(async (event) => {
       origin: '*',
     })
     const searchUrl = `https://en.wikipedia.org/w/api.php?${searchParams}`
-    const searchResp = await fetch(searchUrl)
+    const searchResp = await fetch(searchUrl, { headers: wikiHeaders })
     const searchData = await searchResp.json()
     const articles = searchData.query?.search || []
 
@@ -38,7 +43,7 @@ export default defineEventHandler(async (event) => {
       origin: '*',
     })
     const imageUrl = `https://en.wikipedia.org/w/api.php?${imageParams}`
-    const imageResp = await fetch(imageUrl)
+    const imageResp = await fetch(imageUrl, { headers: wikiHeaders })
     const imageData = await imageResp.json()
     const pages = imageData.query?.pages || {}
 


### PR DESCRIPTION
## Summary

Fixes the admin image picker's Wikipedia search, which was failing with `Unexpected token '<', "<!DOCTYPE"... is not valid JSON`.

Wikimedia's API returns 429 with an HTML error page when a request arrives without a User-Agent. Node's default `fetch` sends none, so the search endpoint was getting HTML back and the JSON parser was blowing up. Added a descriptive User-Agent per [Wikimedia's User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy) so the API serves JSON.

Reproduced during the 2026-04-19 publish-day prep for segment 5 (issue #370). The same endpoint is used by the attraction-search buttons, which were all returning the same error.

## Test plan

- [x] `curl -X POST localhost:3000/api/wikipedia-images -d '{"query":"Lagleygeolle"}'` returns `{ "images": [...] }` with real results
- [x] `/admin/images` — Wikipedia search in the admin image picker works
- [x] Attraction-search buttons on `/admin/images` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)