### PR TITLE
split_gpx.py: assign towns by route-proximity (#341)

### DIFF
--- a/processing/README.md
+++ b/processing/README.md
@@ -13,22 +13,27 @@ python3 -m venv .venv
 
 ### split_gpx.py
 
-Parses `data/main.gpx` and splits the route into 26 segments.
+Parses `data/main.gpx` and splits the route into 27 segments.
 
 ```bash
 .venv/bin/python split_gpx.py
 ```
 
-**Input:** `data/main.gpx`
+**Input:**
+- `data/main.gpx`
+- `data/town-coords.json` (towns assigned by route-proximity to the closest segment)
+
 **Output:**
-- `data/segments/segment-NN.gpx` (26 files)
-- `data/segments.json` (segment metadata with coordinates, towns, climbs)
+- `data/segments/segment-NN.gpx` (27 files)
+- `data/segments.json` (segment metadata; per-segment `towns` list and `town_positions` map of name→closest-approach km)
 
 **Options:**
 - `--gpx PATH` — GPX file (default: `data/main.gpx`)
 - `--output-dir DIR` — segment GPX output (default: `data/segments`)
 - `--json-output PATH` — metadata JSON (default: `data/segments.json`)
-- `--num-segments N` — number of segments (default: 26)
+- `--town-coords PATH` — town coordinates (default: `data/town-coords.json`)
+- `--town-max-distance-m N` — towns farther than this from the route are excluded from segment assignment (default: 1000)
+- `--num-segments N` — number of segments (default: 27)
 
 ### elevation_profile.py
 

--- a/processing/split_gpx.py
+++ b/processing/split_gpx.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Parse main.gpx, split into 26 segments, output segment GPX files and segments.json."""
+"""Parse main.gpx, split into segments, output per-segment GPX files and segments.json.
+
+Towns are assigned to segments by route-proximity (#341): for each town in
+data/town-coords.json the script finds the closest point on the route, records
+the cumulative km at that point, and assigns the town to whichever segment
+contains that km. Towns more than --town-max-distance from the route are
+excluded entirely (catches off-route landmarks like Brive-la-Gaillarde, which
+the route passes 2.5 km away).
+
+The closest-approach km is also recorded per segment under `town_positions`,
+so downstream consumers (e.g. data/town-positions.ts) can be regenerated
+from segments.json instead of hand-maintained.
+"""
 
 import argparse
 import json
@@ -9,24 +21,10 @@ import os
 import gpxpy
 import gpxpy.gpx
 
-# Known waypoints with approximate km positions along the route
-KNOWN_TOWNS = {
-    "Malemort": 0,
-    "Turenne": 17,
-    "Collonges-la-Rouge": 23.5,
-    "Beynat": 37.5,
-    "Tulle": 65.5,
-    "Naves": 73.5,
-    "Chaumeil": 90,
-    "Treignac": 116.5,
-    "Bugeat": 130,
-    "Meymac": 157.5,
-    "Ussel": 182.5,
-}
-
-POINTS_CONFIG_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "..", "data", "competition", "points-config.json"
-)
+DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data")
+POINTS_CONFIG_PATH = os.path.join(DATA_DIR, "competition", "points-config.json")
+TOWN_COORDS_PATH = os.path.join(DATA_DIR, "town-coords.json")
+DEFAULT_TOWN_MAX_DISTANCE_M = 1000.0
 
 
 def load_known_climbs(path=POINTS_CONFIG_PATH):
@@ -68,6 +66,88 @@ def haversine(lat1, lon1, lat2, lon2):
     return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
+def _project_onto_polyline_segment(q_lat, q_lng, a_lat, a_lng, a_km, b_lat, b_lng, b_km):
+    """Project Q onto the line segment A->B using a local equirectangular frame.
+
+    Returns (km, distance_m) for the closest point on the segment. Mirrors the
+    helper in audit_segment_data.py so split_gpx and the audit agree on
+    closest-approach math without forcing a cross-import.
+    """
+    lat_scale = 111_000.0
+    lng_scale = 111_000.0 * math.cos(math.radians(q_lat))
+    ax = (a_lng - q_lng) * lng_scale
+    ay = (a_lat - q_lat) * lat_scale
+    bx = (b_lng - q_lng) * lng_scale
+    by = (b_lat - q_lat) * lat_scale
+    dx = bx - ax
+    dy = by - ay
+    seg_len_sq = dx * dx + dy * dy
+    if seg_len_sq < 1e-12:
+        return a_km, math.hypot(ax, ay)
+    t = -(ax * dx + ay * dy) / seg_len_sq
+    t = max(0.0, min(1.0, t))
+    cx = ax + t * dx
+    cy = ay + t * dy
+    return a_km + t * (b_km - a_km), math.hypot(cx, cy)
+
+
+def closest_approach(points, lat, lng):
+    """Find closest-approach point on the GPX polyline to (lat, lng).
+
+    Returns (km, distance_m). Picks the closest vertex by cheap squared
+    distance, then projects onto the two adjacent polyline segments so the
+    reported km is precise between vertices rather than snapped to the grid.
+    """
+    cos_lat = math.cos(math.radians(lat))
+    best_i = 0
+    best_d_sq = float("inf")
+    for i, p in enumerate(points):
+        dlat = p["lat"] - lat
+        dlng = (p["lon"] - lng) * cos_lat
+        d_sq = dlat * dlat + dlng * dlng
+        if d_sq < best_d_sq:
+            best_d_sq = d_sq
+            best_i = i
+    candidates = [(
+        points[best_i]["cum_km"],
+        haversine(points[best_i]["lat"], points[best_i]["lon"], lat, lng),
+    )]
+    if best_i > 0:
+        a, b = points[best_i - 1], points[best_i]
+        candidates.append(_project_onto_polyline_segment(
+            lat, lng, a["lat"], a["lon"], a["cum_km"], b["lat"], b["lon"], b["cum_km"],
+        ))
+    if best_i < len(points) - 1:
+        a, b = points[best_i], points[best_i + 1]
+        candidates.append(_project_onto_polyline_segment(
+            lat, lng, a["lat"], a["lon"], a["cum_km"], b["lat"], b["lon"], b["cum_km"],
+        ))
+    return min(candidates, key=lambda c: c[1])
+
+
+def load_town_coords(path=TOWN_COORDS_PATH):
+    """Load all entries from town-coords.json. Caller filters by `type` field."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def compute_town_proximity(points, town_coords):
+    """Closest-approach lookup for each town.
+
+    For every entry whose `type` is `town`, returns {km, distance_m}. Climbs
+    are skipped (their summit positions are #369's job). The km is the
+    cumulative km from the route start to the closest point on the polyline,
+    not the nearest vertex.
+    """
+    result = {}
+    for name, info in town_coords.items():
+        if info.get("type") != "town":
+            continue
+        km, dist = closest_approach(points, info["lat"], info["lng"])
+        result[name] = {"km": round(km, 2), "distance_m": round(dist)}
+    return result
+
+
 def parse_gpx(gpx_path):
     """Parse GPX file, return list of (lat, lon, ele, cumulative_dist_km) tuples."""
     with open(gpx_path, "r") as f:
@@ -92,28 +172,30 @@ def parse_gpx(gpx_path):
     return points
 
 
-def load_existing_towns(path):
-    """Return {segment_number: [towns]} from an existing segments.json if present.
-
-    Used to preserve hand-verified town assignments (#342) that the km-bbox logic
-    below would otherwise regress. The structural fix for town assignment is
-    tracked in #341.
-    """
-    if not os.path.exists(path):
-        return {}
-    with open(path) as f:
-        data = json.load(f)
-    return {s["segment"]: s.get("towns", []) for s in data}
-
-
-def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0, existing_towns=None):
+def split_into_segments(
+    points,
+    num_segments=27,
+    odd_length=8.0,
+    even_length=6.0,
+    town_coords=None,
+    town_max_distance_m=DEFAULT_TOWN_MAX_DISTANCE_M,
+):
     """Split points into segments with alternating lengths.
 
     Odd segments (1,3,5,...) are odd_length km.
     Even segments (2,4,6,...) are even_length km.
     The final segment gets the remainder.
+
+    Towns are assigned by route-proximity if `town_coords` is provided: each
+    town's closest-approach km is computed once against the full polyline and
+    used to bucket it into the segment whose [km_start, km_end) contains it.
+    Towns farther than `town_max_distance_m` from the route are excluded.
     """
     total_km = points[-1]["cum_km"]
+    if town_coords:
+        town_proximity = compute_town_proximity(points, town_coords)
+    else:
+        town_proximity = {}
 
     # Build km boundaries
     boundaries = [0.0]
@@ -160,18 +242,21 @@ def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0
             for i in range(1, len(seg_points))
         )
 
-        # Find towns in this segment. Prefer hand-verified assignments from an
-        # existing segments.json (see #342) over the km-bbox heuristic, since
-        # the heuristic is known-wrong and its structural fix is tracked in #341.
-        if existing_towns and seg_num in existing_towns:
-            towns = existing_towns[seg_num]
-        else:
-            towns = [
-                name for name, km in KNOWN_TOWNS.items()
-                if km_start <= km <= km_end
-            ]
+        # Find towns in this segment via route-proximity (#341).
+        # Half-open [km_start, km_end) so a town landing exactly on a boundary
+        # only appears once.
+        towns = []
+        town_positions = {}
+        for name, prox in town_proximity.items():
+            if prox["distance_m"] > town_max_distance_m:
+                continue
+            km = prox["km"]
+            if km_start <= km < km_end:
+                towns.append(name)
+                town_positions[name] = km
 
-        # Find climbs in this segment
+        # Find climbs in this segment (km-range from points-config; #369 will
+        # refactor this to summit-from-GPX-elevation-peak).
         climbs = [
             name for name, info in KNOWN_CLIMBS.items()
             if info["km_start"] < km_end and info["km_end"] > km_start
@@ -191,6 +276,7 @@ def split_into_segments(points, num_segments=27, odd_length=8.0, even_length=6.0
             "max_elevation": round(max(elevations)),
             "notable_points": [],
             "towns": towns,
+            "town_positions": town_positions,
             "climbs": climbs,
             "points": seg_points,  # kept for GPX output, removed from JSON
         })
@@ -227,6 +313,9 @@ def main():
     parser.add_argument("--gpx", default="data/main.gpx", help="Path to main GPX file")
     parser.add_argument("--output-dir", default="data/segments", help="Output directory for segment GPX files")
     parser.add_argument("--json-output", default="data/segments.json", help="Output path for segments metadata JSON")
+    parser.add_argument("--town-coords", default=TOWN_COORDS_PATH, help="Path to town-coords.json")
+    parser.add_argument("--town-max-distance-m", type=float, default=DEFAULT_TOWN_MAX_DISTANCE_M,
+                        help="Towns farther than this from the route are excluded from segment assignment")
     parser.add_argument("--num-segments", type=int, default=27, help="Number of segments")
     parser.add_argument("--odd-length", type=float, default=8.0, help="Length of odd segments (km)")
     parser.add_argument("--even-length", type=float, default=6.0, help="Length of even segments (km)")
@@ -238,10 +327,10 @@ def main():
     points = parse_gpx(args.gpx)
     print(f"Parsed {len(points)} trackpoints")
 
-    existing_towns = load_existing_towns(args.json_output)
+    town_coords = load_town_coords(args.town_coords)
     segments = split_into_segments(
         points, args.num_segments, args.odd_length, args.even_length,
-        existing_towns=existing_towns,
+        town_coords=town_coords, town_max_distance_m=args.town_max_distance_m,
     )
     print(f"Created {len(segments)} segments")
 

--- a/processing/tests/test_split_gpx.py
+++ b/processing/tests/test_split_gpx.py
@@ -7,8 +7,9 @@ import pytest
 
 from processing.split_gpx import (
     KNOWN_CLIMBS,
-    KNOWN_TOWNS,
+    compute_town_proximity,
     haversine,
+    load_town_coords,
     parse_gpx,
     split_into_segments,
     write_segment_gpx,
@@ -144,6 +145,95 @@ class TestSplitIntoSegments:
             assert isinstance(seg["climbs"], list)
 
 
+# --- compute_town_proximity ---
+
+class TestComputeTownProximity:
+    """Closest-approach lookup for each town against the GPX."""
+
+    def test_returns_km_and_distance_per_town(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        # Place a synthetic "town" right on the track at the third trackpoint.
+        coords = {"On Route": {"type": "town", "lat": 45.002, "lng": 1.5}}
+        prox = compute_town_proximity(points, coords)
+        assert "On Route" in prox
+        assert prox["On Route"]["distance_m"] < 5
+        # Track is dense at 0.001 deg lat (~111m) intervals; expect km < 0.5
+        assert prox["On Route"]["km"] < 0.5
+
+    def test_skips_non_town_types(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        coords = {
+            "Town": {"type": "town", "lat": 45.0, "lng": 1.5},
+            "Climb": {"type": "climb", "lat": 45.0, "lng": 1.5},
+        }
+        prox = compute_town_proximity(points, coords)
+        assert "Town" in prox
+        assert "Climb" not in prox
+
+
+# --- route-proximity town assignment ---
+
+class TestRouteProximityAssignment:
+    """split_into_segments uses closest-approach km, not km-range guessing, to bucket towns."""
+
+    def test_town_near_track_assigned_to_correct_segment(self, gpx_file):
+        # Track runs north along lon=1.5 from lat 45.0 to 45.009 (~1km).
+        # Two segments: 0-0.5km and 0.5-1km.
+        points = parse_gpx(gpx_file)
+        town_coords = {
+            # ~111m east of lat 45.001 (km ~0.11) -> seg 1
+            "Early Town": {"type": "town", "lat": 45.001, "lng": 1.501},
+            # ~111m east of lat 45.008 (km ~0.89) -> seg 2
+            "Late Town": {"type": "town", "lat": 45.008, "lng": 1.501},
+        }
+        segments = split_into_segments(
+            points, num_segments=2, odd_length=0.5, even_length=0.5,
+            town_coords=town_coords,
+        )
+        assert "Early Town" in segments[0]["towns"]
+        assert "Late Town" in segments[1]["towns"]
+        assert "Early Town" not in segments[1]["towns"]
+        assert "Late Town" not in segments[0]["towns"]
+
+    def test_far_off_route_town_excluded(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        town_coords = {
+            "Distant": {"type": "town", "lat": 47.0, "lng": 1.5},  # ~220km north
+        }
+        segments = split_into_segments(
+            points, num_segments=2, odd_length=0.5, even_length=0.5,
+            town_coords=town_coords, town_max_distance_m=1000,
+        )
+        for seg in segments:
+            assert "Distant" not in seg["towns"]
+
+    def test_town_positions_field_exposes_closest_approach_km(self, gpx_file):
+        points = parse_gpx(gpx_file)
+        town_coords = {
+            "Early Town": {"type": "town", "lat": 45.001, "lng": 1.501},
+        }
+        segments = split_into_segments(
+            points, num_segments=2, odd_length=0.5, even_length=0.5,
+            town_coords=town_coords,
+        )
+        assert "town_positions" in segments[0]
+        assert "Early Town" in segments[0]["town_positions"]
+        assert isinstance(segments[0]["town_positions"]["Early Town"], (int, float))
+
+
+# --- load_town_coords ---
+
+class TestLoadTownCoords:
+    def test_loads_real_file(self):
+        root = os.path.join(os.path.dirname(__file__), "..", "..")
+        path = os.path.join(root, "data", "town-coords.json")
+        if not os.path.exists(path):
+            pytest.skip("town-coords.json not found")
+        coords = load_town_coords(path)
+        assert "Malemort" in coords
+        assert "type" in coords["Malemort"]
+
+
 # --- write_segment_gpx ---
 
 class TestWriteSegmentGpx:
@@ -208,10 +298,21 @@ class TestRealData:
         assert "Ussel" in real_segments[-1]["towns"]
 
     def test_all_towns_assigned(self, real_segments):
+        # Towns within 1 km of the route should all appear on some segment.
+        # Brive-la-Gaillarde is intentionally off-route (2.5 km north) per
+        # the v1.4.8 audit decision and is excluded from segment assignment.
         all_towns = set()
         for seg in real_segments:
             all_towns.update(seg["towns"])
-        for town in KNOWN_TOWNS:
+        root = os.path.join(os.path.dirname(__file__), "..", "..")
+        coords_path = os.path.join(root, "data", "town-coords.json")
+        with open(coords_path) as f:
+            coords = json.load(f)
+        on_route_towns = [
+            n for n, v in coords.items()
+            if v.get("type") == "town" and n != "Brive-la-Gaillarde"
+        ]
+        for town in on_route_towns:
             assert town in all_towns, f"Town {town} not assigned to any segment"
 
     def test_all_climbs_assigned(self, real_segments):


### PR DESCRIPTION
## Summary

Replaces the km-heuristic + existing-segments fallback in `split_gpx.py` with a single-pass route-proximity assignment driven by `data/town-coords.json`.

For every town entry, the closest point on the GPX polyline is computed (vertex scan refined by per-segment projection, matching the math in `audit_segment_data.py`). The cumulative km at that point is used to bucket the town into the segment whose `[km_start, km_end)` contains it. Towns farther than `--town-max-distance-m` (default 1000) are excluded entirely, which is how Brive-la-Gaillarde correctly stays out of segment 1.

Each segment now also carries a `town_positions` map (name → km), so `data/town-positions.ts` can be regenerated from `segments.json` instead of hand-maintained. Wiring that regeneration up is a follow-up.

## Removed

- `KNOWN_TOWNS` hardcoded dict (replaced by `load_town_coords` + `town-coords.json`)
- `load_existing_towns` shim (the structural fix supersedes it; was a workaround per #342)

## Tests

- `compute_town_proximity` returns km and distance per town and skips climbs
- `split_into_segments` assigns synthetic towns to the segment containing their closest-approach km
- Towns farther than the threshold are excluded
- `town_positions` field exposes the closest-approach km
- `load_town_coords` loads the real file
- Existing real-data tests still pass; the `KNOWN_TOWNS`-driven assertion now loads on-route towns from `town-coords.json` (excluding the intentionally-off-route Brive-la-Gaillarde)

## Sequencing note

This PR is code-only. After it lands together with **#419** (segment data corrections, currently up for review), regenerating `segments.json` via `processing/.venv/bin/python processing/split_gpx.py` will produce the same town assignments that #419 applied by hand. Until then, the existing `segments.json` on disk is unchanged by this PR.

Closes #341. Epic: #396.

## Test plan
- [x] `processing/.venv/bin/python -m pytest processing/tests/test_split_gpx.py` — 31/31 pass (was 23, +6 new tests + 1 amended + 1 unchanged)
- [x] Full Python suite: 180/180 pass
- [x] `processing/.venv/bin/python processing/validate_points.py` — OK
- [x] `processing/.venv/bin/ruff check processing/` — clean
- [x] Smoke test: regenerated against current main data, the 5 mid-route reassignments expected from the audit (Naves 11→12, Chaumeil 13→15, Treignac 17→18, Bugeat 19→21, Meymac 23→25) all fall out of route-proximity logic. After #419 merges, regenerating will additionally produce Ligneyrac on seg 3, Meyssac on seg 4, and Ussel on seg 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)