### PR TITLE
External links in entries open in a new tab (#449)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,19 @@ export default defineNuxtConfig({
   ],
 
   content: {
-    documentDriven: false
+    documentDriven: false,
+    build: {
+      markdown: {
+        rehypePlugins: {
+          'rehype-external-links': {
+            options: {
+              target: '_blank',
+              rel: ['noopener', 'noreferrer']
+            }
+          }
+        }
+      }
+    }
   },
 
   nitro: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "leaflet": "^1.9.4",
         "marked": "^18.0.2",
         "nuxt": "^4.4.2",
+        "rehype-external-links": "^3.0.0",
         "vue-chartjs": "^5.3.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "leaflet": "^1.9.4",
     "marked": "^18.0.2",
     "nuxt": "^4.4.2",
+    "rehype-external-links": "^3.0.0",
     "vue-chartjs": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Wires `rehype-external-links` into Nuxt Content's markdown pipeline so external `<a>` tags in entry body content gain `target="_blank"` and `rel="noopener noreferrer"`.
- Internal links (`/`, `/entries/...`, `#anchor`) are left untouched.
- Reader benefit: clicking a Sources URL or any inline external link no longer loses the reader's place in the entry.

## Scope

Site-wide (all segments) per publisher decision recorded on issue #449. The simpler treatment was preferred over per-segment scoping; component-level links in layouts and `ImageGallery` already open in a new tab, so this brings prose links to the same behaviour.

## Verification

Dev server (`npm run dev`) checked against three entries — seg 6, seg 7, seg 8:

- Internal links (`/`, `/rules`, `/admin`, `/entries/...`, `#sources`, `#rider-dashboard`): same-tab, no `target` attribute added — confirmed across all three entries.
- External links in `## Sources` (Wikipedia, cyclingstage.com, beynat.fr, templiers.net, hameauxdemiel.com, guide-de-la-correze.com, …): all gained `target="_blank" rel="noopener noreferrer"`.
- `StreetViewEmbed` iframe and the publish-day rider-stats paragraph still render correctly under the new config (regression spot-check).

## Test plan

- [x] CI green (test, CodeQL, type-check)
- [x] Visual spot-check on the dev server: any seg 6+ entry's Sources section opens in new tab; an internal `/entries/...` link opens in same tab
- [x] After merge, will be picked up by the seg 8 publish via `./scripts/publish.sh` — same single deploy ships both the entry and the link-behaviour change (per the publish-day plan agreed with publisher)

## Notes

- Plugin shape under `content.build.markdown.rehypePlugins` follows the Nuxt Content v3 schema (`{ options: ... }` map keyed by package name); the package is dynamically imported by name at config time.
- `rehype-external-links` 3.x classifies absolute URLs as external by default; no protocol filter needed.

Closes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)