### PR TITLE
Entry page: rider stats strip above the SegmentMap (#408)

### DIFF
--- a/components/RiderStrip.vue
+++ b/components/RiderStrip.vue
@@ -1,0 +1,65 @@
+<template>
+  <div v-if="rankedRiders.length" class="bg-white rounded-lg shadow-sm p-3 sm:p-4 mb-6">
+    <div class="flex items-baseline justify-between mb-2">
+      <h2 class="text-sm font-semibold text-stone-700">Standings</h2>
+      <a href="#rider-dashboard" class="text-xs text-correze-red font-semibold hover:underline">See full standings &darr;</a>
+    </div>
+    <div class="space-y-1">
+      <div v-for="rider in rankedRiders" :key="rider.id" class="flex items-center gap-2">
+        <span class="w-16 sm:w-20 text-xs sm:text-sm font-medium truncate" :style="{ color: rider.textColor }">{{ rider.name }}</span>
+        <div class="flex-1 bg-stone-100 rounded-full h-2.5 sm:h-3 relative overflow-hidden">
+          <div
+            class="h-full rounded-full transition-all duration-500"
+            :style="{
+              width: (rider.distance / totalDistance * 100) + '%',
+              backgroundColor: rider.color,
+              minWidth: rider.distance > 0 ? '6px' : '0'
+            }"
+          />
+        </div>
+        <span class="w-14 text-xs text-stone-500 text-right font-mono">{{ rider.distance }} km</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+import riderConfigJson from '~/data/riders/rider-config.json'
+import statsJson from '~/data/riders/stats.json'
+
+const props = defineProps({
+  snapshot: { type: Object, default: null },
+})
+
+const stats = props.snapshot?.stats || statsJson
+const totalDistance = riderConfigJson.totalDistance
+
+function displayColor(hex) {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  if (luminance > 0.85) {
+    return `rgb(${Math.round(r * 0.5)}, ${Math.round(g * 0.5)}, ${Math.round(b * 0.5)})`
+  }
+  return hex
+}
+
+const rankedRiders = computed(() => {
+  return riderConfigJson.riders
+    .map(r => {
+      const s = stats?.riders?.[r.id] || {}
+      return {
+        id: r.id,
+        name: r.name,
+        color: r.color,
+        textColor: displayColor(r.color),
+        distance: s.totalDistanceCapped ?? 0,
+        place: s.place ?? 99,
+      }
+    })
+    .sort((a, b) => a.place - b.place)
+})
+</script>

--- a/pages/entries/[...slug].vue
+++ b/pages/entries/[...slug].vue
@@ -9,6 +9,8 @@
       <time class="text-sm text-stone-400 mt-3 block">{{ formatDate(page.publishDate) }}</time>
     </header>
 
+    <RiderStrip :snapshot="riderSnapshot" />
+
     <SegmentMap
       :segment="page.segment"
       :segments="segments"
@@ -37,7 +39,9 @@
 
     <WeatherWidget :weather="page.weather" />
 
-    <RiderDashboard :snapshot="riderSnapshot" />
+    <div id="rider-dashboard" class="scroll-mt-4">
+      <RiderDashboard :snapshot="riderSnapshot" />
+    </div>
 
     <nav class="mt-12 pt-8 border-t border-stone-200 flex justify-between">
       <NuxtLink


### PR DESCRIPTION
Closes #408. Strand C (reader-experience) third deliverable for v1.4.10.

## Summary

- New `components/RiderStrip.vue`: compact "Standings" panel with one row per rider — name in colour, colour bar, capped distance.
- Inserted between the entry `<header>` and `<SegmentMap>` so the standings sit within the first scroll on mobile.
- Anchor link "See full standings ↓" jumps to the existing full `<RiderDashboard>` at the bottom of the page.
- Reads from the same `riderSnapshot` prop the dashboard uses, so per-segment snapshots work identically.

## Locked design decisions

| Question | Decision |
| --- | --- |
| Position | Above the SegmentMap. The brief allowed "after the map" too, but the map is tall enough on mobile that placing standings below would defeat the above-the-fold goal. |
| Anchor target | Wrap `<RiderDashboard>` in `<div id="rider-dashboard">` on the entry page. Avoids editing the dashboard component (the issue's stated non-goal). |
| Strip component | Dedicated `RiderStrip.vue`, not a `compact` prop on `RiderDashboard`. Smaller blast radius, no shared-state risk. |
| Content | Name + colour bar + capped distance. Place implied by sort order. No jersey icons in the strip — they remain in the full dashboard. |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run generate` succeeds (37 routes prerendered)
- [x] Built entry page contains the Standings header, the four rider rows with colour bars, and the anchor link
- [x] `id="rider-dashboard"` target div is present in the rendered HTML
- [ ] Visual confirmation on real browser: strip above-the-fold on mobile + desktop
- [ ] Anchor link scrolls smoothly (browser default; `scroll-mt-4` on the wrapper for header offset)

## Coordination

- No conflict expected with PR #433 or PR #435 — different files.
- Strand A is editing `content/entries/0[8-9]*.md` and `10-*.md` in the shared working tree; observed an in-progress edit to `08-cote-de-miel.md` while working. Staged only my files explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)