### PR TITLE
Homepage: lift entries above the fold, add Stage 9 summary (#361, #381)

### DIFF
--- a/components/DayCounter.vue
+++ b/components/DayCounter.vue
@@ -1,17 +1,19 @@
 <template>
-  <div class="flex flex-wrap items-center gap-3 text-sm">
-    <span class="bg-correze-red text-white font-bold px-3 py-1.5 rounded-lg text-lg">
+  <div class="flex items-center gap-3 text-sm">
+    <span class="bg-correze-red text-white font-bold px-3 py-1.5 rounded-lg text-lg flex-shrink-0">
       Day {{ raceDay }}
     </span>
-    <span v-if="daysUntilTour > 0" class="text-stone-500">
-      Tour starts in <span class="font-semibold text-stone-700">{{ daysUntilTour }}</span> days
-    </span>
-    <span v-if="daysUntilStage > 0" class="text-stone-500">
-      Stage 9 in <span class="font-semibold text-stone-700">{{ daysUntilStage }}</span> days
-    </span>
-    <span v-if="daysUntilStage <= 0" class="text-correze-red font-semibold">
-      Stage 9 is today!
-    </span>
+    <div class="flex flex-col gap-0.5">
+      <span v-if="daysUntilTour > 0" class="text-stone-500">
+        Tour starts in <span class="font-semibold text-stone-700">{{ daysUntilTour }}</span> days
+      </span>
+      <span v-if="daysUntilStage > 0" class="text-stone-500">
+        Stage 9 in <span class="font-semibold text-stone-700">{{ daysUntilStage }}</span> days
+      </span>
+      <span v-if="daysUntilStage <= 0" class="text-correze-red font-semibold">
+        Stage 9 is today!
+      </span>
+    </div>
   </div>
 </template>
 

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -23,7 +23,7 @@
     </div>
 
     <div class="mt-4 pt-3 border-t border-stone-100 text-xs text-stone-400">
-      185 km &middot; 9 climbs &middot; +3,390m elevation
+      {{ Math.round(totals.totalDistance) }} km &middot; {{ totals.uniqueCategorizedClimbs.length }} climbs &middot; +{{ totals.totalElevationGain.toLocaleString('en-US') }}m elevation
     </div>
   </div>
 </template>
@@ -31,6 +31,9 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import { townKmPositions } from '~/data/town-positions'
+import { deriveTotals } from '~/utils/stage-totals'
+
+const totals = deriveTotals(segmentsJson)
 
 const props = defineProps({
   currentKm: { type: Number, default: 0 },

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -31,7 +31,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import { townKmPositions } from '~/data/town-positions'
-import { deriveTotals } from '~/utils/stage-totals'
+import { deriveTotals, CATEGORIZED_CLIMBS } from '~/utils/stage-totals'
 
 const totals = deriveTotals(segmentsJson)
 
@@ -79,6 +79,7 @@ const climbSet = new Map()
 for (const seg of segmentsJson) {
   if (seg.climbs?.length) {
     for (const climb of seg.climbs) {
+      if (!CATEGORIZED_CLIMBS.has(climb)) continue
       if (!climbSet.has(climb)) {
         const data = climbData[climb] || {}
         climbSet.set(climb, {

--- a/components/StageRaceInfo.vue
+++ b/components/StageRaceInfo.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="p-4 bg-amber-100 rounded-lg text-sm text-stone-700">
+    <p class="font-semibold text-stone-800 mb-2">The Race</p>
+    <p>
+      Four riders are virtually cycling from the comfort of their homes. Starting in April,
+      each logs daily kilometres from their own rides, and we track their progress along the
+      185km Stage 9 parcours. Each day, up to 2km counts toward their position on the route -
+      but unused cap rolls over, rewarding rest days followed by big efforts. Four jerseys are
+      contested:
+      <JerseyIcon type="yellow" size="xs" class="inline-block mx-0.5" /> yellow for the race leader,
+      <JerseyIcon type="green" size="xs" class="inline-block mx-0.5" /> green for sprint points,
+      <JerseyIcon type="polkaDot" size="xs" class="inline-block mx-0.5" /> polka dot for climbing points,
+      and the
+      <JerseyIcon type="red" size="xs" class="inline-block mx-0.5" /> lanterne rouge for last place.
+    </p>
+    <NuxtLink to="/rules" class="inline-block mt-2 text-correze-red hover:underline font-medium">
+      Full competition rules
+    </NuxtLink>
+  </div>
+</template>

--- a/components/StageSummary.vue
+++ b/components/StageSummary.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="bg-white rounded-lg border border-stone-200 px-4 py-3">
+    <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs sm:text-sm text-stone-600">
+      <span><span class="font-semibold text-stone-800">{{ totalDistanceKm }} km</span></span>
+      <span class="text-stone-300">&middot;</span>
+      <span>+{{ formatNumber(totals.totalElevationGain) }} m climb</span>
+      <span class="text-stone-300">&middot;</span>
+      <span>{{ totals.uniqueCategorizedClimbs.length }} climbs <span class="text-stone-400">(Mont Bessou 977m)</span></span>
+      <span class="text-stone-300">&middot;</span>
+      <span>{{ totals.uniqueTowns.length }} towns</span>
+      <span class="text-stone-300">&middot;</span>
+      <span class="text-stone-500">Sun 12 Jul 2026</span>
+    </div>
+
+    <div class="mt-3">
+      <div class="relative h-1.5 bg-stone-200 rounded-full overflow-hidden">
+        <div
+          class="absolute inset-y-0 left-0 bg-correze-red rounded-full transition-all"
+          :style="{ width: `${progressPercent}%` }"
+        />
+      </div>
+      <div v-if="progress.kmRidden > 0" class="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-stone-500">
+        <span>{{ Math.round(progress.kmRidden) }} km ridden</span>
+        <span class="text-stone-300">&middot;</span>
+        <span>+{{ formatNumber(progress.elevationClimbed) }} m climbed</span>
+        <span class="text-stone-300">&middot;</span>
+        <span>{{ progress.categorizedClimbsPassed.length }} {{ progress.categorizedClimbsPassed.length === 1 ? 'climb' : 'climbs' }} passed</span>
+      </div>
+      <div v-else class="mt-1.5 text-xs text-stone-500 italic">
+        The journey begins soon.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import segmentsJson from '~/data/segments.json'
+import { deriveTotals, journeyThroughSegment } from '~/utils/stage-totals'
+
+const props = defineProps<{
+  latestSegment?: number | null
+}>()
+
+const totals = deriveTotals(segmentsJson)
+
+const totalDistanceKm = computed(() => Math.round(totals.totalDistance))
+
+const progress = computed(() => {
+  const seg = props.latestSegment ?? 0
+  return journeyThroughSegment(segmentsJson, seg)
+})
+
+const progressPercent = computed(() => {
+  if (totals.totalDistance <= 0) return 0
+  return Math.min(100, Math.max(0, (progress.value.kmRidden / totals.totalDistance) * 100))
+})
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,46 +1,46 @@
 <template>
   <div>
-    <section class="mb-12">
-      <img
-        src="/images/introduction/marian_segment0.png"
-        alt="Malemort to Ussel - Tour de France 2026 Virtual Challenge - 185km"
-        class="w-full max-w-md sm:max-w-lg mx-auto rounded-lg shadow-md mb-6"
-      >
-      <h1 class="text-3xl sm:text-4xl font-serif font-semibold text-correze-red mb-4 tracking-wide">
-        Malemort to Ussel
-      </h1>
-      <p class="text-xl text-stone-600 font-serif leading-relaxed">
-        A cycling travelogue following the 185km route of Stage 9 of the 2026 Tour de France,
-        through the hills, valleys, and villages of Correze.
-      </p>
-      <p class="mt-2 text-stone-500">
-        Published twice weekly, Sunday and Wednesday mornings.
-        The peloton rides this road on Sunday, July 12.
-      </p>
-      <div class="mt-4 p-4 bg-amber-100 rounded-lg text-sm text-stone-700">
-        <p class="font-semibold text-stone-800 mb-2">The Race</p>
-        <p>
-          Four riders are virtually cycling from the comfort of their homes. Starting in April,
-          each logs daily kilometres from their own rides, and we track their progress along the
-          185km Stage 9 parcours. Each day, up to 2km counts toward their position on the route -
-          but unused cap rolls over, rewarding rest days followed by big efforts. Four jerseys are
-          contested:
-          <JerseyIcon type="yellow" size="xs" class="inline-block mx-0.5" /> yellow for the race leader,
-          <JerseyIcon type="green" size="xs" class="inline-block mx-0.5" /> green for sprint points,
-          <JerseyIcon type="polkaDot" size="xs" class="inline-block mx-0.5" /> polka dot for climbing points,
-          and the
-          <JerseyIcon type="red" size="xs" class="inline-block mx-0.5" /> lanterne rouge for last place.
-        </p>
-        <NuxtLink to="/rules" class="inline-block mt-2 text-correze-red hover:underline font-medium">
-          Full competition rules
-        </NuxtLink>
-      </div>
-      <DayCounter class="mt-4" />
-    </section>
-
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-      <div class="lg:col-span-2">
-        <section class="mb-8">
+      <div class="lg:col-span-2 space-y-3">
+        <section class="flex items-center gap-4">
+          <img
+            src="/images/introduction/marian_segment0.png"
+            alt="Malemort to Ussel - Tour de France 2026 Virtual Challenge - 185km"
+            class="w-20 h-20 sm:w-24 sm:h-24 rounded-lg shadow-md flex-shrink-0 object-cover"
+          >
+          <div>
+            <h1 class="text-2xl sm:text-4xl font-serif font-semibold text-correze-red tracking-wide">
+              Malemort to Ussel
+            </h1>
+            <p class="text-sm sm:text-base text-stone-600 font-serif leading-snug mt-1">
+              Stage 9 of the 2026 Tour de France, 185km through Correze.
+            </p>
+          </div>
+        </section>
+
+        <StageSummary :latest-segment="latestSegment" />
+
+        <section>
+          <h2 class="text-2xl font-serif font-bold text-stone-800 mb-3">Latest Entries</h2>
+          <div v-if="entries && entries.length" class="space-y-3">
+            <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
+              <NuxtLink :to="entry.path || entry._path" class="block">
+                <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+                  Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+                </span>
+                <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+                <h3 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h3>
+                <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+                <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+              </NuxtLink>
+            </article>
+          </div>
+          <p v-else class="text-stone-500 italic">No entries published yet.</p>
+        </section>
+
+        <StageRaceInfo class="lg:hidden" />
+
+        <section>
           <h2 class="text-2xl font-serif font-bold text-stone-800 mb-4">The Route</h2>
           <SegmentMap
             :segment="0"
@@ -57,32 +57,14 @@
             <ElevationChart :elevation-data="overviewElevation" :segments="segments" :current-segment="0" :rider-stats="riderStats" :rider-config="riderConfig" :rider-points="riderPointsData" class="mt-6" />
           </ClientOnly>
         </section>
-
-        <section>
-          <h2 class="text-2xl font-serif font-bold text-stone-800 mb-6">Latest Entries</h2>
-          <div v-if="entries && entries.length" class="space-y-6">
-            <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-6 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
-              <NuxtLink :to="entry.path || entry._path" class="block">
-                <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
-                  Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
-                </span>
-                <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
-                <h3 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h3>
-                <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
-                <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
-              </NuxtLink>
-            </article>
-          </div>
-          <p v-else class="text-stone-500 italic">No entries published yet.</p>
-        </section>
       </div>
 
-      <aside>
+      <aside class="space-y-4">
+        <DayCounter />
         <RiderDashboard />
-        <div class="mt-6">
-          <PublishSchedule v-if="isDev" />
-          <StageDetails :current-km="latestKmEnd" />
-        </div>
+        <StageRaceInfo class="hidden lg:block" />
+        <PublishSchedule v-if="isDev" />
+        <StageDetails :current-km="latestKmEnd" />
       </aside>
     </div>
   </div>
@@ -141,10 +123,9 @@ const { data: entries } = await useAsyncData('entries', () =>
     .all()
 )
 
-const latestKmEnd = computed(() => {
-  const latest = entries.value?.[0]
-  return latest?.kmEnd || 0
-})
+const latestEntry = computed(() => entries.value?.[0])
+const latestKmEnd = computed(() => latestEntry.value?.kmEnd || 0)
+const latestSegment = computed(() => latestEntry.value?.segment || 0)
 
 function formatDate(dateStr) {
   if (!dateStr) return ''

--- a/tests/components/StageDetails.test.ts
+++ b/tests/components/StageDetails.test.ts
@@ -7,11 +7,13 @@ vi.mock('~/data/segments.json', () => ({
   default: [
     {
       segment: 1, km_start: 0, km_end: 7.1,
+      elevation_gain: 100, elevation_loss: 50,
       towns: ['Malemort', 'Brive-la-Gaillarde'], climbs: [],
       min_elevation: 214, start_lat: 45.13, start_lng: 1.54,
     },
     {
       segment: 2, km_start: 7.1, km_end: 14.2,
+      elevation_gain: 200, elevation_loss: 75,
       towns: [], climbs: ['Puy Boubou'],
       min_elevation: 172, start_lat: 45.08, start_lng: 1.56,
     },
@@ -30,10 +32,11 @@ describe('StageDetails', () => {
     expect(wrapper.text()).toContain('Puy Boubou')
   })
 
-  it('shows stage summary', () => {
+  it('shows stage summary derived from segment data', () => {
     const wrapper = mount(StageDetails)
-    expect(wrapper.text()).toContain('185 km')
-    expect(wrapper.text()).toContain('9 climbs')
+    expect(wrapper.text()).toContain('14 km')
+    expect(wrapper.text()).toContain('1 climbs')
+    expect(wrapper.text()).toContain('+300m elevation')
   })
 
   it('shows Towns and Climbs section headers', () => {

--- a/utils/stage-totals.ts
+++ b/utils/stage-totals.ts
@@ -1,0 +1,84 @@
+interface Segment {
+  segment: number
+  km_start: number
+  km_end: number
+  elevation_gain: number
+  elevation_loss: number
+  towns?: string[]
+  climbs?: string[]
+}
+
+export const CATEGORIZED_CLIMBS = new Set([
+  'Puy Boubou',
+  'Côte de Lagleygeolle',
+  'Côte de Miel',
+  'Côte des Naves',
+  'Puy de Lachaud',
+  'Suc au May',
+  'Côte de la Croix de Pey',
+  'Mont Bessou',
+  'Côte des Gardes',
+])
+
+export interface StageTotals {
+  totalDistance: number
+  totalElevationGain: number
+  totalElevationLoss: number
+  uniqueTowns: string[]
+  uniqueClimbs: string[]
+  uniqueCategorizedClimbs: string[]
+}
+
+export interface JourneyProgress {
+  kmRidden: number
+  elevationClimbed: number
+  climbsPassed: string[]
+  categorizedClimbsPassed: string[]
+  townsVisited: string[]
+}
+
+export function deriveTotals(segments: Segment[]): StageTotals {
+  const towns = new Set<string>()
+  const climbs = new Set<string>()
+  let totalElevationGain = 0
+  let totalElevationLoss = 0
+
+  for (const seg of segments) {
+    for (const t of seg.towns || []) towns.add(t)
+    for (const c of seg.climbs || []) climbs.add(c)
+    totalElevationGain += seg.elevation_gain
+    totalElevationLoss += seg.elevation_loss
+  }
+
+  return {
+    totalDistance: segments.length ? segments[segments.length - 1].km_end : 0,
+    totalElevationGain,
+    totalElevationLoss,
+    uniqueTowns: Array.from(towns),
+    uniqueClimbs: Array.from(climbs),
+    uniqueCategorizedClimbs: Array.from(climbs).filter(c => CATEGORIZED_CLIMBS.has(c)),
+  }
+}
+
+export function journeyThroughSegment(segments: Segment[], latestSegmentNumber: number): JourneyProgress {
+  const passed = segments.filter(s => s.segment <= latestSegmentNumber)
+  const climbs = new Set<string>()
+  const towns = new Set<string>()
+  let elevationClimbed = 0
+  let kmRidden = 0
+
+  for (const seg of passed) {
+    for (const c of seg.climbs || []) climbs.add(c)
+    for (const t of seg.towns || []) towns.add(t)
+    elevationClimbed += seg.elevation_gain
+    kmRidden = seg.km_end
+  }
+
+  return {
+    kmRidden,
+    elevationClimbed,
+    climbsPassed: Array.from(climbs),
+    categorizedClimbsPassed: Array.from(climbs).filter(c => CATEGORIZED_CLIMBS.has(c)),
+    townsVisited: Array.from(towns),
+  }
+}


### PR DESCRIPTION
Closes #361, closes #381.

## Summary

- Reorders the homepage so Latest Entries sits near the top; hero is now an inline thumbnail, intro collapses to one line, DayCounter and the amber Race block move to the sidebar on desktop.
- Adds a `StageSummary` strip with distance, elevation gain, categorized climb count (with Mont Bessou highlighted), town count, and stage date, plus a progress bar showing journey-so-far (km ridden, meters climbed, climbs passed) based on the latest published entry.
- Introduces `utils/stage-totals.ts` (`deriveTotals`, `journeyThroughSegment`, `CATEGORIZED_CLIMBS`) and switches `StageDetails` footer to computed values so the numbers stay in sync with `data/segments.json`.
- Amber Race block now lives in `components/StageRaceInfo.vue`, rendered in the sidebar on desktop and inline below Latest Entries on mobile.

Progress framing is deliberately journey-state, not publication-state, so the site reads as a ride in progress rather than a schedule.

## Test plan

- [x] `npm run test` (83 passed; StageDetails summary test updated to match computed values)
- [x] `npm run generate` builds cleanly, produces correct values in `.output/public/index.html`
- [x] Mobile 375x667: at least one Latest Entries card visible without scrolling
- [x] Desktop 1280x800: three Latest Entries cards visible (2 full + 3rd with title)
- [x] `/rules` reachable from the Race block on both viewports
- [x] The Route map + elevation chart still render below
- [ ] Spot-check on a real mobile device before merge

## Notes

- `uniqueCategorizedClimbs` filters to the nine climbs in CLAUDE.md; total data-derived climbs is 10 (Côte de Malemort is in segment 1 but uncategorized). StageSummary and StageDetails footer both now display 9 (categorized).
- `data/segments.json` yields `3,411 m` total gain; the previous hardcoded footer said `3,390 m`. The computed value is treated as authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)