### PR TITLE
publish.sh: commit frontmatter changes to main after deploy (#383)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,13 @@ npx nuxt generate
 
 # 4. Deploy to VPS
 rsync -avz .output/public/ user@vps:/var/www/correze-travelogue/
+
+# 5. Commit frontmatter changes (dataCutoff, weather) to main so main
+#    matches the deployed artifact immediately after deploy
+git add content/entries/<entry>.md && git commit -m "..." && git push origin main
 ```
+
+The actual script (`scripts/publish.sh`) has additional steps for points calculation, per-segment stats snapshots, race narrative generation, and image validation. Run `./scripts/publish.sh --help` for current flags.
 
 ### 4b. Weather Integration (`weather.py`)
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Publish-day script: update stats, calculate points, snapshot, fetch weather, build site, deploy
+# Publish-day script: update stats, calculate points, snapshot, fetch weather,
+# build site, deploy, and commit the frontmatter changes this script produced
+# so main is reconciled with the deployed artifact before the script exits.
 #
-# Usage: ./scripts/publish.sh [--segment N] [--skip-deploy] [--skip-weather]
+# Usage: ./scripts/publish.sh [--segment N] [--skip-deploy] [--skip-weather] [--skip-commit]
 #
 # Environment variables (loaded from .env if present):
 #   OPENWEATHERMAP_API_KEY  - API key for weather data (optional)
@@ -22,6 +24,7 @@ fi
 
 SKIP_DEPLOY=false
 SKIP_WEATHER=false
+SKIP_COMMIT=false
 SEGMENT=""
 
 # Parse arguments
@@ -30,12 +33,16 @@ for arg in "$@"; do
         -h|--help)
             echo "Usage: ./scripts/publish.sh [OPTIONS]"
             echo ""
-            echo "Publish-day script: update stats, calculate points, snapshot, fetch weather, build, deploy."
+            echo "Publish-day script: update stats, calculate points, snapshot, fetch weather,"
+            echo "build, deploy, and commit frontmatter changes to main."
             echo ""
             echo "Options:"
             echo "  --segment N     Segment number to publish (auto-detects if omitted)"
-            echo "  --skip-deploy   Skip the deployment step"
+            echo "  --skip-deploy   Skip the deployment step (also skips the commit step)"
             echo "  --skip-weather  Skip weather fetch"
+            echo "  --skip-commit   Deploy but do not commit frontmatter to main"
+            echo "                  (advanced: for deploys run from a branch or in a"
+            echo "                  workflow where the commit is handled separately)"
             echo "  -h, --help      Show this help message"
             echo ""
             echo "Environment variables:"
@@ -48,6 +55,9 @@ for arg in "$@"; do
             ;;
         --skip-weather)
             SKIP_WEATHER=true
+            ;;
+        --skip-commit)
+            SKIP_COMMIT=true
             ;;
         --segment)
             shift_next=true
@@ -215,6 +225,48 @@ elif [ -n "$DEPLOY_TARGET" ]; then
 else
     echo "--- Step 8: No DEPLOY_TARGET set, skipping deploy ---"
     echo "Set DEPLOY_TARGET in .env (e.g., correze:/var/www/correze-travelogue/)"
+fi
+echo ""
+
+# Step 9: Commit frontmatter changes to main
+# Closes the reconciliation gap between the deployed artifact and main. The
+# publish script mutates the entry frontmatter in place (dataCutoff, weather,
+# sometimes images) and those mutations need to land on main before the script
+# exits, or the next fresh clone builds the stub instead of the published entry.
+# See issue #383 and the v1.4.5 retrospective.
+if [ "$SKIP_DEPLOY" = true ]; then
+    echo "--- Step 9: Commit skipped (deploy was skipped) ---"
+elif [ "$SKIP_COMMIT" = true ]; then
+    echo "--- Step 9: Commit skipped (--skip-commit flag) ---"
+elif [ -z "$DEPLOY_TARGET" ]; then
+    echo "--- Step 9: Commit skipped (no DEPLOY_TARGET, no deploy happened) ---"
+else
+    echo "--- Step 9: Committing frontmatter changes to main ---"
+    CURRENT_BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD)
+    if [ "$CURRENT_BRANCH" != "main" ]; then
+        echo "ERROR: publish.sh is not running on main (currently on $CURRENT_BRANCH)."
+        echo "Refusing to commit frontmatter changes from a non-main branch."
+        echo "The deploy happened but main is not reconciled. Resolve manually:"
+        echo "  git checkout main && git add $ENTRY_FILE && git commit && git push"
+        exit 1
+    fi
+    if [ -z "$ENTRY_FILE" ] || [ ! -f "$ENTRY_FILE" ]; then
+        echo "ERROR: ENTRY_FILE not set or not found; cannot commit."
+        echo "The deploy happened but main is not reconciled. Resolve manually."
+        exit 1
+    fi
+    if git -C "$PROJECT_DIR" diff --quiet -- "$ENTRY_FILE" \
+        && git -C "$PROJECT_DIR" diff --staged --quiet -- "$ENTRY_FILE"; then
+        echo "No frontmatter changes to commit on $ENTRY_FILE."
+    else
+        git -C "$PROJECT_DIR" add "$ENTRY_FILE" \
+            || { echo "ERROR: git add failed."; exit 1; }
+        git -C "$PROJECT_DIR" commit -m "Segment $SEGMENT publish: record frontmatter from publish.sh" \
+            || { echo "ERROR: git commit failed. Resolve manually; the deploy already happened."; exit 1; }
+        git -C "$PROJECT_DIR" push origin main \
+            || { echo "ERROR: git push failed. The deploy happened but main is not reconciled. Resolve manually."; exit 1; }
+        echo "Committed and pushed frontmatter changes for segment $SEGMENT."
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Closes #383. Adds a Step 9 to `scripts/publish.sh` that commits and pushes entry frontmatter changes (dataCutoff, weather, sometimes images) to `main` immediately after a successful deploy, closing the reconciliation gap observed during the v1.4.5 publish (seg 5 went live Sunday morning but main did not contain the shipped frontmatter until PR #379 merged the following afternoon - 18 hours of divergence).

## What changed

- New Step 9 in `scripts/publish.sh` runs after Step 8 (deploy) and:
  - Refuses to commit if the script is not running on \`main\` (prints a clear recovery command).
  - Refuses to commit if \`ENTRY_FILE\` is not set or missing.
  - No-ops cleanly when there are no uncommitted frontmatter changes.
  - Wraps each git operation (\`add\`, \`commit\`, \`push\`) with targeted error messages so the operator can tell the difference between a missed step and a deploy-happened-but-main-diverged partial state.
- New \`--skip-commit\` flag for the rare cases where the operator wants to deploy but handle the commit separately.
- Existing \`--skip-deploy\` implies skipping the commit (no deploy, no point).
- Top-of-file comment and \`--help\` output updated.
- \`CLAUDE.md\`'s stylised publish-workflow sketch mirrors the new step with a pointer to \`scripts/publish.sh --help\`.

## Why this shape

Per the v1.4.5 retrospective, the fix belongs in v1.4.6 as the developer slot. Two fix shapes were considered:

- **Operational** (this PR): publish.sh commits its own frontmatter changes.
- **Structural** (backlog): frontmatter changes happen upstream of deploy so publish.sh never mutates the tree.

The structural rethink is a larger rewrite and stays in the backlog. This PR ships the cheap fix; the retro finding is the forcing function.

## Test plan

- [x] \`./scripts/publish.sh --segment 5 --skip-deploy --skip-weather\` dry-run: Step 9 printed \"Commit skipped (deploy was skipped)\" and the script exited cleanly.
- [ ] CI passes
- [ ] Wed 2026-04-22 seg-6 real publish: Step 9 commits and pushes the weather + dataCutoff changes; \`main\` matches the deployed artifact immediately after deploy completes. This is the real verification from the issue's acceptance criteria.

## Fallback if something goes wrong on Wed

If Step 9 misbehaves during the seg-6 publish, the operator can re-run with \`--skip-commit\` and commit manually (the pattern used for seg 5). The deploy still succeeds; only the post-deploy reconciliation is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)