### PR TITLE
Branch cleanup: add repeatable script, prune 122 local + 17 remote branches (#385)

### DIFF
--- a/scripts/list-stale-branches.sh
+++ b/scripts/list-stale-branches.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# List local branches that appear to be squash-merged into main and are safe to delete.
+#
+# Heuristic: GitHub records each merged PR's head ref. A local branch whose name
+# matches a merged PR's head ref is almost certainly the squash-merged branch and
+# can be deleted. Branches without a name match fall through and are listed
+# separately for manual review (they may be pre-PR hotfixes or orphaned work).
+#
+# Usage:
+#   ./scripts/list-stale-branches.sh              # report only
+#   ./scripts/list-stale-branches.sh --delete     # delete the name-matched branches locally
+#   ./scripts/list-stale-branches.sh --delete --push-remote  # also push-delete remote branches
+#
+# Requires: gh CLI authenticated for the current repo.
+
+set -e
+
+DELETE=0
+PUSH_REMOTE=0
+for arg in "$@"; do
+    case "$arg" in
+        --delete) DELETE=1 ;;
+        --push-remote) PUSH_REMOTE=1 ;;
+        -h|--help)
+            sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+git fetch --prune origin >/dev/null 2>&1
+
+gh pr list --state merged --limit 500 --json headRefName --jq '.[].headRefName' \
+    | sort -u > "$tmpdir/merged.txt"
+
+git branch --format '%(refname:short)' | grep -v '^main$' | sort -u > "$tmpdir/local.txt"
+
+comm -12 "$tmpdir/local.txt" "$tmpdir/merged.txt" > "$tmpdir/safe.txt"
+comm -23 "$tmpdir/local.txt" "$tmpdir/merged.txt" > "$tmpdir/ambiguous.txt"
+
+echo "=== Safe to delete (name matches merged PR): $(wc -l < "$tmpdir/safe.txt") ==="
+cat "$tmpdir/safe.txt"
+echo ""
+echo "=== Ambiguous (no PR name match, review manually): $(wc -l < "$tmpdir/ambiguous.txt") ==="
+cat "$tmpdir/ambiguous.txt"
+
+if [ "$DELETE" = "1" ]; then
+    echo ""
+    echo "=== Deleting local branches ==="
+    while read -r b; do [ -n "$b" ] && git branch -D "$b"; done < "$tmpdir/safe.txt"
+fi
+
+if [ "$PUSH_REMOTE" = "1" ]; then
+    git branch -r --format '%(refname:short)' | sed 's|^origin/||' \
+        | grep -v '^HEAD' | grep -v '^main$' | sort -u > "$tmpdir/remote.txt"
+    comm -12 "$tmpdir/remote.txt" "$tmpdir/merged.txt" > "$tmpdir/remote_safe.txt"
+    if [ -s "$tmpdir/remote_safe.txt" ]; then
+        echo ""
+        echo "=== Deleting remote branches ==="
+        refs=$(sed 's|^|:|' "$tmpdir/remote_safe.txt" | tr '\n' ' ')
+        git push origin $refs
+    fi
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/list-stale-branches.sh` — documents and automates the heuristic: a local branch whose name matches a merged-PR head ref is safe to delete.
- Cleanup already performed on this clone: **122 local** and **17 remote** branches deleted, all verified as squash-merged into main.
- 1 remote branch intentionally left: `dependabot/npm_and_yarn/minor-and-patch-986db82916` (open PR #363).

## Method

1. Intersect `git branch` with `gh pr list --state merged --json headRefName`. Name matches → safe to delete (115 of 122 local).
2. For the 7 local branches without a name match, verify squash-merge by patch-id (`git cherry -v main <branch>`) or by the commit message referencing a closed PR:
   - `feature/issue-103-flickr-search` — commit `cc6f7c8 Add Flickr CC image search to admin (#103)`
   - `feature/issue-233-narrative-rewrites` — commit `9e88ec3 ... (#233)`
   - `fix/issue-218-brive-location` — commit `8476dc6 ... (#218)`
   - `fix/ci-rider-data-seed` — patch-id matches upstream
   - `fix/jersey-precedence-order` — patch-id matches `3129d7b ... (#262)`
   - `release/publish-fix`, `release/v0.4.0` — all unique commits reference merged PRs (#182, #178, #177, #174, #159 etc.)
3. Remote branches pruned via single `git push origin :ref1 :ref2 ...`.

## Acceptance criteria

- [x] Documented heuristic as a repeatable script (`scripts/list-stale-branches.sh`)
- [x] Stale merged branches deleted locally (122)
- [x] Corresponding remote branches deleted (17)
- [x] Ambiguous branches listed above for manual review before merge
- [x] `git branch` reduced to current work (now just `main` and this branch); `git branch -r` down to `origin/main` + the open Dependabot PR

## Retro note

Causes of accumulation captured in `project_next_planning_notes.md` under a new "v1.4.6 retro" section. The only durable preventative that looks worth pursuing is enabling GitHub's "Automatically delete head branches" repo setting.

## Test plan

- [x] Script runs cleanly on this repo (`./scripts/list-stale-branches.sh` reports 0 safe, 1 ambiguous — this branch)
- [x] `--delete` and `--push-remote` flags gated behind explicit opt-in
- [ ] Verify remote state on GitHub matches local expectation after merge

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)