### PR TITLE
Postinstall: rebuild better-sqlite3 to retire Module-did-not-self-register class (#425)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nuxt build",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
+    "postinstall": "npm rebuild better-sqlite3 && nuxt prepare",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/tests/smoke-better-sqlite3.test.js
+++ b/tests/smoke-better-sqlite3.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+
+describe('better-sqlite3 native binding', () => {
+  it('loads and runs a trivial query', () => {
+    const db = new Database(':memory:')
+    try {
+      const row = db.prepare('SELECT 1 AS value').get()
+      expect(row).toEqual({ value: 1 })
+    } finally {
+      db.close()
+    }
+  })
+})


### PR DESCRIPTION
Closes #425.

## Summary

- `package.json` `postinstall` now runs `npm rebuild better-sqlite3 && nuxt prepare`. Every `npm ci` / `npm install` rebuilds the native binding against the running Node ABI before `nuxt prepare`. Covers the three failure modes named in #425: fresh clones, dependency updates, and Node version changes (the last via the existing `npm ci` discipline in `feedback_env_check.md`).
- New `tests/smoke-better-sqlite3.test.js` fails fast on any future binding breakage. Loads the module and runs `SELECT 1`.

## Decision: postinstall over startup precheck or version pin

#425 listed three options. Postinstall picked because:

- **Cheapest to land.** Single-line change, no new shell paths.
- **Stays out of `scripts/publish.sh`.** Strand B (#426) lands changes in publish.sh this release; co-locating the sqlite rebuild there would create a cross-strand collision in the same file.
- Startup precheck would be more resilient against drift but adds maintained logic to two startup paths. Defer unless postinstall proves insufficient.
- Version pin would be cleanest but constrains the dep tree; not worth the lock-in to fix a recurring-but-mechanical issue.

If postinstall later turns out to miss a failure mode, escalate before falling back to publish.sh edits.

## Recursion check

`npm rebuild better-sqlite3` runs `better-sqlite3`'s own install/postinstall (which is the rebuild step), not the project-root `postinstall`. Verified by running `npm ci` in the worktree: rebuild fires once, no recursion, `nuxt prepare` runs after.

## Test strategy

Layer 2 behavioural smoke chosen. Layer 1 (parse package.json, assert string) discussed and skipped as low-value config-mirror. Heavier deletion-fixture integration test (delete `.node`, run `npm ci`, assert restored) deferred — re-evaluate at v1.4.11 retro only if the smoke stays silent and a publisher hits the failure again. Logged in `project_next_planning_notes.md`.

Red/green proven manually in the worktree by removing `node_modules/better-sqlite3/build/Release/better_sqlite3.node` (smoke fails at `new Database(...)` with the bindings-resolution error), then restoring (smoke passes).

## Test plan

- [x] `npm ci` in clean worktree fires `npm rebuild better-sqlite3` once and runs `nuxt prepare` after
- [x] `node -e "require('better-sqlite3')"` succeeds after `npm ci`
- [x] `npm run lint` clean
- [x] `npm test` 95/95 pass, including the new smoke
- [x] `npm run build` succeeds end-to-end
- [x] Branch verified with `git branch --show-current` immediately before each `git add` / `git commit`
- [x] CI green on the PR