### PR TITLE
sanitize: shared attribution sanitizer, replaces 4 hand-rolled stripHtml (#440)

### DIFF
--- a/components/ImageGallery.vue
+++ b/components/ImageGallery.vue
@@ -15,8 +15,8 @@
           <p class="text-sm text-stone-700">{{ img.alt }}</p>
           <p v-if="img.author" class="text-xs text-stone-400 mt-1">
             Photo by
-            <a v-if="img.authorUrl" :href="img.authorUrl" target="_blank" rel="noopener noreferrer" class="text-correze-red hover:underline">{{ stripHtml(img.author) }}</a>
-            <span v-else>{{ stripHtml(img.author) }}</span>
+            <a v-if="img.authorUrl" :href="img.authorUrl" target="_blank" rel="noopener noreferrer" class="text-correze-red hover:underline">{{ sanitizeAttributionText(img.author) }}</a>
+            <span v-else>{{ sanitizeAttributionText(img.author) }}</span>
             <template v-if="img.license">
               &middot;
               <a v-if="img.licenseUrl" :href="img.licenseUrl" target="_blank" rel="noopener noreferrer" class="hover:underline">{{ img.license }}</a>
@@ -27,7 +27,7 @@
               <a :href="img.sourceUrl" target="_blank" rel="noopener noreferrer" class="hover:underline">Source</a>
             </template>
           </p>
-          <p v-else-if="img.attribution" class="text-xs text-stone-400 mt-1">{{ stripHtml(img.attribution) }}</p>
+          <p v-else-if="img.attribution" class="text-xs text-stone-400 mt-1">{{ sanitizeAttributionText(img.attribution) }}</p>
         </figcaption>
       </figure>
     </div>
@@ -35,12 +35,9 @@
 </template>
 
 <script setup>
+import { sanitizeAttributionText } from '~/utils/sanitize'
+
 defineProps({
   images: { type: Array, default: () => [] }
 })
-
-function stripHtml(str) {
-  if (!str) return ''
-  return str.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"')
-}
 </script>

--- a/components/content/InlineFigure.vue
+++ b/components/content/InlineFigure.vue
@@ -13,8 +13,8 @@
       <p v-if="author || license || sourceUrl" class="text-xs text-stone-400 mt-1">
         <template v-if="author">
           Photo by
-          <a v-if="authorUrl" :href="authorUrl" target="_blank" rel="noopener noreferrer" class="text-correze-red hover:underline">{{ stripHtml(author) }}</a>
-          <span v-else>{{ stripHtml(author) }}</span>
+          <a v-if="authorUrl" :href="authorUrl" target="_blank" rel="noopener noreferrer" class="text-correze-red hover:underline">{{ sanitizeAttributionText(author) }}</a>
+          <span v-else>{{ sanitizeAttributionText(author) }}</span>
         </template>
         <template v-if="license">
           <span v-if="author"> &middot; </span>
@@ -31,6 +31,8 @@
 </template>
 
 <script setup>
+import { sanitizeAttributionText } from '~/utils/sanitize'
+
 defineProps({
   src: { type: String, required: true },
   alt: { type: String, default: '' },
@@ -41,9 +43,4 @@ defineProps({
   licenseUrl: { type: String, default: '' },
   sourceUrl: { type: String, default: '' },
 })
-
-function stripHtml(str) {
-  if (!str) return ''
-  return str.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"')
-}
 </script>

--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -170,6 +170,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import attractionsData from '~/data/attractions.json'
+import { sanitizeAttributionText } from '~/utils/sanitize'
 
 definePageMeta({ layout: 'admin' })
 
@@ -230,11 +231,10 @@ function toggleImage(img) {
   if (isSelected(img)) {
     selected.value = selected.value.filter(s => s.src !== img.url)
   } else {
-    const artist = (img.artist || '').replace(/<[^>]*>/g, '').trim()
     selected.value.push({
       src: img.url,
-      alt: (img.description || img.title || '').replace(/<[^>]*>/g, '').trim(),
-      author: artist,
+      alt: sanitizeAttributionText(img.description || img.title),
+      author: sanitizeAttributionText(img.artist),
       authorUrl: img.description_url || null,
       license: img.license || 'Unknown',
       licenseUrl: img.license === 'Public domain' ? null : 'https://creativecommons.org/licenses/by-sa/4.0/',

--- a/server/api/wikipedia-images.post.ts
+++ b/server/api/wikipedia-images.post.ts
@@ -1,3 +1,5 @@
+import { sanitizeAttributionText } from '~/utils/sanitize'
+
 type WikiImage = {
   title: string
   url: string
@@ -23,10 +25,6 @@ const WIKI_HEADERS = {
   'Accept': 'application/json',
 }
 
-function stripHtml(value: string): string {
-  return value.replace(/<[^>]*>/g, '').trim()
-}
-
 async function fetchCommonsMetadata(fileNames: string[]): Promise<Record<string, CommonsMeta>> {
   if (!fileNames.length) return {}
   const params = new URLSearchParams({
@@ -49,7 +47,7 @@ async function fetchCommonsMetadata(fileNames: string[]): Promise<Record<string,
     if (!title || !info) continue
     const ext = (info.extmetadata ?? {}) as Record<string, { value?: string } | undefined>
     byTitle[title] = {
-      artist: stripHtml(ext.Artist?.value ?? ''),
+      artist: sanitizeAttributionText(ext.Artist?.value),
       license: ext.LicenseShortName?.value ?? '',
       licenseUrl: ext.LicenseUrl?.value ?? null,
       descriptionurl: (info.descriptionurl as string | undefined) ?? null,

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeAttributionText } from '~/utils/sanitize'
+
+describe('sanitizeAttributionText', () => {
+  it('returns empty string for empty / null / undefined input', () => {
+    expect(sanitizeAttributionText('')).toBe('')
+    expect(sanitizeAttributionText(null)).toBe('')
+    expect(sanitizeAttributionText(undefined)).toBe('')
+  })
+
+  it('passes plain text through unchanged', () => {
+    expect(sanitizeAttributionText('Jean Dupont')).toBe('Jean Dupont')
+    expect(sanitizeAttributionText('  Author Name  ')).toBe('Author Name')
+  })
+
+  it('strips a single tag wrapping an artist name (the common Wikipedia attribution shape)', () => {
+    const input = '<a href="//commons.wikimedia.org/wiki/User:Jean">Jean Dupont</a>'
+    expect(sanitizeAttributionText(input)).toBe('Jean Dupont')
+  })
+
+  it('strips nested-looking <<script>script> patterns (closes CodeQL js/incomplete-multi-character-sanitization)', () => {
+    // A single-pass /<[^>]*>/g leaves "<script" in the output.
+    // The fix is to loop until stable; the assertion is that no "<script"
+    // substring survives.
+    const result = sanitizeAttributionText('<<script>script>alert(1)<</script>/script>')
+    expect(result.toLowerCase()).not.toContain('<script')
+    expect(result.toLowerCase()).not.toContain('</script')
+  })
+
+  it('decodes &amp;amp; to &amp; (closes CodeQL js/double-escaping)', () => {
+    // Naive: replace(/&amp;/g, '&') applied after stripping turns "&amp;amp;"
+    // into "&" via two passes. The fix is single-pass entity decoding.
+    expect(sanitizeAttributionText('&amp;amp;')).toBe('&amp;')
+  })
+
+  it('decodes the standard named entities exactly once', () => {
+    expect(sanitizeAttributionText('Tom &amp; Jerry')).toBe('Tom & Jerry')
+    expect(sanitizeAttributionText('a &lt; b')).toBe('a < b')
+    expect(sanitizeAttributionText('a &gt; b')).toBe('a > b')
+    expect(sanitizeAttributionText('she said &quot;hi&quot;')).toBe('she said "hi"')
+    expect(sanitizeAttributionText('it&apos;s')).toBe("it's")
+  })
+
+  it('decodes numeric entities (decimal and hex)', () => {
+    expect(sanitizeAttributionText('it&#39;s')).toBe("it's")
+    expect(sanitizeAttributionText('it&#x27;s')).toBe("it's")
+    expect(sanitizeAttributionText('caf&#233;')).toBe('café')
+  })
+
+  it('strips tags first, then decodes entities (so &lt;script&gt; survives as text)', () => {
+    // After strip there are no "<...>" substrings to remove. Decoding then
+    // gives back the literal text "<script>". Vue's text interpolation
+    // re-escapes this at render time, so it is safe to leave as text.
+    expect(sanitizeAttributionText('&lt;script&gt;')).toBe('<script>')
+  })
+
+  it('handles a realistic Wikipedia Artist field with mixed markup and entities', () => {
+    const input = '<a href="//commons.wikimedia.org/wiki/User:Marie">Marie &amp; Pierre Curie</a>'
+    expect(sanitizeAttributionText(input)).toBe('Marie & Pierre Curie')
+  })
+
+  it('trims surrounding whitespace left after tag removal', () => {
+    expect(sanitizeAttributionText('  <span>Hello</span>  ')).toBe('Hello')
+  })
+})

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -1,0 +1,55 @@
+// Wikipedia attribution metadata may carry HTML markup and entity escapes.
+// We render those values as plain text (Vue {{ }} interpolation, never v-html),
+// so the goal of this module is "give me a clean text version."
+//
+// Two failure modes the previous hand-rolled regex hit (CodeQL #4-#10):
+//   - Single-pass /<[^>]*>/g leaves nested patterns like "<<script>script>"
+//     partially intact. Fix: loop until the strip is stable. This is the
+//     canonical fix recommended by the CodeQL js/incomplete-multi-character-
+//     sanitization rule documentation.
+//   - Decoding "&amp;" after stripping turns "&amp;amp;" into "&" via two
+//     passes — fresh "&" characters that an earlier escape meant to neutralise
+//     get re-decoded. Fix: single-pass entity decoding via one regex with a
+//     replacer, no rescans.
+//
+// Order matters: strip tags first, decode entities second. That way "&lt;script&gt;"
+// survives the strip (it has no real "<...>" substrings), then decodes to the
+// literal text "<script>". Vue re-escapes that at render time.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+}
+
+function decodeEntitiesOnce(input: string): string {
+  return input.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, name: string) => {
+    const lower = name.toLowerCase()
+    if (lower.startsWith('#x')) {
+      const code = parseInt(lower.slice(2), 16)
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match
+    }
+    if (lower.startsWith('#')) {
+      const code = parseInt(lower.slice(1), 10)
+      return Number.isFinite(code) ? String.fromCodePoint(code) : match
+    }
+    return NAMED_ENTITIES[lower] ?? match
+  })
+}
+
+function stripTagsUntilStable(input: string): string {
+  let prev: string
+  let s = input
+  do {
+    prev = s
+    s = s.replace(/<[^>]*>/g, '')
+  } while (s !== prev)
+  return s
+}
+
+export function sanitizeAttributionText(input: string | null | undefined): string {
+  if (!input) return ''
+  return decodeEntitiesOnce(stripTagsUntilStable(input)).trim()
+}


### PR DESCRIPTION
## Summary

- Adds `utils/sanitize.ts` with `sanitizeAttributionText()`: iterative tag strip until stable, single-pass entity decode.
- Replaces the four hand-rolled `stripHtml` copies in `ImageGallery.vue`, `InlineFigure.vue`, `pages/admin/images.vue`, and `server/api/wikipedia-images.post.ts`.
- Adds 10 vitest cases under `tests/utils/sanitize.test.ts` covering the adversarial shapes the CodeQL alerts call out (nested `<<script>script>`, `&amp;amp;`, link-wrapped artist names, standard named entities, decimal/hex numeric entities).

Closes seven CodeQL alerts on the same class of bug:
- [#4](https://github.com/gneeek/tdf26/security/code-scanning/4), [#5](https://github.com/gneeek/tdf26/security/code-scanning/5), [#6](https://github.com/gneeek/tdf26/security/code-scanning/6), [#7](https://github.com/gneeek/tdf26/security/code-scanning/7), [#8](https://github.com/gneeek/tdf26/security/code-scanning/8) — `js/incomplete-multi-character-sanitization`. Single-pass `/<[^>]*>/g` leaves nested patterns intact after one pass; looping until stable is the canonical CodeQL fix.
- [#9](https://github.com/gneeek/tdf26/security/code-scanning/9), [#10](https://github.com/gneeek/tdf26/security/code-scanning/10) — `js/double-escaping`. The hand-rolled decode used sequential `/&amp;/g` + `/&lt;/g` + … which double-decoded `&amp;amp;` to `&`. Single-pass decode keeps each entity to one decode.

Order is strip-then-decode, so `&lt;script&gt;` survives the strip and decodes to literal text `<script>`; Vue `{{ }}` interpolation re-escapes that at render time.

## Why no new dependency

The issue suggests DOMPurify or `DOMParser`. Both have isomorphism issues for our setup (Nuxt static-generates SSR on Node, where `DOMParser` is undefined; DOMPurify needs jsdom on the server). A small, tested utility owns ~10 lines of code and avoids ~50KB on `ImageGallery`'s bundle (loads on every entry page). The CodeQL rule docs themselves prescribe loop-until-stable as the fix, so this is on the canonical path.

Closes #440. Strand A of v1.4.11.

## Test plan

- [x] `npm test` — 104/104 across the suite (10 new + existing 94 untouched).
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `npm run generate` + spot-check rendered attribution on \`/entries/06-beynat\` — all 10 \`Photo by <author>\` lines render with author names intact (Sebcosmic, Hovallef, AirScott, Babsy, Wikipedia, Unknown).
- [ ] After merge, confirm CodeQL alerts #4-#10 transition to \`fixed\` on the next scan: \`gh api repos/gneeek/tdf26/code-scanning/alerts --jq '[.[] | select(.number | IN(4,5,6,7,8,9,10)) | {number, state}]'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)