### PR TITLE
Homepage: thumbnail on each Latest Entries card (#391)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,14 +24,23 @@
           <h2 class="text-2xl font-serif font-bold text-stone-800 mb-3">Latest Entries</h2>
           <div v-if="entries && entries.length" class="space-y-3">
             <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
-              <NuxtLink :to="entry.path || entry._path" class="block">
-                <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
-                  Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
-                </span>
-                <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
-                <h3 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h3>
-                <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
-                <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+              <NuxtLink :to="entry.path || entry._path" class="flex gap-4 items-start">
+                <img
+                  v-if="entry.images && entry.images.length"
+                  :src="entry.images[0].src"
+                  :alt="entry.images[0].alt || ''"
+                  loading="lazy"
+                  class="w-20 h-20 sm:w-28 sm:h-28 rounded object-cover flex-shrink-0"
+                >
+                <div class="min-w-0 flex-1">
+                  <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+                    Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+                  </span>
+                  <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+                  <h3 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h3>
+                  <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+                  <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+                </div>
               </NuxtLink>
             </article>
           </div>


### PR DESCRIPTION
Closes #391. Strand C (reader-experience) deliverable for v1.4.10.

## Summary

- Renders `images[0].src` from each entry's frontmatter as a square thumbnail on the left of the Latest Entries card.
- 80px on mobile, 112px (`sm:` and up) on desktop.
- Lazy-loaded; hides cleanly when an entry has no images.

## Locked design decisions

These were the five open questions from #391 — locked at the start of the strand to keep scope tight:

| Question | Decision |
| --- | --- |
| Image source | `images[0].src` from frontmatter. No new `thumbnail` field. |
| Position | Left of text, single flex row at all breakpoints. |
| Size | `w-20 h-20` mobile / `sm:w-28 sm:h-28` desktop (80px / 112px). |
| Fallback | Hide the image slot when `images` is empty or missing. |
| Attribution | Not rendered on the card; remains on the entry page. |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run generate` succeeds; built HTML inspected
- [x] All five visible cards (segs 7-3) render with a thumbnail
- [x] `loading="lazy"` set on each thumbnail
- [x] Visual confirmation on a real browser at mobile + desktop widths
- [x] #361 still holds: at least one card above the fold on mobile, at least three on desktop

## Notes

- Entry 01 has `images: []`. The empty-array fallback is exercised by the v-if guard but not currently visible because seg 1 is no longer in the latest-5 window.
- Strand A is editing `content/entries/0[8-9]*.md` and `10-*.md`; no overlap with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)