### PR TITLE
attractions: Commanderie de Puy de Noix coords to Beynat (#454)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -643,17 +643,21 @@
   {
     "name": "Commanderie de Puy de Noix",
     "category": "heritage",
-    "lat": 45.1389,
-    "lng": 1.8364,
-    "description": "Twelfth-century Templar commandery in Albussac commune, about 4km east of the route at its closest point. Acquired by the Knights Templar in the late 12th century; passed to the Hospitallers of Saint John after the order's suppression in 1312.",
+    "lat": 45.1441579,
+    "lng": 1.7631538,
+    "description": "Twelfth-century Templar commandery in Beynat commune, on a wooded hill less than a kilometre off the route. Acquired by the Knights Templar in the late 12th century; passed to the Hospitallers of Saint John after the order's suppression in 1312.",
     "links": [
       {
-        "url": "https://fr.wikipedia.org/wiki/Albussac",
+        "url": "https://fr.wikipedia.org/wiki/Liste_des_commanderies_templi%C3%A8res_en_Corr%C3%A8ze",
         "label": "Wikipedia (fr)"
+      },
+      {
+        "url": "https://www.beynat.fr/decouvrir/8806",
+        "label": "Espace historique de Puy de Noix"
       }
     ],
-    "nearest_km": 50.51,
-    "nearest_distance_m": 4265
+    "nearest_km": 51.98,
+    "nearest_distance_m": 794
   },
   {
     "name": "Dolmen de Rochesseux",


### PR DESCRIPTION
## Summary

- Move the Commanderie de Puy de Noix pin off Albussac village église (the prior `45.1389, 1.8364` was the village église, not the Templar ruin) onto the actual Templar ruin in Beynat commune at `45.1441579, 1.7631538` per beynat.fr.
- Re-run `processing/calculate_attraction_positions.py`: `nearest_km` 50.51 → 51.98, `nearest_distance_m` 4265 → **794**. Same segment (seg 8) — no reassignment.
- Update the description string to match the corrected commune ("Beynat", not "Albussac"); swap the Wikipedia link from the unrelated Albussac commune article to the Corrèze commanderies list, and add the Beynat.fr Espace historique page as a second link.

## Source for the new coord

`https://www.beynat.fr/decouvrir/8806` — the Beynat commune's official page for the Espace historique de Puy de Noix lists `45.1441579050718, 1.76315381403195`. Cross-checked: the recalculated distance (794 m) is consistent with the prose's "off-route hill" framing in the seg 8 entry, even though the prose's specific distance figure differs (see below).

## Out of scope

The seg 8 published entry has compounding factual errors that originated from the prior wrong coord:

- "in the same Albussac commune" — actually Beynat commune.
- "Four kilometres east" / "Four thousand two hundred and sixty-five metres east" — the recalc returns 794 m and a different bearing.
- "near a stream that feeds the Cascades de Murel" — geographically inconsistent with the actual ruin location.
- The Street View embed caption "junction in Albussac" — the embed lat/long sits in Beynat near the Puy de Noix hamlet, not Albussac.

Per the content-change rule (published entries are fixed; corrections carry forward), seg 8 prose is intentionally **not** edited in this PR. The pin will sit ~800 m west of the route while the seg 8 prose still describes a 4 km eastern off-route detour. Carry-forward correction may surface in a later entry.

## Test plan

- [x] `python -m pytest processing/tests/` — 189 passed
- [x] `npm test` — 108 passed across 21 files
- [x] `python processing/audit_segment_data.py --segment 8` — Commanderie reports "matches stored", segment 8

Closes #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)