### PR TITLE
StreetViewEmbed component for entries

### DIFF
--- a/components/StreetViewEmbed.vue
+++ b/components/StreetViewEmbed.vue
@@ -1,0 +1,31 @@
+<template>
+  <figure class="bg-white rounded-lg shadow-sm p-4 mt-8 mb-8">
+    <div class="relative w-full overflow-hidden rounded" style="padding-top: 56.25%">
+      <iframe
+        :src="embedUrl"
+        class="absolute inset-0 w-full h-full border-0"
+        :title="iframeTitle"
+        loading="lazy"
+        allowfullscreen
+        referrerpolicy="no-referrer-when-downgrade"
+      />
+    </div>
+    <figcaption v-if="caption" class="text-sm text-stone-600 mt-3 italic">
+      {{ caption }}
+    </figcaption>
+    <p class="text-xs text-stone-400 mt-2">
+      Interactive view. Imagery &copy; Google Street View.
+    </p>
+  </figure>
+</template>
+
+<script setup>
+const props = defineProps({
+  embedUrl: { type: String, required: true },
+  caption: { type: String, default: '' },
+})
+
+const iframeTitle = computed(() =>
+  props.caption ? `Street View: ${props.caption}` : 'Google Street View'
+)
+</script>

--- a/content.config.ts
+++ b/content.config.ts
@@ -15,6 +15,10 @@ export default defineContentConfig({
         gpxFile: z.string().optional().nullable(),
         elevationData: z.string().optional().nullable(),
         images: z.array(z.any()).optional(),
+        streetView: z.object({
+          embedUrl: z.string(),
+          caption: z.string().optional()
+        }).optional().nullable(),
         weather: z.any().optional().nullable(),
         draft: z.boolean().default(true)
       })

--- a/content/entries/05-lagleygeolle.md
+++ b/content/entries/05-lagleygeolle.md
@@ -9,6 +9,9 @@ kmEnd: 36
 gpxFile: /gpx/segment-05.gpx
 elevationData: /data/elevation/segment-05.json
 images: []
+streetView:
+  embedUrl: "https://www.google.com/maps/embed?pb=!4v1776601427962!6m8!1m7!1s6u5Skg6XBK2JtK0367TOqQ!2m2!1d45.10663522951817!2d1.706948614352781!3f42.52766762728022!4f1.7385706322044712!5f0.7820865974627469"
+  caption: "Main intersection at Le Planchat, the hamlet the road passes closest to in segment 5."
 weather: null
 draft: false
 ---

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -27,6 +27,12 @@
       <ContentRenderer :value="page" />
     </div>
 
+    <StreetViewEmbed
+      v-if="page.streetView?.embedUrl"
+      :embed-url="page.streetView.embedUrl"
+      :caption="page.streetView.caption"
+    />
+
     <ImageGallery :images="page.images" />
 
     <NearbyAttractions :segment="page.segment" />


### PR DESCRIPTION
## Summary

Resolves #373. Adds a `<StreetViewEmbed>` component so entries can illustrate places where Wikimedia Commons has no usable photo but Google Street View does. Uses the Maps Embed iframe flow, which is a sanctioned Google use and preserves their branding for attribution. First consumer: segment 5, pointing at the intersection in Le Planchat.

## Changes

- **`components/StreetViewEmbed.vue`**: new component. 16:9 responsive iframe, lazy-loaded, with optional caption and an explicit "Imagery © Google Street View" attribution line.
- **`content.config.ts`**: extends the entries Zod schema with an optional `streetView: { embedUrl, caption }` object. Without this the field gets silently stripped from parsed frontmatter.
- **`pages/entries/[...slug].vue`**: renders the embed between `<ContentRenderer>` and `<ImageGallery>` when `page.streetView?.embedUrl` is set.
- **`content/entries/05-lagleygeolle.md`**: adds the streetView frontmatter pointing at Le Planchat.

## How the embed URL is generated

Today we use the pb-format URL from Google Maps' Share → Embed flow. No API key, no infrastructure.

If the feature earns more use, two natural follow-ups:
- Upgrade to the Maps Embed API with a Google Cloud API key for programmatic generation and domain restrictions.
- MDC-style inline embeds (`::street-view-embed{...}::`) so multiple embeds per entry become possible.

## Test plan

- [x] Segment 5 page renders the iframe with its caption and attribution line
- [x] Other entries (no `streetView` frontmatter) render unchanged
- [x] Iframe loads lazily (only when scrolled into view)
- [x] Component passes through `allowfullscreen` and `referrerpolicy` correctly
- [x] Graceful fallback if `streetView.embedUrl` is missing — component renders nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)