### PR TITLE
attractions: add Fromagerie Duroux official-site and Pavé Corrézien links

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -175,7 +175,16 @@
     "lat": 45.19,
     "lng": 1.77,
     "description": "Artisan fromagerie near Tulle aging cheese in a reconverted railway tunnel. Produces Pave Correzien.",
-    "links": [],
+    "links": [
+      {
+        "url": "https://www.fromagerie-duroux.fr/",
+        "label": "Official site"
+      },
+      {
+        "url": "https://www.fromagerie-duroux.fr/pave-correzien/",
+        "label": "Pavé Corrézien"
+      }
+    ],
     "nearest_km": 57.91,
     "nearest_distance_m": 20
   },


### PR DESCRIPTION
## Summary

The Fromagerie Duroux attraction entry had an empty `links` array. Add the two URLs the publisher supplied during v1.4.13 dev-server review:

- `https://www.fromagerie-duroux.fr/` — official site root, label "Official site" (matches the convention used by other on-route attractions).
- `https://www.fromagerie-duroux.fr/pave-correzien/` — product page for the cheese the seg 9 entry references, label "Pavé Corrézien".

Both URLs verified live (HTTP 200) and on-topic before commit.

## Note observed during verification (not actioned)

The Pavé Corrézien page states the company is "based in Rilhac-Xaintrie, Corrèze" — south of Tulle, ~30 km from this attraction's coords (`45.19, 1.77`, on-route between Sainte-Fortunade and Tulle at km 57.91). The attraction may be a retail outlet or affinage point distinct from the production site in Rilhac-Xaintrie. Not changing the location here; flagging for the publisher's awareness.

## Test plan

- [x] `python -m pytest processing/tests/` — 189 passed
- [x] JSON validates
- [x] Both link URLs return HTTP 200

## Milestone

Left unset — publisher to decide whether this lands inside v1.4.13 (alongside the Commanderie data fix in #463) or holds for a later release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
