### PR TITLE
v1.4.11 strand briefs: security, bug-class cleanup, sqlite stretch

### DIFF
--- a/docs/strands/README.md
+++ b/docs/strands/README.md
@@ -1,9 +1,31 @@
-# Strand briefs (v1.4.10)
+# Strand briefs (v1.4.11)
 
-Three parallel Claude sessions are running for v1.4.10. Each session reads the [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) for the goals/outcomes view, then reads the brief in this directory for issue-level scope.
+Three parallel Claude sessions for v1.4.11. Each session reads the [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) for the goals/outcomes view, then reads its brief in this directory for issue-level scope.
 
-- [Strand A — Content: segments 8/9/10](strand-a-content.md)
-- [Strand B — Developer experience: dependency-update queue](strand-b-deps.md)
-- [Strand C — Reader experience: landing page](strand-c-landing.md)
+- [Strand A — Process: security alerts](strand-a-security.md) (#440 + #442)
+- [Strand B — Developer: bug-class cleanup](strand-b-bugclass.md) (#422 + #426)
+- [Strand C — Publisher (stretch): better-sqlite3 rebuild](strand-c-sqlite.md) (#425)
 
-These briefs are working artifacts for one release. Once v1.4.10 ships and the retro is published, the briefs that are no longer load-bearing should be removed; any patterns worth keeping go into the wiki or memory.
+## Brief template (applied to all three)
+
+Each brief contains, in this order:
+
+1. **Goal** — one paragraph, plus which milestone goal it serves.
+2. **Filesystem posture** — worktree path, branch verification rule (`git branch --show-current` before each `git add` / `git commit`).
+3. **Target issues** — issue numbers, ordering rationale.
+4. **Workflow per issue** — concrete steps.
+5. **Verification commands** — only commands that actually exist in `package.json` / the codebase. No `npm run typecheck` (it does not exist).
+6. **Cross-strand sharing notes** — file regions touched, collision avoidance, rebasing rules.
+7. **Scope discipline** — what to file as new issues vs fix inline.
+8. **Memories that apply** — the relevant feedback / project memory pointers.
+9. **Stop when** — exit criteria.
+
+This template is the v1.4.10 retro's "strand-brief template" gap, applied. If a future multi-strand release deviates, the deviation should be deliberate.
+
+## v1.4.10 strand briefs
+
+The v1.4.10 briefs (`strand-a-content.md`, `strand-b-deps.md`, `strand-c-landing.md`) remain in the directory until v1.4.10 tags on Wed 2026-04-29 alongside the segment 8 publish, after which they should be removed per the "working artifacts for one release" rule below.
+
+## Lifecycle
+
+These briefs are working artifacts for one release. Once a release ships and its retro is published, the briefs that are no longer load-bearing should be removed; any patterns worth keeping go into the wiki, memory, or this README's template section.

--- a/docs/strands/strand-a-security.md
+++ b/docs/strands/strand-a-security.md
@@ -1,0 +1,110 @@
+# Strand A — Process: security alerts (v1.4.11)
+
+**Start here:** [Roadmap → Next → v1.4.11](https://github.com/gneeek/tdf26/wiki/Roadmap#next)
+
+## Goal
+
+Close the eight remaining high-severity / hygiene CodeQL alerts opened 2026-04-25. After this strand, the security tab queue drops to one parked low-severity item (#441, deferred per not-internet-exposed context).
+
+Goal 5 (process). Commit-tier: both issues should land. The roadmap success bar (three of four commit-tier items) treats #440 and #442 as two of the four, so this strand is load-bearing for the milestone hitting its bar.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree to keep this strand's branch-switching off any concurrent strand's checkout.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-security main
+cd tdf26-security
+```
+
+When the strand finishes: `git worktree remove tdf26-security` from the main checkout.
+
+Within the worktree, branches are per-issue: `feature/issue-440-html-strippers`, `feature/issue-442-deploy-permissions`. Verify `git branch --show-current` immediately before each `git add` / `git commit` (the v1.4.10 retro learning — shared-tree branch state is non-stationary across any sequence of git commands; even in a worktree, do the check, since recovery from a wrong-branch commit costs more than the check).
+
+## Target issues
+
+- **[#440](https://github.com/gneeek/tdf26/issues/440)** — Replace hand-rolled HTML strippers in image attribution rendering. Closes seven CodeQL alerts (#4, #5, #6, #7, #8, #9, #10).
+- **[#442](https://github.com/gneeek/tdf26/issues/442)** — Add explicit permissions block to deploy workflow. Closes CodeQL alert #1.
+
+Order: land #442 first (one-line workflow edit, fast win, opens a minute); land #440 second (the real refactor).
+
+## Workflow per issue
+
+### #442 (small)
+
+1. Add a minimal `permissions:` block to `.github/workflows/deploy.yml`. The deploy job does not use `GITHUB_TOKEN` (uses an SSH deploy key); `permissions: contents: read` should be sufficient for `actions/checkout`.
+2. Open PR, assign to milestone v1.4.11.
+3. After merge, confirm CodeQL alert #1 transitions to `fixed` via `gh api repos/gneeek/tdf26/code-scanning/alerts/1 --jq '.state'`.
+
+### #440 (refactor)
+
+Four files carry the hand-rolled `stripHtml` pattern that CodeQL flags for incomplete-multi-character-sanitization and double-escaping:
+
+| File | Line | CodeQL alerts |
+|---|---|---|
+| `components/ImageGallery.vue` | 44 | #4, #9 |
+| `components/content/InlineFigure.vue` | 47 | #5, #10 |
+| `pages/admin/images.vue` | (TBD) | #6, #7 |
+| `server/api/wikipedia-images.post.ts` | (TBD) | #8 |
+
+Approach:
+
+1. Read all four sites first to confirm they share a single sanitization shape (Wikipedia attribution metadata cleanup) before deciding the replacement.
+2. Replace with a DOM-based sanitizer. Two reasonable options — pick one and apply consistently:
+   - `DOMParser` + `textContent` extraction (no new dependency; client-only Vue components).
+   - A maintained sanitization library (e.g. `dompurify` or `sanitize-html`) if the textContent route loses needed structure.
+   The server route (`wikipedia-images.post.ts`) needs a Node-compatible path; `DOMParser` is browser-only, so the server file likely needs a different approach (e.g. `sanitize-html` or `html-entities` for the specific attribution case). Decide once and document inline.
+3. Add or update unit tests covering the attribution shapes that previously broke the hand-rolled regex (entity sequences, nested tags, multi-character constructs). The CodeQL alert descriptions name the failure modes — convert each into a test case.
+4. Open PR, assign to milestone v1.4.11.
+5. After merge, confirm the seven alerts (#4, #5, #6, #7, #8, #9, #10) transition to `fixed` via `gh api repos/gneeek/tdf26/code-scanning/alerts --jq '[.[] | select(.number | IN(4,5,6,7,8,9,10)) | {number, state}]'`.
+
+## Verification commands
+
+The following npm scripts exist in `package.json` and are real:
+
+- `npm ci` — install
+- `npm run lint` (eslint)
+- `npm test` (vitest)
+- `npm run build`
+- `npm run generate`
+- `npm run preview`
+
+There is **no** `npm run typecheck` (the v1.4.10 strand-B brief named one and was wrong). Type errors surface during `npm run build` via Nuxt's prepare step.
+
+For a worktree, prefix Node-touching Bash with `source ~/.nvm/nvm.sh && nvm use --silent &&` (per `feedback_bash_nvm_sourcing.md`).
+
+For #440 verification before opening the PR:
+- `npm run lint && npm test && npm run build`
+- Production preview the rendered attribution in `ImageGallery` and `InlineFigure` on a published entry that exercises Wikimedia attribution (per `feedback_production_preview.md`).
+
+For #442 verification:
+- `gh workflow view deploy.yml --repo gneeek/tdf26` and read the merged file.
+- The actual deploy job runs on the next publish (Wed 2026-04-29 segment 8 ship); a dry-run is not feasible.
+
+## Cross-strand sharing notes
+
+- Strand B (bug-class) touches `utils/stage-totals.ts`, `components/StageDetails.vue`, `data/competition/points-config.json`, `scripts/publish.sh`. **No file-region overlap with this strand.**
+- Strand C (sqlite stretch) touches `package.json` (postinstall augmentation). **No overlap with this strand.**
+- This strand's PRs do not need to coordinate with B or C beyond standard rebasing on main.
+
+## Scope discipline
+
+- File new issues for anything that surfaces during the refactor and is not part of closing these alerts. Do not fix inline.
+- The CodeQL alerts on `pages/admin/images.vue` (#6, #7) live in admin UI not exposed to the public internet. Still close them — they are in the same class of bug as the public sites and the strand goal is "close the eight alerts," not "close only the public ones."
+
+## Memories that apply
+
+- `feedback_bash_nvm_sourcing.md` — prefix Node-touching Bash with nvm sourcing.
+- `feedback_env_check.md` — verify Node version against `.nvmrc` before installing.
+- `feedback_pr_polling.md` — verify PR merges via GitHub API.
+- `feedback_production_preview.md` — production preview before merging visual PRs.
+- `feedback_shared_tree_branch_verification.md` — verify `git branch --show-current` before each `git add` / `git commit`.
+- `feedback_issues_describe_problems.md` — issues describe problems; solutions go in PR descriptions.
+
+## Stop when
+
+- Both #440 and #442 PRs are merged into main.
+- All eight CodeQL alerts (#1, #4, #5, #6, #7, #8, #9, #10) confirmed transitioned to `fixed`.
+- Worktree removed.
+- Any unrelated issues surfaced during the refactor are filed, not fixed inline.

--- a/docs/strands/strand-b-bugclass.md
+++ b/docs/strands/strand-b-bugclass.md
@@ -1,0 +1,112 @@
+# Strand B — Developer experience: bug-class cleanup (v1.4.11)
+
+**Start here:** [Roadmap → Next → v1.4.11](https://github.com/gneeek/tdf26/wiki/Roadmap#next)
+
+## Goal
+
+Close two lingering bug-classes by fixing them at the root, each of which has bitten the project once already:
+
+- Parallel-source-of-truth: a hand-maintained list naming strings declared elsewhere drifts. (#369 Côte de Malemort silent-drop incident.)
+- Silent-failure: a shell pipeline prints success regardless of exit code. (Seg 7 publish-day false-success deploy print, 2026-04-26.)
+
+Goal 4 (developer experience). Commit-tier: both should land. Together with strand A's two items, these are the four commit-tier items in the milestone's success bar.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-bugclass main
+cd tdf26-bugclass
+```
+
+When the strand finishes: `git worktree remove tdf26-bugclass` from the main checkout.
+
+Branches per issue: `feature/issue-422-categorized-climbs-derive`, `feature/issue-426-publish-deploy-exit-code`. Verify `git branch --show-current` immediately before each `git add` / `git commit`.
+
+## Target issues
+
+- **[#422](https://github.com/gneeek/tdf26/issues/422)** — Derive `CATEGORIZED_CLIMBS` from `points-config.json` instead of hand-maintaining it.
+- **[#426](https://github.com/gneeek/tdf26/issues/426)** — `publish.sh` deploy step prints 'Deploy complete' even when SSH fails.
+
+Order: independent. Either order works. #426 is smaller; landing it first frees a slot quickly.
+
+## Workflow per issue
+
+### #422 (refactor)
+
+Current state:
+
+- `utils/stage-totals.ts:15` exports `CATEGORIZED_CLIMBS` as a hand-maintained `Set<string>`.
+- `data/competition/points-config.json` declares `climbs[].name` and self-describes as "Single source of truth for climb identity, summit segment, and span."
+- `components/StageDetails.vue:34,82` consumes `CATEGORIZED_CLIMBS`.
+- `utils/stage-totals.ts:64,86` consumes it twice more.
+
+Approach:
+
+1. In `utils/stage-totals.ts`, replace the hand-maintained `Set` with a `Set<string>` derived from `points-config.json`'s `climbs[].name` field. Decide whether to keep the export name (`CATEGORIZED_CLIMBS`) or rename to something derivative (`POINTS_CONFIG_CLIMB_NAMES`). Default: keep the name to minimise churn in consumers.
+2. Add a unit test that asserts the derived set matches the points-config climbs and fails if the two drift. (This test, not the hand-maintained list, becomes the parallel-source-of-truth detector for this case.)
+3. Confirm `components/StageDetails.vue` continues to render correctly under `npm run build` and a production preview.
+4. Open PR, assign to milestone v1.4.11.
+
+Out of scope: building the general parallel-source-of-truth detector noted in `project_next_planning_notes.md`. File a follow-up issue if it surfaces during this work.
+
+### #426 (shell hardening)
+
+Current state:
+
+- `scripts/publish.sh` Step 8 (Deploy) runs an SSH-tar pipeline and unconditionally `echo "Deploy complete."` afterwards.
+- The seg 7 publish (2026-04-26) emitted SSH `agent refused operation` warnings; the deploy succeeded (SSH fell back to IdentityFile), but the misleading success message would have masked a real failure.
+
+Approach:
+
+1. Add explicit exit-code handling to the SSH-tar pipeline in Step 8. Options:
+   - `set -o pipefail` at the top of the step + check `$?` after the pipeline.
+   - Capture the SSH exit code into a variable and gate the success message on it.
+   - Run the pipeline under a function that exits non-zero on failure.
+   Pick one and document inline why.
+2. If the deploy fails, the script should print a clear failure message naming the failed step and exit non-zero so the orchestrating release process notices.
+3. Verify by simulating a deploy failure in a local invocation (e.g. point the SSH host at an unreachable target) and confirming the script no longer prints "Deploy complete."
+4. Open PR, assign to milestone v1.4.11.
+
+Out of scope: end-to-end render verification (carryforward from v1.4.6+v1.4.7 retro) and other steps in `publish.sh` that may have similar silent-failure patterns. If they surface, file new issues — do not fix inline.
+
+## Verification commands
+
+The following npm scripts exist in `package.json`:
+
+- `npm ci`, `npm run lint`, `npm test`, `npm run build`, `npm run generate`, `npm run preview`.
+- There is **no** `npm run typecheck`. Type errors surface during `npm run build`.
+
+Per-issue:
+
+- #422: `npm run lint && npm test && npm run build`. Production preview confirms `StageDetails.vue` renders the climb list.
+- #426: `bash -n scripts/publish.sh` (syntax check). Manual simulation of an SSH failure to confirm the failure path.
+
+For Node-touching Bash, prefix with `source ~/.nvm/nvm.sh && nvm use --silent &&`.
+
+## Cross-strand sharing notes
+
+- Strand A (security) touches `components/ImageGallery.vue`, `components/content/InlineFigure.vue`, `pages/admin/images.vue`, `server/api/wikipedia-images.post.ts`, `.github/workflows/deploy.yml`. **No overlap with this strand.**
+- Strand C (sqlite stretch) is briefed to prefer the `package.json` postinstall route to avoid touching `scripts/publish.sh`, which is this strand's #426 region. **If C lands first** with a `publish.sh` edit (it shouldn't, per its brief), this strand rebases on C. Default expectation: C does not touch `publish.sh`.
+- This strand should land #426 cleanly without coordinating with C. If C surprises, rebase.
+
+## Scope discipline
+
+- Two issues, two PRs. Do not bundle.
+- File new issues for class-of-bug instances surfaced during this work (e.g. other parallel-source-of-truth lists, other silent-failure shell pipelines). Do not fix inline.
+
+## Memories that apply
+
+- `feedback_bash_nvm_sourcing.md`, `feedback_env_check.md`, `feedback_pr_polling.md`, `feedback_production_preview.md`, `feedback_shared_tree_branch_verification.md`.
+- `feedback_no_regex_in_bash.md` — relevant if any inline Python lands in `publish.sh` shell-embedded contexts.
+- `feedback_issues_describe_problems.md`.
+
+## Stop when
+
+- Both #422 and #426 PRs are merged into main.
+- The #422 unit test asserts the derived/declared sets match.
+- The #426 fix is confirmed by a local failure simulation that does not print "Deploy complete."
+- Worktree removed.
+- Any class-of-bug residue is filed as new issues, not fixed inline.

--- a/docs/strands/strand-c-sqlite.md
+++ b/docs/strands/strand-c-sqlite.md
@@ -1,0 +1,102 @@
+# Strand C — Publisher experience (stretch): better-sqlite3 rebuild (v1.4.11)
+
+**Start here:** [Roadmap → Next → v1.4.11](https://github.com/gneeek/tdf26/wiki/Roadmap#next)
+
+## Goal
+
+Stop `better-sqlite3`'s `Module did not self-register` error from interrupting publisher and developer workflows. After this strand, fresh clones, Node version changes, and dependency updates should not require a manual `npm rebuild better-sqlite3` recovery step.
+
+Goal 3 (publisher experience). **Stretch tier.** Drops out of scope if strands A and B consume the available window. Three of the four commit-tier items (A's two plus B's two) is the milestone's success bar; this strand makes it five.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-sqlite main
+cd tdf26-sqlite
+```
+
+When the strand finishes: `git worktree remove tdf26-sqlite` from the main checkout.
+
+Branch: `feature/issue-425-sqlite-rebuild-automation`. Verify `git branch --show-current` immediately before each `git add` / `git commit`.
+
+## Target issue
+
+- **[#425](https://github.com/gneeek/tdf26/issues/425)** — Automate `better-sqlite3` rebuild on install or dev/publish startup.
+
+## File-region constraint (load-bearing)
+
+**Prefer the `package.json` postinstall route. Avoid touching `scripts/publish.sh` and `scripts/dev.sh`.**
+
+Why: strand B's #426 lands changes in `scripts/publish.sh`. Putting the sqlite rebuild in publish.sh creates a cross-strand collision in the same file. The postinstall hook in `package.json` runs on every `npm ci` / `npm install`, which covers fresh clones and dependency updates — the failure modes named in #425's body. Node version changes are also covered if the publisher re-runs `npm ci` after switching Node (which the existing `feedback_env_check.md` discipline already requires).
+
+Existing `package.json` `postinstall` value: `nuxt prepare`. **Do not clobber it.** Augment as a chained command, e.g.:
+
+```json
+"postinstall": "npm rebuild better-sqlite3 && nuxt prepare"
+```
+
+Watch for recursion: `npm rebuild better-sqlite3` runs `better-sqlite3`'s own install/postinstall (the rebuild step), not the project-root `postinstall`, so this should be safe. Verify by running `npm ci` in a clean checkout and confirming the rebuild fires once.
+
+If during implementation the postinstall route is genuinely insufficient — e.g. it does not address a failure mode named in #425's body — escalate to the publisher before falling back to a `publish.sh` / `dev.sh` edit. Falling back to `publish.sh` requires rebasing on strand B's #426 branch (or waiting for B's PR to merge to main).
+
+## Workflow
+
+1. Read `#425`'s body in full to confirm the failure modes the issue is targeting.
+2. Read the current `package.json` `postinstall` value and confirm it is `nuxt prepare`.
+3. Augment `postinstall` to chain `npm rebuild better-sqlite3` before the existing command.
+4. Test the failure recovery path: in the worktree, after the change, simulate the failure mode by running `node -e "require('better-sqlite3')"` directly (which is what trips the `Module did not self-register` error), then run `npm ci` and re-test. Confirm the error is gone.
+5. Test the no-regression path: run `npm test` and `npm run build` to confirm the augmented postinstall does not break the existing flow.
+6. Open PR, assign to milestone v1.4.11.
+
+## Verification commands
+
+The following npm scripts exist in `package.json`:
+
+- `npm ci`, `npm run lint`, `npm test`, `npm run build`, `npm run generate`, `npm run preview`, `postinstall` (chained: `npm rebuild better-sqlite3 && nuxt prepare`).
+- There is **no** `npm run typecheck`.
+
+Pre-PR:
+
+- `npm ci` (confirm rebuild fires and existing postinstall behavior preserved)
+- `node -e "require('better-sqlite3')"` (smoke test the previously failing import)
+- `npm run lint && npm test && npm run build`
+
+For Node-touching Bash, prefix with `source ~/.nvm/nvm.sh && nvm use --silent &&`.
+
+## Cross-strand sharing notes
+
+- Strand A (security) and strand B (#422) do not touch `package.json`. **No overlap.**
+- Strand B's #426 touches `scripts/publish.sh`. **This strand stays out of `publish.sh` per the brief above.** That keeps the cross-strand collision profile zero.
+- If B's #426 lands first, no rebase needed for this strand. If this strand lands first, B does not need to rebase.
+
+## Scope discipline
+
+- One issue, one PR. Do not start a second.
+- File new issues for any other recurring publisher-experience interrupts surfaced while reading #425's context. Do not fix inline.
+- If the postinstall route turns into a non-trivial investigation (recursion edge case, npm version-specific behavior), file a follow-up issue and escalate to the publisher rather than silently falling back to publish.sh.
+
+## Memories that apply
+
+- `feedback_bash_nvm_sourcing.md`, `feedback_env_check.md`, `feedback_pr_polling.md`, `feedback_shared_tree_branch_verification.md`.
+- `feedback_issues_describe_problems.md`.
+
+## Stop when
+
+- The #425 PR is merged into main.
+- A clean `npm ci` in a fresh checkout reproduces the rebuild without manual intervention.
+- The previously failing `require('better-sqlite3')` smoke test passes after install.
+- Worktree removed.
+- Any unrelated issues are filed, not fixed inline.
+
+## Drop-out conditions
+
+This is the stretch item. Drop out without prejudice if any of these fire:
+
+- Strand A or B is still in flight near the segment 9 publish window (Sun 2026-05-03) and finishing this strand would push them.
+- The postinstall route turns out to require a non-trivial investigation that would consume the remaining window.
+- The publisher needs window for an unrelated urgent item between now and segment 9 publish.
+
+Dropping out means: close the worktree without merging, leave #425 open for a future release, file any partial findings as comments on #425.


### PR DESCRIPTION
## Summary

- Adds three strand briefs for v1.4.11 in `docs/strands/`, one per parallel Claude session.
- Refreshes `docs/strands/README.md` to point at the v1.4.11 strands and codify the brief template (the v1.4.10 retro's "strand-brief template" gap, applied).
- Working artifacts only — expected to be removed at the v1.4.11 retro per the README's lifecycle rule.

## The three strands

| Strand | Goal | Issues | Worktree |
|---|---|---|---|
| A — Process: security alerts | Goal 5 (process) | #440 + #442 | `tdf26-security` |
| B — Developer: bug-class cleanup | Goal 4 (developer) | #422 + #426 | `tdf26-bugclass` |
| C — Publisher (stretch): better-sqlite3 rebuild | Goal 3 (publisher) | #425 | `tdf26-sqlite` |

Cross-strand collision profile: zero. Strand C is briefed to prefer the `package.json` postinstall route (chained with the existing `nuxt prepare`) to keep `scripts/publish.sh` exclusively in strand B's #426 region.

## v1.4.10 retro learnings folded in

- Filesystem isolation policy named explicitly per strand (all three in worktrees).
- `git branch --show-current` checkpoint required before each `git add` / `git commit`.
- Verification commands cross-checked against `package.json` — no phantom `npm run typecheck` (the v1.4.10 strand-B brief named one and was wrong).

## Test plan

- [x] README links resolve to the three new brief files.
- [x] Each brief names a worktree path, branch verification rule, real verification commands, cross-strand sharing notes, and stop-when criteria.
- [ ] Strand C's brief explicitly forbids touching `scripts/publish.sh` / `scripts/dev.sh` without publisher escalation, to prevent collision with strand B's #426 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)