### PR TITLE
utils/stage-totals: derive CATEGORIZED_CLIMBS from points-config (#422)

### DIFF
--- a/tests/utils/stage-totals.test.ts
+++ b/tests/utils/stage-totals.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+
+import pointsConfig from '~/data/competition/points-config.json'
+import { CATEGORIZED_CLIMBS } from '~/utils/stage-totals'
+
+// Drift detector. CATEGORIZED_CLIMBS must equal points-config.json's
+// climbs[].name. #369 surfaced exactly this drift: Côte de Malemort was added
+// to points-config (so KOM points were awarded) but stayed out of the
+// hand-maintained set, so the seg-1 stage-details card silently omitted it.
+// This test is the structural guarantee — failing here means the two surfaces
+// have diverged again.
+describe('CATEGORIZED_CLIMBS vs points-config.json', () => {
+  const declared = new Set<string>(pointsConfig.climbs.map(c => c.name))
+
+  it('contains every climb declared in points-config.json', () => {
+    for (const name of declared) {
+      expect(CATEGORIZED_CLIMBS.has(name)).toBe(true)
+    }
+  })
+
+  it('contains no climbs not declared in points-config.json', () => {
+    for (const name of CATEGORIZED_CLIMBS) {
+      expect(declared.has(name)).toBe(true)
+    }
+  })
+
+  it('has the same size as the declared set', () => {
+    expect(CATEGORIZED_CLIMBS.size).toBe(declared.size)
+  })
+})

--- a/utils/stage-totals.ts
+++ b/utils/stage-totals.ts
@@ -1,3 +1,5 @@
+import pointsConfig from '~/data/competition/points-config.json'
+
 interface Segment {
   segment: number
   km_start: number
@@ -8,22 +10,13 @@ interface Segment {
   climbs?: string[]
 }
 
-// Hand-maintained mirror of climb names in data/competition/points-config.json.
-// Drift between the two surfaces silently filters climbs out of stage-details
-// rendering — exactly the seg-1 Malemort case found during #369. Refactor to
-// derive this Set from points-config.json directly is tracked separately.
-export const CATEGORIZED_CLIMBS = new Set([
-  'Côte de Malemort',
-  'Puy Boubou',
-  'Côte de Lagleygeolle',
-  'Côte de Miel',
-  'Côte des Naves',
-  'Puy de Lachaud',
-  'Suc au May',
-  'Côte de la Croix de Pey',
-  'Mont Bessou',
-  'Côte des Gardes',
-])
+// Derived from points-config.json's climbs[].name, which self-describes as the
+// single source of truth for climb identity. Adding/removing/renaming a climb
+// in points-config flows through to stage-details rendering with no second
+// edit. tests/utils/stage-totals.test.ts asserts this set stays in sync.
+export const CATEGORIZED_CLIMBS: Set<string> = new Set(
+  pointsConfig.climbs.map(c => c.name),
+)
 
 export interface StageTotals {
   totalDistance: number


### PR DESCRIPTION
## Summary

Fixes #422. The hand-maintained \`CATEGORIZED_CLIMBS\` Set in \`utils/stage-totals.ts\` is now derived at import time from \`data/competition/points-config.json\`'s \`climbs[].name\` field — the file that already self-describes as the single source of truth for climb identity. Adding, removing, or renaming a climb in points-config now flows through to stage-details rendering with no second edit.

A new structural test, \`tests/utils/stage-totals.test.ts\`, asserts the two surfaces stay aligned and fails on drift. This test (not the hand-maintained list) is the parallel-source-of-truth detector for this case.

## Locked decisions

| Question (from issue / brief) | Choice |
|---|---|
| Keep export name `CATEGORIZED_CLIMBS` or rename to something derivative (e.g. `POINTS_CONFIG_CLIMB_NAMES`)? | Keep — minimises consumer churn (StageDetails.vue:34, stage-totals.ts:64,86). |
| Eager JSON import vs `useAsyncData` runtime fetch? | Eager `import` — Vite/Nuxt handle it, the data is committed in the repo, and the existing `pointsConfig` consumers (`processing/calculate_points.py` etc.) treat it as build-time canon. |
| Where to put the new test? | New `tests/utils/` subdirectory matching the source layout. |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 97 tests pass (19 files), including the existing `tests/components/StageDetails.test.ts` and the new drift-detector test
- [x] `npm run build` — types pass, production bundle generated
- [x] Behaviour unchanged: both consumers (`utils/stage-totals.ts`, `components/StageDetails.vue`) use only `.has()` against the Set, so a same-content Set built two different ways yields identical output. The drift test guarantees same content.

## Out of scope (per brief)

- Building a general parallel-source-of-truth detector that scans the repo for similar hand-maintained mirrors. If a second instance surfaces during this work, file a new issue rather than fix inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)