### PR TITLE
v1.4.10 strand briefs: content, dependency queue, landing page

### DIFF
--- a/docs/strands/README.md
+++ b/docs/strands/README.md
@@ -1,0 +1,9 @@
+# Strand briefs (v1.4.10)
+
+Three parallel Claude sessions are running for v1.4.10. Each session reads the [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) for the goals/outcomes view, then reads the brief in this directory for issue-level scope.
+
+- [Strand A — Content: segments 8/9/10](strand-a-content.md)
+- [Strand B — Developer experience: dependency-update queue](strand-b-deps.md)
+- [Strand C — Reader experience: landing page](strand-c-landing.md)
+
+These briefs are working artifacts for one release. Once v1.4.10 ships and the retro is published, the briefs that are no longer load-bearing should be removed; any patterns worth keeping go into the wiki or memory.

--- a/docs/strands/strand-a-content.md
+++ b/docs/strands/strand-a-content.md
@@ -1,0 +1,50 @@
+# Strand A — Content: segments 8/9/10
+
+**Start here:** [Roadmap → Now → Content strand](https://github.com/gneeek/tdf26/wiki/Roadmap#now)
+
+## Goal
+
+Publish segment 8 on Wed 2026-04-29. Produce drafts of segments 9 and 10 inside this strand using shared research across the 20km block (km ~49.7-70). Segments 9 and 10 ship in v1.4.11 and v1.4.12 respectively.
+
+## The 20km block
+
+- **Seg 8 (km 50-56):** Beynat foothills, Côte de Miel climb, Albussac. Templar Commanderie de Puy de Noix is ~4 km off-route, already in `data/attractions.json`.
+- **Seg 9 (km 56-64):** Corrèze valley descent. Connective tissue.
+- **Seg 10 (km 64-70):** Tulle. Heaviest cultural payload of the block: lace, accordion-making (Maugein already in `data/attractions.json`, see music-thread ledger in `project_next_planning_notes.md`), the WWII massacre of 9 June 1944, Hollande's mayoralty.
+
+Segments 8 and 9 must set up the Tulle arrival. Do not write segment 10's material into the earlier two.
+
+## Workflow
+
+1. Research the full 20km block in one shared pass — history, geology, cycling context, attractions, sources.
+2. Bring findings back to the publisher to decide narrative arc and voice register per segment.
+3. Spawn three draft subagents — each gets the segment number, the agreed arc, the agreed voice, and the relevant slice of research.
+4. Refine seg 8 to publish-ready; commit segs 9 and 10 as first drafts (still `draft: true`).
+
+## Target issues
+
+Open these as the strand's first commits, all on milestone v1.4.10:
+
+- **Segment 8 entry content** — primary deliverable. Placeholder at `content/entries/08-cote-de-miel.md`.
+- **Segment 9 entry draft** — drafted in v1.4.10, ships v1.4.11.
+- **Segment 10 entry draft** — drafted in v1.4.10, ships v1.4.12.
+- **Segment 8 publication** — publish-day tracking issue, matching the pattern set by #423 and #393.
+
+## File regions and branches
+
+- `content/entries/08-cote-de-miel.md`, `09-descent-to-the-correze-valley.md`, `10-tulle-lace-accordions-and-memory.md` (placeholders exist with frontmatter).
+- `public/images/segment-08/`, `public/images/segment-09/`, `public/images/segment-10/`.
+- `data/attractions.json` only if research surfaces a missing or wrong attraction. Coordinate if any other strand wants this file (none expected).
+- Branches: `feature/issue-N-segment-08-content`, etc.
+
+## Memories that apply
+
+- `feedback_literary_footnotes.md`, `feedback_sources_section.md`, `project_disclosure_practice.md`, `feedback_content_change_rule.md`, `feedback_pre_publish_scrutiny.md`, `feedback_on_route_checks.md`.
+- Voice references: `project_meymac_voice.md` (seg 24, not these), `project_barthes_callback.md` (segs 6/12/15, not these). Voice for segs 8/9/10 is open and decided with the publisher.
+- Music-thread ledger in `project_next_planning_notes.md`.
+
+## Stop when
+
+- Segment 8 is publish-ready (images + attribution, optional `## Sources`, disclosure footer, `draft: false` only after publisher confirms).
+- Segments 9 and 10 are first-draft committed (still `draft: true`).
+- Any cross-segment concern that surfaces during research is filed as a new issue rather than fixed inline.

--- a/docs/strands/strand-b-deps.md
+++ b/docs/strands/strand-b-deps.md
@@ -1,0 +1,63 @@
+# Strand B — Developer experience: dependency-update queue
+
+**Start here:** [Roadmap → Now → Developer-experience strand](https://github.com/gneeek/tdf26/wiki/Roadmap#now)
+
+## Goal
+
+Clear the open dependency-update queue. Verify each pending update against a real build and a real test run; merge what is safe, close what is not. Nothing else.
+
+## Worktree first
+
+This strand runs in a separate git worktree to keep its branch-switching off the shared checkout. Strands A and C work in `/home/jhs/code/tdf26/`; do not disrupt that working tree.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-deps main
+cd tdf26-deps
+```
+
+When the strand finishes: `git worktree remove tdf26-deps` from the main checkout.
+
+## Target PRs
+
+Seven open Dependabot PRs as of 2026-04-27 (refresh with `gh pr list --repo gneeek/tdf26 --author app/dependabot`):
+
+- #418 pytest-cov >=6.0.0 → >=7.1.0
+- #417 ruff >=0.11.0 → >=0.15.12
+- #416 numpy >=1.26.0 → >=2.4.4
+- #415 pytest >=8.0.0 → >=9.0.3
+- #414 gpxpy >=1.6.0 → >=1.6.2
+- #406 minor-and-patch group across 1 directory with 8 updates (npm)
+- #405 postcss 8.5.8 → 8.5.10
+
+All seven were opened in a single wave on 2026-04-24.
+
+## Verify-then-merge loop
+
+Per PR:
+
+1. `gh pr checkout <N>` (inside the worktree).
+2. Install for the affected ecosystem:
+   - npm PRs (#405, #406): `npm ci`
+   - python PRs (#414-#418): use the project's processing tooling (see `processing/pyproject.toml` and `processing/requirements.txt`).
+3. Run the relevant test set:
+   - npm: `npm run lint && npm run typecheck && npm test && npm run build`
+   - python: `cd processing && pytest`
+4. If green, merge via `gh pr merge --squash --delete-branch <N>` and assign to milestone v1.4.10.
+5. If red: investigate. If the failure is a real breakage with the new version, close the PR with a comment explaining why and the safer pin to keep. Do not merge red PRs.
+
+## Memories that apply
+
+- `feedback_bash_nvm_sourcing.md` — prefix Node-touching Bash with `source ~/.nvm/nvm.sh && nvm use --silent &&`.
+- `feedback_env_check.md` — verify Node and Python versions match `.nvmrc` and `pyproject.toml` engines before installing.
+- `feedback_pr_polling.md` — verify merges via GitHub API, don't rely solely on what `gh pr merge` prints.
+
+## Scope discipline
+
+If a PR fails for an unrelated reason (flaky test, environment drift), the fix belongs to the strand only if it unblocks merging. Anything that turns into a non-trivial investigation gets filed as a new issue and the PR is left for the next pass. Do not re-scope into an upgrade-and-fix sprint.
+
+## Stop when
+
+- All seven PRs have been resolved (merged or closed with reason).
+- Any failures that surfaced during verification are filed as new issues.
+- Worktree removed.

--- a/docs/strands/strand-c-landing.md
+++ b/docs/strands/strand-c-landing.md
@@ -1,0 +1,41 @@
+# Strand C — Reader experience: landing page
+
+**Start here:** [Roadmap → Now → Reader-experience strand](https://github.com/gneeek/tdf26/wiki/Roadmap#now)
+
+## Goal
+
+Improve the experience for readers landing on the homepage. Pick one improvement, ship it, stop. The goal is a noticeably better landing page, not a particular feature.
+
+## Candidate set
+
+These are the open issues in scope for the strand. Pick one and start there; the others can be redirected to a future release.
+
+- **#391** Homepage: add thumbnail image to each entry card.
+- **#407** Homepage: let readers reach entries older than the latest 5.
+- **#408** Entry page: show simplified rider stats at top, link to full dashboard below. *(In scope here because the publisher grouped it with the landing-page set; entries are the main reader destination after the homepage.)*
+
+## How to choose
+
+The publisher has not pre-selected. The strand decides based on:
+
+- Smallest scope that produces a noticeable reader-experience win.
+- Avoid anything that would conflict with strand A's edits to `content/entries/0[8-9]*.md`, `content/entries/10-*.md`. None of the three candidates touch those files.
+
+If you start one and find it bigger than estimated, finish it anyway — do not split mid-flight.
+
+## Scope discipline
+
+- One improvement only. Do not start a second.
+- File touches expected: `pages/index.vue`, `components/`, possibly `composables/` or `layouts/default.vue`. If the change reaches into `data/` or `processing/`, the scope has drifted; reset.
+- Branch: `feature/issue-N-<short-name>`. Assign the PR to milestone v1.4.10.
+
+## Memories that apply
+
+- `feedback_production_preview.md` — preview a production build before merging visual PRs.
+- `feedback_pr_polling.md` — verify PR merges via GitHub API.
+
+## Stop when
+
+- The chosen issue is shipped (PR merged into main).
+- A production preview has confirmed the change works.
+- The other candidate issues are left untouched for a future release.


### PR DESCRIPTION
## Summary

- Adds `docs/strands/` with one brief per parallel Claude session for v1.4.10.
- The wiki [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) is the goals/outcomes view; these briefs hold the issue-level scope each session needs to start.
- Working artifacts only — expected to be removed (or pruned to whatever proved portable) at the v1.4.10 retro.

## Test plan

- [ ] README.md links resolve (Roadmap anchor + the three brief files).
- [ ] Each strand brief reads top-to-bottom as a self-contained starting point for a fresh session.