### PR TITLE
Bash allowlist additions and license-defaults CLAUDE.md note

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,16 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(source ~/.nvm/nvm.sh)",
+      "Bash(nvm use --silent)",
+      "Bash(npm test)",
+      "Bash(npx nuxt prepare)",
+      "Bash(ruff check *)",
+      "Bash(curl -s *)",
+      "Bash(curl -sI *)"
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,7 @@ Each entry (~800–1200 words) should weave together:
 - Rider stats are recalculated fresh each time from the full daily-log.json
 - The site must work fully as a static site — no server-side rendering required at runtime
 - Prioritize mobile-responsive design; entries will be shared on social media
+- New repositories in this ecosystem use Apache 2.0 for code repos and CC BY-SA 4.0 for content/text repos. The `gh repo create --license` default is Apache 2.0, which is wrong for content-centric repos such as `unfold`; pass the correct flag explicitly at creation time.
 
 ## References: Cycling History Along the Route
 


### PR DESCRIPTION
## Summary

Two small project-config additions parked from a 2026-04-27 v1.4.11 strand session that didn't make it into a commit at the time. Captured as a stash on the seg-10 branch on 2026-04-30; surfaced and unstashed during the seg 8 publish window.

- **`.claude/settings.json`** — add a `permissions.allow` block listing seven bash matchers commonly invoked during strand work: nvm sourcing, `npm test`, `npx nuxt prepare`, `ruff check`, and read-only `curl -s` / `curl -sI`. Reduces permission prompts when sessions run in the main checkout. The worktree-inheritance gap remains; this only documents what should apply (see the "Git worktrees don't inherit `.claude/` settings" item in `project_next_planning_notes.md`).
- **`CLAUDE.md`** — record that new repos in this ecosystem use Apache 2.0 for code and CC BY-SA 4.0 for content. The `gh repo create --license` default is Apache 2.0, which is wrong for content-centric repos like `unfold`; pass the correct flag explicitly at creation time.

## Test plan

- [x] CI green
- [x] No functional impact at runtime — settings.json is read by Claude Code only, CLAUDE.md is doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)