### PR TITLE
Segment 5: record publish-day images and weather

### DIFF
--- a/content/entries/05-lagleygeolle.md
+++ b/content/entries/05-lagleygeolle.md
@@ -8,8 +8,8 @@ kmStart: 28
 kmEnd: 36
 gpxFile: /gpx/segment-05.gpx
 elevationData: /data/elevation/segment-05.json
-images: []
-weather: null
+images: [{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Vache-de-race-limousine-en-correze-2.jpg/960px-Vache-de-race-limousine-en-correze-2.jpg","alt":"Vache de race limousine","author":"Koakoo","authorUrl":"https://commons.wikimedia.org/wiki/File:Vache-de-race-limousine-en-correze-2.jpg","license":"CC BY-SA 2.5","licenseUrl":"https://creativecommons.org/licenses/by-sa/2.5","sourceUrl":"https://commons.wikimedia.org/wiki/File:Vache-de-race-limousine-en-correze-2.jpg"},{"src":"https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Anem_%C3%B2c_%21_Per_la_lenga_occitana_%21-2.jpg/960px-Anem_%C3%B2c_%21_Per_la_lenga_occitana_%21-2.jpg","alt":"'Anem òc ! Per la lenga occitana !' demonstration for the Occitan language, Toulouse, 2012","author":"Pierre-Selim","authorUrl":"https://commons.wikimedia.org/wiki/User:PierreSelim","license":"CC BY-SA 3.0","licenseUrl":"https://creativecommons.org/licenses/by-sa/3.0","sourceUrl":"https://commons.wikimedia.org/wiki/File:Anem_%C3%B2c_!_Per_la_lenga_occitana_!-2.jpg"}]
+weather: {"fetchedAt": "2026-04-19", "current": {"temp": 22, "conditions": "Clear sky", "wind": "10 km/h WSW"}, "forecast": null}
 draft: false
 ---
 


### PR DESCRIPTION
## Summary

Segment 5 shipped to production on its scheduled publish day (2026-04-19). This commit captures the frontmatter state produced by \`scripts/publish.sh\` so the repo matches what was deployed.

- Gallery images: *Vache de race limousine* (Commons, CC BY-SA 2.5, Koakoo) and *Anem òc ! Per la lenga occitana* demonstration (Commons, CC BY-SA 3.0, Pierre-Selim).
- Weather: Clear sky, 22 C, 10 km/h WSW.

## Attribution note worth flagging

The two images were picked via the admin image picker's **Wikipedia article search** path, which returns the article's thumbnail URL but does **not** fetch per-image Commons metadata. The saved frontmatter had placeholder attribution (\`"author": "Wikipedia"\`, \`"license": "See Wikipedia article for license"\`), which doesn't meet the project's CC-attribution convention. I fetched proper author names and license identifiers from the Commons API and patched the frontmatter before running publish.

**Follow-up issue to file**: the admin picker should resolve per-image Commons metadata when saving article-search results, so this manual step goes away. I'll file it once this lands.

## Verification

- [x] https://tour26.iamsosmrt.com/entries/05-lagleygeolle/ returns HTTP 200 with the updated title, subtitle, inline church figure (Conlinp CC BY-SA 4.0), Street View embed for Le Planchat, gallery images with full attribution, and weather widget.
- [x] Climbing points awarded: Puy Boubou (cat 3, km 29.06) — Marian 4, Justin 3, Nan 2. Wally hasn't crossed yet.
- [x] Rider dashboard totals in segment 5 snapshot match the expected calculation.

## Not in scope

- \`data/riders/stats.json\`, \`data/riders/points.json\`, \`data/riders/snapshots/\` — .gitignored (managed locally, not committed).
- Admin picker metadata-resolution fix — will be filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)