### PR TITLE
Segment 5 pre-publish: geographic corrections and attractions data

### DIFF
--- a/content/entries/05-lagleygeolle.md
+++ b/content/entries/05-lagleygeolle.md
@@ -1,7 +1,7 @@
 ---
 segment: 5
-title: "Lagleygeolle"
-subtitle: "Km 28-36: Over the top, into the commune of the small church"
+title: "Past Lagleygeolle"
+subtitle: "Km 28-36: Down from Puy Boubou, across the commune line, toward the Côte"
 publishDate: 2026-04-19
 dataCutoff: 2026-04-18
 kmStart: 28
@@ -13,17 +13,17 @@ weather: null
 draft: false
 ---
 
-# Lagleygeolle
+# Past Lagleygeolle
 
 In the middle of a Sunday afternoon in July, or an evening in mid-April for our four riders, at the top of a climb that is technically still finishing, the road turns left around a hedge and the forest runs out. This is the summit of Puy Boubou, at four hundred and four metres, a kilometre past the point at which the climb is usually described as over. A rider on a good day would not notice the difference. The difference, on the map, is segment five.
 
-For seven kilometres from here the road descends. Not steeply. A sustained grade of around two per cent, with stretches of four or five, nothing that asks for brakes. The chestnut forest that made the second half of segment four so dark thins within a kilometre and the sky comes back. A little to the east, in high ground the road does not climb, the village of Lagleygeolle sits on a promontory the route does not visit. The Vicomte de Turenne once held the land. A twelfth-century priory stood near where the present church stands now. The village is two hundred and twenty-two inhabitants. The road passes to its west and does not stop.
+For seven kilometres from here the road descends. Not steeply. A sustained grade of around two per cent, with stretches of four or five, nothing that asks for brakes. The chestnut forest that made the second half of segment four so dark thins within a kilometre and the sky comes back. A little to the west, across an open field, the village of Lagleygeolle sits two hundred metres from the road the Tour is about to take. The Vicomte de Turenne once held the land. A twelfth-century priory stood near where the present church stands now. The village is two hundred and twenty-two inhabitants. The road passes the village to its east and does not stop.
 
-Lagleygeolle is an Occitan name that means "the small church", from *la gleisòla*; the commune is named for the priory that became the church that became the centre of the village. The name passed into French in a Frenchified spelling that no longer looks Occitan, and into the language of cyclists who will see the commune on the road-book and never see the gleisòla itself. The present church, Notre Dame de la Nativité, carries vestiges of the twelfth, fifteenth, and sixteenth centuries; the bell tower is from 1889. The Tour will cross the commune that contains all of this in a few minutes at racing speed. Lagleygeolle and Meyssac were one commune until 1870, when a long administrative argument finally found its line; the road today crosses that line without noticing.
+Lagleygeolle is an Occitan name that means "the small church", from *la gleisòla*; the commune is named for the priory that became the church that became the centre of the village. The name passed into French in a Frenchified spelling that no longer looks Occitan, and into the language of cyclists who will see the commune on the road-book and, if they look left at the right kilometre, the *gleisòla* itself across the field. The present church, Notre Dame de la Nativité, carries vestiges of the twelfth, fifteenth, and sixteenth centuries; the bell tower is from 1889. The Tour will cross the commune that contains all of this in a few minutes at racing speed. Lagleygeolle and Meyssac were one commune until 1870, when a long administrative argument finally found its line; the road today crosses that line without noticing.
+
+What the road does meet is a string of hamlets too small for any map a stage-watcher is likely to consult. The names come in order along the descent: Antignac past Lagleygeolle village, Fouilloux halfway down, and then a cluster of them, Cornilloux and Le Planchat and Le Suc and Le Faure, where the road eases toward the Beynat commune line. These are lieux-dits more than villages. A few houses, a farm, a cluster of outbuildings set back from the verge. The Tour will pass dozens of such places on its way to Ussel. Most stages, once they leave the cities, are mostly made of them. A rider on a training day, or a local on a shopping trip from Beynat, registers them the way any country road registers anything: as a change in the hedge, a new roof line, a dog that looks up and then does not bother.
 
 Around kilometre thirty-four, on a stretch that is neither memorable nor forgettable, the road leaves Lagleygeolle for Beynat. The change is invisible. There is no sign, no shift in road surface, no new cast of hedgerow. Beynat village is still more than a kilometre ahead and will not appear in this segment; the chestnut festival there, mentioned in the previous entry, waits another week of writing to arrive.
-
-The commune has older things than festivals, and the road meets none of them. At Puy-de-Noix, a hamlet a little away from the route, the Templars acquired a commandery in the late twelfth century; its last commander, Raynaud de Bort, was about fifty-five when Philippe le Bel's commissioners came for him in 1311, and the house passed shortly after to the Hospitallers of Saint John. Older still, also in the commune and also away from the road, the Cabane de la Fée is a Neolithic dolmen, listed as a Historic Monument since 1910. What the descent shows of all this, this afternoon, is what the descent shows of every similar ridge in the Corrèze: more of the same, marginally lower down, the fields a slightly different green because they are grazed rather than cropped, the farms a little further apart.
 
 This is the first stretch of the stage that will feel, in the riding, like a transition rather than an event. The category-three climb is done. The next climb, the Côte de Lagleygeolle, starts two kilometres after segment five ends, and takes its name from the village the road just passed without seeing. The segment between these two climbs is a corridor, not a destination, and a stage is made of both. I find that I do not mind writing about a corridor. A stage with no corridors would be exhausting, and a department with no quiet communes would be smaller than the Corrèze actually is.
 
@@ -34,5 +34,4 @@ The descent runs out at kilometre thirty-six, on the Beynat side of an invisible
 ## Sources
 
 - Lagleygeolle commune history, population, and church: [Histoire de Lagleygeolle (charles-de-flahaut.fr)](https://www.charles-de-flahaut.fr/wordpress/histoire-de-lagleygeolle-correze/), [Lagleygeolle (Wikipedia)](https://en.wikipedia.org/wiki/Lagleygeolle)
-- Temple of Puy-de-Noix and Raynaud de Bort: [Templiers et Hospitaliers (Terres de Corrèze)](https://www.terresdecorreze.com/en/culture-patrimoine/templiers-et-hospitaliers/), [Les Biens Templiers et Hospitaliers en Corrèze (templiers.net)](http://www.templiers.net/grands-prieures/index_3.php?page=Correze)
-- Cabane de la Fée dolmen, Beynat: [Musée du Patrimoine de France](https://museedupatrimoine.fr/dolmen-dit-la-cabane-de-la-fee-a-beynat-correze/12019.html), [Corrèze découverte](https://correze-decouverte.fr/380-dolmen-cabane-fee-beynat-19190-cornil-petit-patrimoine.php)
+- Hamlet names and positions along the route (Antignac, Fouilloux, Cornilloux, Le Planchat, Le Suc, Le Faure), and the Lagleygeolle / Beynat commune boundary: [OpenStreetMap](https://www.openstreetmap.org/), queried via Overpass API within 4 km of Lagleygeolle village centre.

--- a/data/attractions.json
+++ b/data/attractions.json
@@ -585,10 +585,10 @@
     "category": "heritage",
     "lat": 45.0569,
     "lng": 1.6726,
-    "description": "12th-16th century church with Romanesque Limousin-style portal, fortified during the Hundred Years War. Red sandstone bell tower with white limestone tympanum \u2014 both sides of the Meyssac fault in one building.",
+    "description": "12th-16th century church with Romanesque Limousin-style portal, fortified during the Hundred Years War. Red sandstone bell tower with white limestone tympanum — both sides of the Meyssac fault in one building.",
     "links": [],
-    "nearest_km": 23.7,
-    "nearest_distance_m": 277
+    "nearest_km": 23.23,
+    "nearest_distance_m": 100
   },
   {
     "name": "Halle aux Grains de Meyssac",
@@ -597,8 +597,8 @@
     "lng": 1.673,
     "description": "18th-century grain hall with red sandstone columns supporting a Travassac slate roof on a chestnut timber frame. The geological fault made architectural.",
     "links": [],
-    "nearest_km": 23.7,
-    "nearest_distance_m": 280
+    "nearest_km": 23.52,
+    "nearest_distance_m": 91
   },
   {
     "name": "Espace de Decouverte de la Faille de Meyssac",
@@ -612,7 +612,47 @@
         "url": "https://noailhacpatrimoine.fr/notre-patrimoine/geologie-l-espace-de-decouverte-de-la-faille-de-meyssac-et-de-la-pierre"
       }
     ],
-    "nearest_km": 24.5,
-    "nearest_distance_m": 3200
+    "nearest_km": 20.46,
+    "nearest_distance_m": 485
+  },
+  {
+    "name": "Église Notre-Dame-de-la-Nativité, Lagleygeolle",
+    "category": "church",
+    "lat": 45.0782143,
+    "lng": 1.6965683,
+    "description": "Village church of Lagleygeolle, carrying vestiges from the 12th, 15th, and 16th centuries; the bell tower is from 1889. The commune's Occitan name (la gleisòla, \"the small church\") derives from the priory that became this church.",
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Lagleygeolle",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 29.15,
+    "nearest_distance_m": 198
+  },
+  {
+    "name": "Cabane de la Fée (dolmen)",
+    "category": "archaeology",
+    "lat": 45.1465605,
+    "lng": 1.7119226,
+    "description": "Neolithic dolmen in Beynat commune, listed as a Historic Monument since 1910. Off the route, reached via Route du Dolmen.",
+    "links": [],
+    "nearest_km": 44.16,
+    "nearest_distance_m": 2203
+  },
+  {
+    "name": "Commanderie de Puy de Noix",
+    "category": "heritage",
+    "lat": 45.1389,
+    "lng": 1.8364,
+    "description": "Twelfth-century Templar commandery in Albussac commune, about 4km east of the route at its closest point. Acquired by the Knights Templar in the late 12th century; passed to the Hospitallers of Saint John after the order's suppression in 1312.",
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Albussac",
+        "label": "Wikipedia (fr)"
+      }
+    ],
+    "nearest_km": 50.51,
+    "nearest_distance_m": 4265
   }
 ]


### PR DESCRIPTION
## Summary

Resolves #370. Pre-publish review of segment 5 found three geographic inaccuracies in the merged entry and no nearby-attractions data for the segment. This PR fixes both before the Sun 2026-04-19 deploy.

**Route-proximity verification against the master GPX:**

| Attraction | nearest_km | distance from route | Assigned to |
|---|---|---|---|
| Église Notre-Dame-de-la-Nativité | 29.15 | 198 m | seg 5 |
| Cabane de la Fée (dolmen) | 44.16 | 2,203 m | seg 7 |
| Commanderie de Puy de Noix | 50.51 | 4,265 m | seg 8 |

## Entry changes

- **Title**: `Lagleygeolle` → `Past Lagleygeolle`
- **Subtitle**: `Over the top, into the commune of the small church` → `Down from Puy Boubou, across the commune line, toward the Côte`
- **Paragraph 2 (direction fix)**: village is 198 m *west* of route, not east; road passes village to its *east*, not west. Dropped unverifiable "promontory" and "in high ground" claims.
- **Paragraph 3**: softened "never see the *gleisòla*" — route passes 200 m from the church.
- **Paragraph 4**: removed Puy-de-Noix and Cabane de la Fée content. The commandery is in Albussac commune (not Beynat as the draft implied). The dolmen is in Beynat but the route's closest approach is at km 44 (segment 7), not here. Both now appear as Nearby Attractions on their correct segments.
- **Paragraph 4 (replacement)**: new paragraph on the string of hamlets the road actually threads through this descent: Antignac, Fouilloux, Cornilloux, Le Planchat, Le Suc, Le Faure. Names and positions verified via OpenStreetMap.
- Paragraphs 1, 5, 6, 7, 8 unchanged.

File slug unchanged (`05-lagleygeolle.md`) — no URL change.

## Data changes

- `data/attractions.json`: 3 new entries (church, dolmen, commandery) with OSM coordinates. `processing/calculate_attraction_positions.py` was run to populate `nearest_km` and `nearest_distance_m`.

## Content leads preserved

Dolmen and commandery facts from the original segment 5 draft have been recorded in `project_next_planning_notes.md` as content leads for drafters of segments 7 and 8.

## Test plan

- [x] `processing/calculate_attraction_positions.py` — 3 new attractions assigned to correct segments
- [x] Word count 920 (within 800-1200)
- [x] Em-dashes: 0
- [x] Exclamation marks: 0
- [x] `/entries/05-lagleygeolle` renders with new title, subtitle, corrected prose, Église in Nearby Attractions
- [x] `/entries/07-the-long-climb-to-lagleygeolle` shows Cabane de la Fée in Nearby Attractions
- [x] `/entries/08-cote-de-miel` shows Commanderie de Puy de Noix in Nearby Attractions

## Not in scope

- Images, weather, deploy (tracked in #368 as the publish-day checklist)
- Admin segment-name consistency audit (separate planning-notes item)
- Wikipedia-images API User-Agent fix (separate PR, #371)

🤖 Generated with [Claude Code](https://claude.com/claude-code)