### PR TITLE
Admin image picker: use entry titles in the segment dropdown

### DIFF
--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -173,6 +173,10 @@ import attractionsData from '~/data/attractions.json'
 
 definePageMeta({ layout: 'admin' })
 
+const { data: entries } = await useAsyncData('admin-picker-entry-titles', () =>
+  queryCollection('entries').all()
+)
+
 const selectedSegment = ref(1)
 const suggestions = ref([])
 const selected = ref([])
@@ -184,10 +188,11 @@ const saveMessage = ref('')
 const saveError = ref(false)
 
 function segmentTitle(n) {
+  const entry = entries.value?.find(e => e.segment === n)
+  if (entry?.title) return entry.title
   const seg = segmentsJson.find(s => s.segment === n)
-  if (!seg) return ''
-  if (seg.towns?.length) return seg.towns[0]
-  if (seg.climbs?.length) return seg.climbs[0]
+  if (seg?.towns?.length) return seg.towns[0]
+  if (seg?.climbs?.length) return seg.climbs[0]
   return `Segment ${n}`
 }
 


### PR DESCRIPTION
## Summary

Resolves #375. The admin image picker's segment dropdown was showing labels derived from \`data/segments.json\`'s \`towns[0]\` / \`climbs[0]\` fields — automatic geographic metadata, not the current entry title. Examples of what publishers saw in the dropdown:

| Seg | Before | After |
|---|---|---|
| 3 | Ligneyrac | The Causse Between |
| 5 | Puy Boubou | Past Lagleygeolle |
| 6 | Beynat | Beynat and the Cote de Lagleygeolle |

Every retitle reopened the drift. This change reads entry titles via \`queryCollection\` at runtime and uses \`entry.title\` directly. Falls back to the prior derivation (and then to \`Segment N\`) for segments that don't yet have an entry.

## Test plan

- [x] Segment 5 dropdown reads "Past Lagleygeolle" (verified in dev)
- [x] All 26 segments show entry titles in the admin dropdown
- [x] Other admin pages (e.g., \`/admin/entries\`) unaffected — they already used \`entry.title\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)