### PR TITLE
deploy.yml: declare workflow-level permissions: contents: read (#442)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds workflow-level `permissions: contents: read` to `.github/workflows/deploy.yml`.
- Closes CodeQL alert [#1](https://github.com/gneeek/tdf26/security/code-scanning/1).

The deploy workflow only checks out the repo and pushes a built artifact via SSH (separate deploy key, not `GITHUB_TOKEN`), so the smallest grant that lets `actions/checkout` work is the right ceiling. If a future step needs more, expand at that step's job level rather than globally.

Closes #442. Strand A of v1.4.11.

## Test plan

- [ ] CI runs (build + generate) pass on this PR.
- [ ] After merge, next publish-day run of the deploy workflow succeeds.
- [ ] CodeQL alert #1 transitions to \`fixed\` on the next scan: \`gh api repos/gneeek/tdf26/code-scanning/alerts/1 --jq '.state'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)