### PR TITLE
Segment 6 data fix: Beynat and Lanteuil town positions (#395)

### DIFF
--- a/data/segments.json
+++ b/data/segments.json
@@ -108,7 +108,7 @@
     "max_elevation": 259,
     "notable_points": [],
     "towns": [
-      "Beynat"
+      "Lanteuil"
     ],
     "climbs": [
       "Côte de Lagleygeolle"
@@ -127,7 +127,9 @@
     "min_elevation": 259,
     "max_elevation": 537,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Beynat"
+    ],
     "climbs": [
       "Côte de Lagleygeolle"
     ]

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -18,7 +18,8 @@ export const townKmPositions: Record<string, number> = {
   'Ligneyrac': 17.11,        // verified 2026-04-11, 628m south of route
   'Collonges-la-Rouge': 21.75, // verified 2026-04-11, first arrival (219m from village)
   'Meyssac': 23.70,          // verified 2026-04-11, 277m from village
-  'Beynat': 37.5,
+  'Lanteuil': 38.35,         // verified 2026-04-21, 115m from village (seg 6)
+  'Beynat': 46.23,           // verified 2026-04-21, 75m from village (seg 7; previously mispinned at 37.5)
   'Tulle': 65.5,
   'Naves': 73.5,
   'Chaumeil': 90,


### PR DESCRIPTION
## Summary

Route-proximity check against \`data/main.gpx\` shows Lanteuil village is in segment 6 (km 38.35) and Beynat village is in segment 7 (km 46.23). The stored \`Beynat: 37.5\` was unverified legacy data from the pre-#321 hardcoded table and happened to sit roughly where Lanteuil actually is — which is why segment 6's elevation chart label looked mispositioned.

## Changes

- \`data/town-positions.ts\`: \`Beynat: 37.5\` → \`Beynat: 46.23\` (verified 75 m from route), add \`Lanteuil: 38.35\` (verified 115 m from route) so segment 6's chart retains a label
- \`data/segments.json\` seg 6 \`towns\`: \`[\"Beynat\"]\` → \`[\"Lanteuil\"]\`
- \`data/segments.json\` seg 7 \`towns\`: \`[]\` → \`[\"Beynat\"]\`

## Not changed

- \`data/attractions.json\`: Aubazine Abbey is already correct (\`nearest_km: 38.9\`, \`nearest_distance_m: 4716\`) via the \`processing/calculate_attraction_positions.py\` pipeline from #344. The issue description over-scoped this; correcting that note in #395.
- Narrative: already reconciled in the narrative commit merged as part of PR #394 (segment 6 now says \"crosses the commune along its northern reach\" rather than \"enters the village\").
- Root-cause systematic fix: tracked in the v1.4.8 audit epic (#396), #341, and #369.

## Test plan

- [x] \`npm test -- --run\` passes (83/83)
- [ ] Visual check after merge: segment 6 elevation profile (should now show \"Lanteuil\" label at ~km 38), segment 7 elevation profile (should show \"Beynat\" label at ~km 46), homepage elevation profile (Beynat should move east)
- [ ] Stage details card for seg 6 and seg 7
- [ ] Nearby attractions still correct for seg 6

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)