### PR TITLE
Homepage: /entries archive reachable via See all entries link (#407)

### DIFF
--- a/pages/entries/index.vue
+++ b/pages/entries/index.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="max-w-3xl">
+    <header class="mb-6">
+      <h1 class="text-3xl font-serif font-bold text-correze-red tracking-wide">All entries</h1>
+      <p class="text-stone-600 font-serif mt-2">
+        Every published segment of the Corrèze travelogue, newest first.
+      </p>
+    </header>
+
+    <section v-if="entries && entries.length" class="space-y-3">
+      <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
+        <NuxtLink :to="entry.path || entry._path" class="block">
+          <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+            Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+          </span>
+          <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+          <h2 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h2>
+          <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+          <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+        </NuxtLink>
+      </article>
+    </section>
+    <p v-else class="text-stone-500 italic">No entries published yet.</p>
+
+    <p class="mt-6">
+      <NuxtLink to="/" class="text-correze-red hover:underline">&larr; Back to homepage</NuxtLink>
+    </p>
+  </div>
+</template>
+
+<script setup>
+const today = new Date().toISOString().split('T')[0]
+
+const { data: entries } = await useAsyncData('all-entries', () =>
+  queryCollection('entries')
+    .where('draft', '=', false)
+    .where('publishDate', '<=', today)
+    .order('publishDate', 'DESC')
+    .all()
+)
+
+useHead({ title: 'All entries - Corrèze Travelogue' })
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,6 +36,9 @@
             </article>
           </div>
           <p v-else class="text-stone-500 italic">No entries published yet.</p>
+          <p v-if="entries && entries.length" class="mt-3 text-right">
+            <NuxtLink to="/entries" class="text-sm text-correze-red font-semibold hover:underline">See all entries &rarr;</NuxtLink>
+          </p>
         </section>
 
         <StageRaceInfo class="lg:hidden" />


### PR DESCRIPTION
Closes #407. Strand C (reader-experience) follow-on for v1.4.10.

## Summary

- New `pages/entries/index.vue` archive page at `/entries`, listing every published entry newest-first.
- New "See all entries →" link on the homepage, just below the Latest Entries cards.
- Reader can now reach any published entry from the homepage in two clicks (one to /entries, one to the entry).

## Locked design decisions

| Question | Decision |
| --- | --- |
| Shape | Dedicated `/entries` archive page. Picked over pagination or homepage-expand because it's a 26-entry finite series. |
| Card markup | Duplicated from homepage once — refactor to a shared component only if a third caller appears. |
| Filter | Same as homepage: `draft: false` AND `publishDate <= today`. No limit. |
| Order | Flat reverse-chronological. No grouping. |
| Link placement | Below Latest Entries cards, right-aligned, small red text matching the segment-label colour. |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run generate` succeeds; 39 routes prerendered (was 37) — `/entries/index.html` exists
- [x] Served `/entries/` lists all 8 published entries (segs 1-7 + preview); homepage shows the new link
- [x] Visual confirmation on real browser at mobile + desktop widths
- [x] Two-click reachability check from homepage to any entry

## Coordination

- **PR #433** (#391 thumbnails) and this PR both touch `pages/index.vue` in adjacent regions. Whichever lands first, the other rebases trivially.
- Once both land, the duplicated card markup in `pages/entries/index.vue` won't have thumbnails — small follow-up edit. Worth tracking: extracting a shared `EntryCard` component would close the duplication if a third caller appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)