### PR TITLE
publish.sh: tag and create GitHub Release on successful publish (#456)

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Tag HEAD and create a GitHub Release for it.
+#
+# Usage:
+#   ./scripts/create-release.sh <tag> [--title <title>]
+#
+# Example:
+#   ./scripts/create-release.sh v1.4.14
+#   ./scripts/create-release.sh v1.4.14 --title "v1.4.14 - Segment 9 publication"
+#
+# The release body is auto-generated from the git log between the previous tag
+# and HEAD, plus a retro-link placeholder. The publisher can edit the body and
+# title on GitHub afterwards (the tag and release exist after this script runs;
+# their content is editable).
+#
+# Refuses to act if the tag already exists locally or as a GitHub Release.
+
+set -e
+
+TAG=""
+TITLE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --title)
+            TITLE="$2"
+            shift 2
+            ;;
+        -*)
+            echo "ERROR: unknown flag: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$TAG" ]; then
+                TAG="$1"
+            else
+                echo "ERROR: unexpected positional arg: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$TAG" ]; then
+    echo "Usage: $0 <tag> [--title <title>]" >&2
+    exit 1
+fi
+
+if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: tag must match v<major>.<minor>.<patch> (got: $TAG)" >&2
+    exit 1
+fi
+
+if [ -z "$TITLE" ]; then
+    TITLE="$TAG"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if git -C "$PROJECT_DIR" rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "ERROR: tag $TAG already exists locally." >&2
+    exit 1
+fi
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+    echo "ERROR: GitHub Release $TAG already exists." >&2
+    exit 1
+fi
+
+PREVIOUS_TAG=$(git -C "$PROJECT_DIR" describe --tags --abbrev=0 2>/dev/null || true)
+HEAD_SHA=$(git -C "$PROJECT_DIR" rev-parse --short HEAD)
+
+NOTES_FILE=$(mktemp)
+trap 'rm -f "$NOTES_FILE"' EXIT
+
+{
+    echo "## What shipped"
+    echo ""
+    if [ -n "$PREVIOUS_TAG" ]; then
+        echo "Commits since [$PREVIOUS_TAG](https://github.com/gneeek/tdf26/releases/tag/$PREVIOUS_TAG):"
+        echo ""
+        git -C "$PROJECT_DIR" log --pretty=format:'- %s' "$PREVIOUS_TAG..HEAD"
+        echo ""
+    else
+        echo "Recent commits (no previous tag found):"
+        echo ""
+        git -C "$PROJECT_DIR" log --pretty=format:'- %s' -20
+        echo ""
+    fi
+    echo ""
+    echo "## Retro"
+    echo ""
+    echo "Retro link will be added when the retro is filed: https://github.com/gneeek/tdf26/wiki/Retrospectives"
+} > "$NOTES_FILE"
+
+echo "Tagging $HEAD_SHA as $TAG..."
+git -C "$PROJECT_DIR" tag -a "$TAG" -m "Release $TAG"
+git -C "$PROJECT_DIR" push origin "$TAG"
+
+echo "Creating GitHub Release $TAG..."
+gh release create "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE"
+
+echo ""
+echo "Release created: https://github.com/gneeek/tdf26/releases/tag/$TAG"
+echo "Edit the release on GitHub to expand the framing and add the retro link as needed."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,8 @@
 # build site, deploy, and commit the frontmatter changes this script produced
 # so main is reconciled with the deployed artifact before the script exits.
 #
-# Usage: ./scripts/publish.sh [--segment N] [--skip-deploy] [--skip-weather] [--skip-commit]
+# Usage: ./scripts/publish.sh [--segment N] [--release-tag vX.Y.Z]
+#                             [--skip-deploy] [--skip-weather] [--skip-commit] [--skip-release]
 #
 # Environment variables (loaded from .env if present):
 #   OPENWEATHERMAP_API_KEY  - API key for weather data (optional)
@@ -25,7 +26,9 @@ fi
 SKIP_DEPLOY=false
 SKIP_WEATHER=false
 SKIP_COMMIT=false
+SKIP_RELEASE=false
 SEGMENT=""
+RELEASE_TAG=""
 
 # Parse arguments
 for arg in "$@"; do
@@ -34,16 +37,20 @@ for arg in "$@"; do
             echo "Usage: ./scripts/publish.sh [OPTIONS]"
             echo ""
             echo "Publish-day script: update stats, calculate points, snapshot, fetch weather,"
-            echo "build, deploy, and commit frontmatter changes to main."
+            echo "build, deploy, commit frontmatter changes to main, and create a GitHub Release."
             echo ""
             echo "Options:"
-            echo "  --segment N     Segment number to publish (auto-detects if omitted)"
-            echo "  --skip-deploy   Skip the deployment step (also skips the commit step)"
-            echo "  --skip-weather  Skip weather fetch"
-            echo "  --skip-commit   Deploy but do not commit frontmatter to main"
-            echo "                  (advanced: for deploys run from a branch or in a"
-            echo "                  workflow where the commit is handled separately)"
-            echo "  -h, --help      Show this help message"
+            echo "  --segment N            Segment number to publish (auto-detects if omitted)"
+            echo "  --release-tag vX.Y.Z   Tag and GitHub Release to create after a successful"
+            echo "                         deploy (must match v<major>.<minor>.<patch> format and"
+            echo "                         not already exist). Required unless --skip-release."
+            echo "  --skip-deploy          Skip the deployment step (also skips commit and release)"
+            echo "  --skip-weather         Skip weather fetch"
+            echo "  --skip-commit          Deploy but do not commit frontmatter to main"
+            echo "                         (advanced: for deploys run from a branch or in a"
+            echo "                         workflow where the commit is handled separately)"
+            echo "  --skip-release         Deploy but do not create a tag or GitHub Release"
+            echo "  -h, --help             Show this help message"
             echo ""
             echo "Environment variables:"
             echo "  OPENWEATHERMAP_API_KEY  API key for weather data (optional)"
@@ -59,17 +66,43 @@ for arg in "$@"; do
         --skip-commit)
             SKIP_COMMIT=true
             ;;
+        --skip-release)
+            SKIP_RELEASE=true
+            ;;
         --segment)
-            shift_next=true
+            arg_consumer="SEGMENT"
+            ;;
+        --release-tag)
+            arg_consumer="RELEASE_TAG"
             ;;
         *)
-            if [ "$shift_next" = true ]; then
-                SEGMENT="$arg"
-                shift_next=false
+            if [ -n "$arg_consumer" ]; then
+                printf -v "$arg_consumer" "%s" "$arg"
+                arg_consumer=""
             fi
             ;;
     esac
 done
+
+# Validate release tag up front so we don't deploy then discover a malformed tag.
+if [ "$SKIP_RELEASE" = false ] && [ "$SKIP_DEPLOY" = false ]; then
+    if [ -z "$RELEASE_TAG" ]; then
+        echo "ERROR: --release-tag is required (or pass --skip-release to suppress)." >&2
+        exit 1
+    fi
+    if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "ERROR: --release-tag must match v<major>.<minor>.<patch> (got: $RELEASE_TAG)." >&2
+        exit 1
+    fi
+    if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+        echo "ERROR: tag $RELEASE_TAG already exists locally." >&2
+        exit 1
+    fi
+    if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+        echo "ERROR: GitHub Release $RELEASE_TAG already exists." >&2
+        exit 1
+    fi
+fi
 
 echo "=== Correze Travelogue - Publish ==="
 echo "Date: $(date +%Y-%m-%d)"
@@ -273,6 +306,23 @@ else
             || { echo "ERROR: git push failed. The deploy happened but main is not reconciled. Resolve manually."; exit 1; }
         echo "Committed and pushed frontmatter changes for segment $SEGMENT."
     fi
+fi
+
+# Step 10: Tag and create GitHub Release
+# Fires after the frontmatter commit so the tag captures main in agreement with
+# the deployed artifact. Skipped if any earlier deploy/commit step was skipped,
+# since those leave main and production out of sync.
+if [ "$SKIP_RELEASE" = true ]; then
+    echo "--- Step 10: Release skipped (--skip-release flag) ---"
+elif [ "$SKIP_DEPLOY" = true ] || [ "$SKIP_COMMIT" = true ]; then
+    echo "--- Step 10: Release skipped (deploy or commit was skipped) ---"
+elif [ -z "$DEPLOY_TARGET" ]; then
+    echo "--- Step 10: Release skipped (no DEPLOY_TARGET, no deploy happened) ---"
+else
+    echo "--- Step 10: Creating release tag $RELEASE_TAG ---"
+    "$SCRIPT_DIR/create-release.sh" "$RELEASE_TAG" \
+        --title "$RELEASE_TAG - Segment $SEGMENT publication" \
+        || { echo "ERROR: create-release.sh failed. Deploy and frontmatter commit succeeded; tag/release require manual creation."; exit 1; }
 fi
 
 echo ""


### PR DESCRIPTION
Closes #456.

## Summary

Adds a new step 10 to `scripts/publish.sh` that creates the publication's tag and GitHub Release after deploy and frontmatter commit succeed. The release-creation logic factors out into a new `scripts/create-release.sh` so the publisher can also fire releases manually for non-publication production changes — for example, today's v1.4.12 release-ceremony work that ships outside `publish.sh`.

## What ships

- **`scripts/create-release.sh <tag> [--title <title>]`** — tags HEAD, pushes the tag, creates a GitHub Release with auto-generated notes (commit list since previous tag + retro-link placeholder). Refuses to act if the tag exists locally or as a GitHub Release. Tag must match `v<major>.<minor>.<patch>`.
- **`scripts/publish.sh`** new flags: `--release-tag vX.Y.Z` (required unless `--skip-release`) and `--skip-release`. Validation fires up front, before any deploy, so a malformed or duplicate tag causes the script to fail before changing production.
- **Step 10 in `publish.sh`** invokes `create-release.sh` after step 9, with title `vX.Y.Z - Segment N publication`. Skipped automatically if any earlier deploy/commit step was skipped.

## Test plan

- [x] `./scripts/publish.sh --help` shows the new flags
- [x] `./scripts/create-release.sh --help` shows usage
- [x] `./scripts/create-release.sh v1.4.11` fails with "tag already exists"
- [x] `./scripts/create-release.sh notavtag` fails on format check
- [x] `./scripts/create-release.sh` (no arg) prints usage and exits 1
- [x] `./scripts/publish.sh --release-tag bogus` fails up front on format
- [x] `./scripts/publish.sh --release-tag v1.4.11` fails up front on existing tag
- [x] `./scripts/publish.sh` (no flags) fails up front demanding `--release-tag` or `--skip-release`
- [x] `./scripts/publish.sh --skip-deploy --skip-release --segment 1` proceeds past validation (skip path)
- [ ] First real-world fire on the seg 9 publish 2026-05-03 (validates the integrated path)

## Coupling with #451

Step 10 runs after step 9 (frontmatter commit-and-push). #451 will replace step 9's direct push with a PR-based path; step 10's contract (tag the post-step-9 HEAD) is unchanged. If step 9 fails, step 10 doesn't fire (the tag captures only post-reconciliation state).

## Today's v1.4.12 release

The factored helper lets today's v1.4.12 release fire as `./scripts/create-release.sh v1.4.12` once today's v1.4.12 work is on main. No change to publish.sh's invocation needed for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)