### PR TITLE
publish.sh: gate Deploy complete on actual deploy exit code (#426)

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -220,7 +220,13 @@ if [ "$SKIP_DEPLOY" = true ]; then
 elif [ -n "$DEPLOY_TARGET" ]; then
     echo "--- Step 8: Deploying to $DEPLOY_TARGET ---"
     echo "Uploading to $DEPLOY_TARGET..."
-    tar -czf - -C .output/public . | ssh "${DEPLOY_TARGET%%:*}" "mkdir -p ${DEPLOY_TARGET#*:} && tar -xzf - -C ${DEPLOY_TARGET#*:}"
+    # Run under `if !` so set -e cannot bail before we print a step-named
+    # failure; subshell-local `set -o pipefail` so a left-side tar failure
+    # is not masked by a trailing ssh exit of 0.
+    if ! ( set -o pipefail; tar -czf - -C .output/public . | ssh "${DEPLOY_TARGET%%:*}" "mkdir -p ${DEPLOY_TARGET#*:} && tar -xzf - -C ${DEPLOY_TARGET#*:}" ); then
+        echo "ERROR: Step 8 deploy failed. Site was NOT uploaded to $DEPLOY_TARGET."
+        exit 1
+    fi
     echo "Deploy complete."
 else
     echo "--- Step 8: No DEPLOY_TARGET set, skipping deploy ---"


### PR DESCRIPTION
## Summary

Fixes #426. \`scripts/publish.sh\` Step 8 now refuses to print "Deploy complete." unless the \`tar | ssh\` pipeline actually succeeded, and exits non-zero with a step-named failure message when it does not.

## Locked decisions

| Question (from issue) | Choice |
|---|---|
| Add `set -o pipefail` globally, capture exit code, or both? | Subshell-scoped `set -o pipefail` + `if ! ( ... )` capture, scoped to Step 8. |
| Why scoped, not global? | Brief's "do not fix inline" scope discipline — other steps in `publish.sh` may have similar patterns; if they surface, file new issues. |
| Why `if !` and not bare `set -e` exit? | Lets us print a clear step-named failure message before exit, instead of a bare `set -e` bail-out that doesn't say which step. |

## Test plan

- [x] `bash -n scripts/publish.sh` (syntax)
- [x] Local failure simulation: invoke the same pipeline with an unreachable SSH host. Confirmed `exit=1`, "Deploy complete." not printed, and a clear `ERROR: Step 8 deploy failed.` line emitted instead.
- [x] Pattern verified with isolated `bash -c` cases for: (a) success, (b) right-side ssh failure, (c) left-side tar failure with pipefail, (d) left-side tar failure without pipefail (proves pipefail is load-bearing).

## Out of scope (per brief)

- Other silent-failure pipelines elsewhere in `publish.sh` — file new issues if any surface, do not fix inline.
- Adding a shell-test harness (`bats` etc.) — surfaced separately to planning notes during this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)