### PR TITLE
Admin: drop nav links to pages that do not yet exist (#384)

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -12,9 +12,9 @@
             <NuxtLink to="/admin/entries" class="text-stone-300 hover:text-white">Entries</NuxtLink>
             <NuxtLink to="/admin/images" class="text-stone-300 hover:text-white">Images</NuxtLink>
             <NuxtLink to="/admin/weather" class="text-stone-300 hover:text-white">Weather</NuxtLink>
-            <NuxtLink to="/admin/schedule" class="text-stone-300 hover:text-white">Schedule</NuxtLink>
+            <!-- Schedule nav entry removed in #384 until #73 (publish schedule editor) ships in v1.6.0 -->
             <NuxtLink to="/admin/publish" class="text-stone-300 hover:text-white">Publish</NuxtLink>
-            <NuxtLink to="/admin/settings" class="text-stone-300 hover:text-white">Settings</NuxtLink>
+            <!-- Settings nav entry removed in #384 until #71 (site settings editor) ships in v1.6.0 -->
           </div>
         </div>
         <NuxtLink to="/" class="text-sm text-stone-400 hover:text-white">

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -18,10 +18,7 @@
         <h2 class="text-lg font-semibold text-stone-800">Weather</h2>
         <p class="text-sm text-stone-500 mt-1">Fetch and inject weather data</p>
       </NuxtLink>
-      <NuxtLink to="/admin/schedule" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
-        <h2 class="text-lg font-semibold text-stone-800">Schedule</h2>
-        <p class="text-sm text-stone-500 mt-1">Configure publish dates</p>
-      </NuxtLink>
+      <!-- Schedule dashboard card removed in #384 until #73 (publish schedule editor) ships in v1.6.0 -->
       <NuxtLink to="/admin/publish" class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow">
         <h2 class="text-lg font-semibold text-stone-800">Publish</h2>
         <p class="text-sm text-stone-500 mt-1">Build and deploy the site</p>


### PR DESCRIPTION
## Summary

Closes #384. Removes the admin nav entries for \`/admin/schedule\` and \`/admin/settings\` from \`layouts/admin.vue\`, plus the Schedule dashboard card from \`pages/admin/index.vue\`. Target pages do not exist yet and are tracked as v1.6.0 work:

- [#71](https://github.com/gneeek/tdf26/issues/71) - admin page, site settings editor
- [#73](https://github.com/gneeek/tdf26/issues/73) - admin page, publish schedule editor

## What this fixes

During the v1.4.5 \`scripts/publish.sh\` run on 2026-04-19, Nitro prerender emitted two \`[404]\` warnings for these paths (noisy in publish output; misleading if a publisher ever clicked them). After this change, \`npx nuxt generate\` completes with 33 prerendered routes and no \`[404]\` warnings.

## Restore path

Each removed nav entry is replaced by an HTML comment referencing the issue that will restore it (#71 or #73). The v1.6.0 milestone description has been updated with a matching restore note, so whoever ships those pages will see the reminder.

## Test plan

- [x] \`npx nuxt generate\` - 33 routes prerendered, no \`[404]\` warnings for admin/schedule or admin/settings
- [ ] CI passes

## Not in scope

- The target pages themselves (v1.6.0, #71 and #73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)