### PR TITLE
Rider admin: propagate subprocess failures, run calculate_points (#330)

### DIFF
--- a/pages/admin/riders.vue
+++ b/pages/admin/riders.vue
@@ -142,8 +142,9 @@ async function submitEntry() {
     for (const r of riders.value) {
       entryDistances.value[r.id] = 0
     }
-  } catch {
-    saveMessage.value = 'Error saving entry.'
+  } catch (err) {
+    const serverMessage = err?.data?.message || err?.data?.statusMessage || err?.statusMessage || err?.message
+    saveMessage.value = serverMessage ? `Error: ${serverMessage}` : 'Error saving entry.'
     saveError.value = true
   } finally {
     submitting.value = false

--- a/server/api/riders.post.ts
+++ b/server/api/riders.post.ts
@@ -2,6 +2,22 @@ import { readFileSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { execSync } from 'child_process'
 
+function runPython(scriptPath: string, args: string[]) {
+  const venvPython = resolve('processing/.venv/bin/python')
+  const cmd = [venvPython, scriptPath, ...args].map(s => JSON.stringify(s)).join(' ')
+  try {
+    execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (err: unknown) {
+    const e = err as { stderr?: Buffer | string; message?: string }
+    const stderr = e.stderr ? e.stderr.toString().trim() : ''
+    const scriptName = scriptPath.split('/').pop() ?? scriptPath
+    throw createError({
+      statusCode: 500,
+      message: `${scriptName} failed: ${stderr || e.message || 'unknown error'}`,
+    })
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { date, distances } = body
@@ -13,30 +29,27 @@ export default defineEventHandler(async (event) => {
   const logPath = resolve('data/riders/daily-log.json')
   const configPath = resolve('data/riders/rider-config.json')
   const statsPath = resolve('data/riders/stats.json')
+  const pointsConfigPath = resolve('data/competition/points-config.json')
+  const pointsPath = resolve('data/riders/points.json')
 
-  // Read current log
   const log = JSON.parse(readFileSync(logPath, 'utf8'))
-
-  // Remove existing entry for this date if it exists
-  log.entries = log.entries.filter((e: any) => e.date !== date)
-
-  // Add new entry
+  log.entries = log.entries.filter((e: { date: string }) => e.date !== date)
   log.entries.push({ date, distances })
-  log.entries.sort((a: any, b: any) => a.date.localeCompare(b.date))
-
-  // Write updated log
+  log.entries.sort((a: { date: string }, b: { date: string }) => a.date.localeCompare(b.date))
   writeFileSync(logPath, JSON.stringify(log, null, 2))
 
-  // Regenerate stats
-  try {
-    const venvPython = resolve('processing/.venv/bin/python')
-    const statsScript = resolve('processing/rider_stats.py')
-    execSync(`${venvPython} ${statsScript} --daily-log ${logPath} --rider-config ${configPath} --output ${statsPath}`)
-  } catch (err: any) {
-    console.error('Stats regeneration failed:', err.message)
-  }
+  runPython(resolve('processing/rider_stats.py'), [
+    '--daily-log', logPath,
+    '--rider-config', configPath,
+    '--output', statsPath,
+  ])
+  runPython(resolve('processing/calculate_points.py'), [
+    '--daily-log', logPath,
+    '--rider-config', configPath,
+    '--points-config', pointsConfigPath,
+    '--output', pointsPath,
+  ])
 
-  // Read and return updated stats
   const stats = JSON.parse(readFileSync(statsPath, 'utf8'))
   return { success: true, stats }
 })

--- a/tests/api/riders.test.ts
+++ b/tests/api/riders.test.ts
@@ -59,7 +59,7 @@ describe('POST /api/riders', () => {
     expect(result.success).toBe(true)
     const writtenLog = JSON.parse(mockedWriteFile.mock.calls[0][1] as string)
     expect(writtenLog.entries).toHaveLength(2)
-    expect(mockedExec).toHaveBeenCalledOnce()
+    expect(mockedExec).toHaveBeenCalledTimes(2)
   })
 
   it('replaces existing entry for same date', async () => {
@@ -89,5 +89,50 @@ describe('POST /api/riders', () => {
 
   it('throws 400 without distances', async () => {
     await expect((postHandler as Function)(mockEvent({ body: { date: '2026-04-02' } }))).rejects.toThrow('Missing date or distances')
+  })
+
+  it('returns 5xx with stderr text when rider_stats.py fails', async () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog)
+    mockedExec.mockImplementationOnce(() => {
+      const err: any = new Error('Command failed')
+      err.status = 1
+      err.stderr = Buffer.from('Traceback: division by zero in rider_stats')
+      throw err
+    })
+    await expect(
+      (postHandler as Function)(mockEvent({ body: { date: '2026-04-03', distances: { alice: 2.0 } } }))
+    ).rejects.toMatchObject({
+      statusCode: 500,
+      message: expect.stringContaining('Traceback: division by zero in rider_stats'),
+    })
+  })
+
+  it('invokes calculate_points.py after rider_stats.py on success', async () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog).mockReturnValueOnce(sampleStats)
+    mockedExec.mockReturnValue(Buffer.from(''))
+    await (postHandler as Function)(mockEvent({ body: { date: '2026-04-03', distances: { alice: 2.0 } } }))
+    expect(mockedExec).toHaveBeenCalledTimes(2)
+    const firstCallArgs = JSON.stringify(mockedExec.mock.calls[0])
+    const secondCallArgs = JSON.stringify(mockedExec.mock.calls[1])
+    expect(firstCallArgs).toContain('rider_stats.py')
+    expect(secondCallArgs).toContain('calculate_points.py')
+  })
+
+  it('returns 5xx with stderr text when calculate_points.py fails', async () => {
+    mockedReadFile.mockReturnValueOnce(sampleLog)
+    mockedExec
+      .mockReturnValueOnce(Buffer.from(''))
+      .mockImplementationOnce(() => {
+        const err: any = new Error('Command failed')
+        err.status = 1
+        err.stderr = Buffer.from('KeyError: missing rider in points-config')
+        throw err
+      })
+    await expect(
+      (postHandler as Function)(mockEvent({ body: { date: '2026-04-03', distances: { alice: 2.0 } } }))
+    ).rejects.toMatchObject({
+      statusCode: 500,
+      message: expect.stringContaining('KeyError: missing rider in points-config'),
+    })
   })
 })


### PR DESCRIPTION
## Summary

- POST /api/riders no longer swallows subprocess failures. A failing rider_stats.py or calculate_points.py now throws a 500 with the subprocess stderr attached as the error message.
- calculate_points.py is now invoked in sequence after rider_stats.py so points stay in sync with stats.
- Admin riders UI surfaces the actual server error message instead of a generic string.

Closes #330. Part of v1.4.7.

## Test plan

- [x] Three new vitest tests fail against the old handler (verified before implementation): rider_stats.py failure surface, points.py invocation after stats, points.py failure surface.
- [x] Full vitest suite: 86/86 passing.
- [x] \`npx nuxt typecheck\`: 26 errors, same as main baseline (no regressions).
- [x] \`npm run lint\`: clean on Node 22.
- [ ] Manual: publisher sanity check — intentionally break rider_stats.py (e.g. rename data/riders/rider-config.json) and confirm the admin UI shows the traceback, not a green success.
- [ ] Manual: publisher sanity check — log a rider distance normally and confirm data/riders/points.json is updated alongside data/riders/stats.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)