### PR TITLE
Image picker: round-trip frontmatter through js-yaml (#327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See the [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) for planned work
 
 ## Getting Started
 
-Requires Node.js 22+ and Python 3.11+.
+Requires Node.js 22+ and Python 3.11+. The Node version is pinned in `.nvmrc`.
 
 ```bash
 # Use correct Node version (if using nvm)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chart.js": "^4.4.0",
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-zoom": "^2.2.0",
+        "js-yaml": "^4.1.1",
         "leaflet": "^1.9.4",
         "marked": "^18.0.0",
         "nuxt": "^4.4.2",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@nuxt/eslint-config": "^1.15.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/leaflet": "^1.9.8",
         "@vitest/coverage-v8": "^4.1.4",
         "@vue/test-utils": "^2.4.6",
@@ -4674,6 +4676,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chart.js": "^4.4.0",
     "chartjs-plugin-annotation": "^3.1.0",
     "chartjs-plugin-zoom": "^2.2.0",
+    "js-yaml": "^4.1.1",
     "leaflet": "^1.9.4",
     "marked": "^18.0.0",
     "nuxt": "^4.4.2",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.15.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/leaflet": "^1.9.8",
     "@vitest/coverage-v8": "^4.1.4",
     "@vue/test-utils": "^2.4.6",

--- a/server/api/images.post.ts
+++ b/server/api/images.post.ts
@@ -1,5 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve, join } from 'path'
+import yaml from 'js-yaml'
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---(\r?\n?)/
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -10,15 +13,32 @@ export default defineEventHandler(async (event) => {
   }
 
   const filePath = join(resolve('content/entries'), filename)
-  let content = readFileSync(filePath, 'utf8')
+  const content = readFileSync(filePath, 'utf8')
 
-  const imagesJson = JSON.stringify(images)
-  content = content.replace(
-    /^images:.*$/m,
-    `images: ${imagesJson}`
-  )
+  const match = content.match(FRONTMATTER_RE)
+  if (!match || match[1] === undefined) {
+    throw createError({ statusCode: 422, message: `Entry ${filename} has no frontmatter block` })
+  }
 
-  writeFileSync(filePath, content)
+  const rawFrontmatter = match[1]
+  const parsed = yaml.load(rawFrontmatter)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw createError({ statusCode: 422, message: `Entry ${filename} frontmatter is not a mapping` })
+  }
+
+  const frontmatter = parsed as Record<string, unknown>
+  frontmatter.images = images
+
+  const dumped = yaml.dump(frontmatter, {
+    lineWidth: -1,
+    flowLevel: 1,
+    noRefs: true,
+    quotingType: '"',
+  })
+
+  const body_ = content.slice(match[0].length)
+  const rebuilt = `---\n${dumped}---\n${body_}`
+  writeFileSync(filePath, rebuilt)
 
   return { success: true, filename, count: images.length }
 })

--- a/tests/api/images.test.ts
+++ b/tests/api/images.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import yaml from 'js-yaml'
 import { mockEvent } from './helpers'
 
 import getHandler from '~/server/api/images.get'
@@ -57,7 +58,65 @@ describe('POST /api/images', () => {
     mockedReadFile.mockReturnValue('---\nsegment: 1\nimages: []\n---\n# Content')
     const images = [{ src: '/img/new.jpg', alt: 'New photo' }]
     await (postHandler as Function)(mockEvent({ body: { filename: '01-test.md', images } }))
-    const written = mockedWriteFile.mock.calls[0][1] as string
+    const written = mockedWriteFile.mock.calls[0]![1] as string
     expect(written).toContain('/img/new.jpg')
+  })
+
+  it('preserves valid YAML when entry has a multi-line images list', async () => {
+    const existing = [
+      '---',
+      'segment: 1',
+      'title: "Example"',
+      'images:',
+      '  - src: /img/a.jpg',
+      '    alt: First',
+      '  - src: /img/b.jpg',
+      '    alt: Second',
+      '---',
+      '# Content',
+    ].join('\n')
+    mockedReadFile.mockReturnValue(existing)
+    const images = [{ src: '/img/c.jpg', alt: 'Third' }]
+    await (postHandler as Function)(mockEvent({ body: { filename: '01-test.md', images } }))
+    const written = mockedWriteFile.mock.calls[0]![1] as string
+    const match = written.match(/^---\n([\s\S]*?)\n---/)
+    expect(match).not.toBeNull()
+    const parsed: any = yaml.load(match![1] as string)
+    expect(parsed.segment).toBe(1)
+    expect(parsed.title).toBe('Example')
+    expect(parsed.images).toEqual(images)
+    // The old src values must be gone — not dangling orphan list items below the replaced line.
+    expect(written).not.toContain('/img/a.jpg')
+    expect(written).not.toContain('/img/b.jpg')
+  })
+
+  it('replaces the full list when adding to an entry that already has multiple inline images', async () => {
+    const existing = '---\nsegment: 1\nimages: [{"src":"/img/a.jpg"},{"src":"/img/b.jpg"}]\n---\n# Content'
+    mockedReadFile.mockReturnValue(existing)
+    const images = [
+      { src: '/img/a.jpg', alt: 'A' },
+      { src: '/img/b.jpg', alt: 'B' },
+      { src: '/img/c.jpg', alt: 'C' },
+    ]
+    await (postHandler as Function)(mockEvent({ body: { filename: '01-test.md', images } }))
+    const written = mockedWriteFile.mock.calls[0]![1] as string
+    const match = written.match(/^---\n([\s\S]*?)\n---/)
+    const parsed: any = yaml.load(match![1] as string)
+    expect(parsed.images).toHaveLength(3)
+    expect(parsed.images[2].src).toBe('/img/c.jpg')
+    expect(written).toContain('# Content')
+  })
+
+  it('adds an images key when the entry has imagesOptional: true and no existing images list', async () => {
+    const existing = '---\nsegment: 1\nimagesOptional: true\n---\n# Content'
+    mockedReadFile.mockReturnValue(existing)
+    const images = [{ src: '/img/new.jpg', alt: 'New' }]
+    await (postHandler as Function)(mockEvent({ body: { filename: '01-test.md', images } }))
+    const written = mockedWriteFile.mock.calls[0]![1] as string
+    const match = written.match(/^---\n([\s\S]*?)\n---/)
+    expect(match).not.toBeNull()
+    const parsed: any = yaml.load(match![1] as string)
+    expect(parsed.imagesOptional).toBe(true)
+    expect(parsed.images).toEqual(images)
   })
 })


### PR DESCRIPTION
## Summary

- Replace the single-line regex in `server/api/images.post.ts` with a `js-yaml` round-trip so the images field updates don't corrupt multi-line YAML or silently no-op on `imagesOptional` entries.
- Add three failing tests before the fix: multi-line YAML list, adding to an inline multi-image list, and `imagesOptional: true` with no prior images key.
- README picks up a one-line note that the Node version is pinned in `.nvmrc`.

Closes #327. Part of v1.4.7.

## Test plan

- [x] New tests fail against the regex implementation (verified before applying the fix)
- [x] `npx vitest run` — 86/86 passing
- [x] `npm run lint` — clean on Node 22
- [x] `npx nuxt typecheck` — 25 errors, 1 below pre-change baseline of 26
- [ ] Manual: save images on an entry with `imagesOptional: true` via the admin picker (publisher sanity check before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)