### PR TITLE
lightbox: add prev/next navigation within a gallery (#465)

### DIFF
--- a/components/ImageGallery.vue
+++ b/components/ImageGallery.vue
@@ -7,7 +7,7 @@
           type="button"
           class="block w-full p-0 border-0 bg-transparent cursor-pointer"
           :aria-label="`Open ${img.alt || 'image'} in viewer`"
-          @click="show(img)"
+          @click="show(img, images, idx)"
         >
           <img
             :src="img.src"

--- a/components/ImageLightbox.vue
+++ b/components/ImageLightbox.vue
@@ -15,13 +15,33 @@
     >
       ✕
     </button>
+    <button
+      v-if="hasSiblings"
+      type="button"
+      class="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 text-white text-2xl font-bold hover:bg-white/20 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-white/10"
+      aria-label="Previous image"
+      :disabled="!hasPrev"
+      @click.stop="prev"
+    >
+      ‹
+    </button>
+    <button
+      v-if="hasSiblings"
+      type="button"
+      class="absolute right-3 sm:right-4 top-1/2 -translate-y-1/2 w-12 h-12 flex items-center justify-center rounded-full bg-white/10 text-white text-2xl font-bold hover:bg-white/20 transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-white/10"
+      aria-label="Next image"
+      :disabled="!hasNext"
+      @click.stop="next"
+    >
+      ›
+    </button>
     <figure class="max-w-full max-h-full flex flex-col items-center gap-3" @click.self="close">
       <img
         :src="image.src"
         :alt="image.alt || ''"
         class="max-w-full max-h-[80vh] object-contain rounded shadow-lg"
       >
-      <figcaption v-if="hasAttribution" class="text-center text-stone-200 text-sm max-w-2xl px-2">
+      <figcaption v-if="hasAttribution || hasSiblings" class="text-center text-stone-200 text-sm max-w-2xl px-2">
         <p v-if="image.caption || image.alt" class="text-stone-100">{{ image.caption || image.alt }}</p>
         <p v-if="image.author" class="text-xs text-stone-400 mt-1">
           Photo by
@@ -38,6 +58,7 @@
           </template>
         </p>
         <p v-else-if="image.attribution" class="text-xs text-stone-400 mt-1">{{ sanitizeAttributionText(image.attribution) }}</p>
+        <p v-if="hasSiblings" class="text-xs text-stone-500 mt-1">{{ currentIndex + 1 }} / {{ siblings.length }}</p>
       </figcaption>
     </figure>
   </div>
@@ -48,7 +69,7 @@ import { computed, onMounted, onUnmounted, watch } from 'vue'
 import { sanitizeAttributionText } from '~/utils/sanitize'
 import { useImageLightbox } from '~/composables/useImageLightbox'
 
-const { image, isOpen, close } = useImageLightbox()
+const { image, siblings, currentIndex, isOpen, hasSiblings, hasPrev, hasNext, close, next, prev } = useImageLightbox()
 
 const hasAttribution = computed(() => {
   if (!image.value) return false
@@ -56,7 +77,10 @@ const hasAttribution = computed(() => {
 })
 
 function onKeydown(e: KeyboardEvent) {
-  if (e.key === 'Escape' && isOpen.value) close()
+  if (!isOpen.value) return
+  if (e.key === 'Escape') close()
+  else if (e.key === 'ArrowRight' && hasNext.value) next()
+  else if (e.key === 'ArrowLeft' && hasPrev.value) prev()
 }
 
 onMounted(() => window.addEventListener('keydown', onKeydown))

--- a/composables/useImageLightbox.ts
+++ b/composables/useImageLightbox.ts
@@ -12,15 +12,42 @@ interface LightboxImage {
 
 export function useImageLightbox() {
   const image = useState<LightboxImage | null>('lightbox-image', () => null)
-  const isOpen = computed(() => image.value !== null)
+  const siblings = useState<LightboxImage[]>('lightbox-siblings', () => [])
+  const currentIndex = useState<number>('lightbox-index', () => -1)
 
-  function show(payload: LightboxImage) {
+  const isOpen = computed(() => image.value !== null)
+  const hasSiblings = computed(() => siblings.value.length > 1)
+  const hasPrev = computed(() => hasSiblings.value && currentIndex.value > 0)
+  const hasNext = computed(() => hasSiblings.value && currentIndex.value < siblings.value.length - 1)
+
+  function show(payload: LightboxImage, siblingList?: LightboxImage[], index?: number) {
     image.value = payload
+    if (siblingList && typeof index === 'number' && index >= 0) {
+      siblings.value = siblingList
+      currentIndex.value = index
+    } else {
+      siblings.value = []
+      currentIndex.value = -1
+    }
   }
 
   function close() {
     image.value = null
+    siblings.value = []
+    currentIndex.value = -1
   }
 
-  return { image, isOpen, show, close }
+  function next() {
+    if (!hasNext.value) return
+    currentIndex.value += 1
+    image.value = siblings.value[currentIndex.value]
+  }
+
+  function prev() {
+    if (!hasPrev.value) return
+    currentIndex.value -= 1
+    image.value = siblings.value[currentIndex.value]
+  }
+
+  return { image, siblings, currentIndex, isOpen, hasSiblings, hasPrev, hasNext, show, close, next, prev }
 }

--- a/tests/components/ImageGallery.test.ts
+++ b/tests/components/ImageGallery.test.ts
@@ -70,6 +70,18 @@ describe('ImageGallery', () => {
     const wrapper = mount(ImageGallery, { props: { images: [img] } })
     await wrapper.find('button').trigger('click')
     expect(showSpy).toHaveBeenCalledTimes(1)
-    expect(showSpy).toHaveBeenCalledWith(img)
+    expect(showSpy).toHaveBeenCalledWith(img, [img], 0)
+  })
+
+  it('passes the full image array and index to the lightbox', async () => {
+    const images = [
+      { src: '/img/a.jpg', alt: 'A' },
+      { src: '/img/b.jpg', alt: 'B' },
+      { src: '/img/c.jpg', alt: 'C' },
+    ]
+    const wrapper = mount(ImageGallery, { props: { images } })
+    const buttons = wrapper.findAll('button')
+    await buttons[1].trigger('click')
+    expect(showSpy).toHaveBeenCalledWith(images[1], images, 1)
   })
 })

--- a/tests/components/ImageLightbox.test.ts
+++ b/tests/components/ImageLightbox.test.ts
@@ -1,25 +1,68 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, enableAutoUnmount } from '@vue/test-utils'
 import { ref, computed } from 'vue'
 import ImageLightbox from '~/components/ImageLightbox.vue'
 
+enableAutoUnmount(afterEach)
+
 const lightboxImage = ref<any>(null)
-const closeSpy = vi.fn(() => { lightboxImage.value = null })
+const siblings = ref<any[]>([])
+const currentIndex = ref<number>(-1)
+const closeSpy = vi.fn(() => { lightboxImage.value = null; siblings.value = []; currentIndex.value = -1 })
+const nextSpy = vi.fn(() => {
+  if (currentIndex.value < siblings.value.length - 1) {
+    currentIndex.value += 1
+    lightboxImage.value = siblings.value[currentIndex.value]
+  }
+})
+const prevSpy = vi.fn(() => {
+  if (currentIndex.value > 0) {
+    currentIndex.value -= 1
+    lightboxImage.value = siblings.value[currentIndex.value]
+  }
+})
 const isOpen = computed(() => lightboxImage.value !== null)
+const hasSiblings = computed(() => siblings.value.length > 1)
+const hasPrev = computed(() => hasSiblings.value && currentIndex.value > 0)
+const hasNext = computed(() => hasSiblings.value && currentIndex.value < siblings.value.length - 1)
 
 vi.mock('~/composables/useImageLightbox', () => ({
   useImageLightbox: () => ({
     image: lightboxImage,
+    siblings,
+    currentIndex,
     isOpen,
-    show: (img: any) => { lightboxImage.value = img },
+    hasSiblings,
+    hasPrev,
+    hasNext,
+    show: (img: any, list?: any[], idx?: number) => {
+      lightboxImage.value = img
+      if (list && typeof idx === 'number') {
+        siblings.value = list
+        currentIndex.value = idx
+      } else {
+        siblings.value = []
+        currentIndex.value = -1
+      }
+    },
     close: closeSpy,
+    next: nextSpy,
+    prev: prevSpy,
   }),
 }))
+
+const A = { src: '/img/a.jpg', alt: 'A' }
+const B = { src: '/img/b.jpg', alt: 'B' }
+const C = { src: '/img/c.jpg', alt: 'C' }
 
 describe('ImageLightbox', () => {
   beforeEach(() => {
     lightboxImage.value = null
+    siblings.value = []
+    currentIndex.value = -1
     closeSpy.mockClear()
+    nextSpy.mockClear()
+    prevSpy.mockClear()
   })
 
   it('renders nothing when no image is open', () => {
@@ -67,7 +110,6 @@ describe('ImageLightbox', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
     await wrapper.vm.$nextTick()
     expect(closeSpy).toHaveBeenCalledTimes(1)
-    wrapper.unmount()
   })
 
   it('does not close on non-Escape keydown', async () => {
@@ -77,6 +119,128 @@ describe('ImageLightbox', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
     await wrapper.vm.$nextTick()
     expect(closeSpy).not.toHaveBeenCalled()
-    wrapper.unmount()
+  })
+
+  it('shows prev and next buttons when there are siblings', async () => {
+    lightboxImage.value = A
+    siblings.value = [A, B, C]
+    currentIndex.value = 1
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('button[aria-label="Previous image"]').exists()).toBe(true)
+    expect(wrapper.find('button[aria-label="Next image"]').exists()).toBe(true)
+  })
+
+  it('hides prev and next buttons when there are no siblings', async () => {
+    lightboxImage.value = A
+    siblings.value = []
+    currentIndex.value = -1
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('button[aria-label="Previous image"]').exists()).toBe(false)
+    expect(wrapper.find('button[aria-label="Next image"]').exists()).toBe(false)
+  })
+
+  it('disables prev button at the first image', async () => {
+    lightboxImage.value = A
+    siblings.value = [A, B, C]
+    currentIndex.value = 0
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('button[aria-label="Previous image"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('button[aria-label="Next image"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('disables next button at the last image', async () => {
+    lightboxImage.value = C
+    siblings.value = [A, B, C]
+    currentIndex.value = 2
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('button[aria-label="Previous image"]').attributes('disabled')).toBeUndefined()
+    expect(wrapper.find('button[aria-label="Next image"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('calls next() when next button is clicked', async () => {
+    lightboxImage.value = A
+    siblings.value = [A, B, C]
+    currentIndex.value = 0
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    await wrapper.find('button[aria-label="Next image"]').trigger('click')
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls prev() when prev button is clicked', async () => {
+    lightboxImage.value = B
+    siblings.value = [A, B, C]
+    currentIndex.value = 1
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    await wrapper.find('button[aria-label="Previous image"]').trigger('click')
+    expect(prevSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates to the next image on ArrowRight keydown', async () => {
+    lightboxImage.value = A
+    siblings.value = [A, B, C]
+    currentIndex.value = 0
+    const wrapper = mount(ImageLightbox, { attachTo: document.body })
+    await wrapper.vm.$nextTick()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+    await wrapper.vm.$nextTick()
+    expect(nextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates to the previous image on ArrowLeft keydown', async () => {
+    lightboxImage.value = B
+    siblings.value = [A, B, C]
+    currentIndex.value = 1
+    const wrapper = mount(ImageLightbox, { attachTo: document.body })
+    await wrapper.vm.$nextTick()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await wrapper.vm.$nextTick()
+    expect(prevSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not navigate past the end on ArrowRight at the last image', async () => {
+    lightboxImage.value = C
+    siblings.value = [A, B, C]
+    currentIndex.value = 2
+    const wrapper = mount(ImageLightbox, { attachTo: document.body })
+    await wrapper.vm.$nextTick()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }))
+    await wrapper.vm.$nextTick()
+    expect(nextSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate before the start on ArrowLeft at the first image', async () => {
+    lightboxImage.value = A
+    siblings.value = [A, B, C]
+    currentIndex.value = 0
+    const wrapper = mount(ImageLightbox, { attachTo: document.body })
+    await wrapper.vm.$nextTick()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
+    await wrapper.vm.$nextTick()
+    expect(prevSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows position indicator when there are siblings', async () => {
+    lightboxImage.value = B
+    siblings.value = [A, B, C]
+    currentIndex.value = 1
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('2 / 3')
+  })
+
+  it('does not show position indicator with no siblings', async () => {
+    lightboxImage.value = { src: '/img/x.jpg', alt: 'X' }
+    siblings.value = []
+    currentIndex.value = -1
+    const wrapper = mount(ImageLightbox)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).not.toContain('/ 0')
+    expect(wrapper.text()).not.toMatch(/\d+ \/ \d+/)
   })
 })


### PR DESCRIPTION
## Summary

Closes #465. Carve-out from the v1.4.13 lightbox (PR #464): readers can now move between sibling images in the same gallery without closing and reopening the modal.

- `composables/useImageLightbox.ts` — adds `siblings`, `currentIndex`, `hasSiblings`, `hasPrev`, `hasNext`, `next()`, `prev()`. The `show()` signature gains optional `(payload, siblingList?, index?)`; calls without the extra args (e.g. `InlineFigure`) clear sibling state, so single-image surfaces show no prev/next UI.
- `components/ImageLightbox.vue` — prev/next buttons (visible only when siblings.length > 1, disabled at boundaries), ArrowLeft/ArrowRight keyboard handlers, "n / total" position indicator.
- `components/ImageGallery.vue` — passes the full image array + clicked index to `show()`.
- `components/content/InlineFigure.vue` — unchanged. Backward-compatible call signature.
- Tests extended 6 → 18 cases.

## Locked decisions

| Question | Decision |
|---|---|
| Wrap-around at boundaries? | No — disabled buttons at first/last for predictability. |
| Show prev/next UI on single-image lightbox opens (e.g. InlineFigure)? | No — `hasSiblings` gates the buttons and the position indicator. |
| Position indicator format? | `n / total`, plain text under attribution. |

## Test plan

- [ ] `npx vitest run` — full suite green (133/133 locally).
- [ ] Open any multi-image gallery (e.g. seg 8 entry); thumbnail click opens lightbox with prev/next visible. ArrowLeft/ArrowRight navigate. Buttons disabled at first/last image. Esc still closes. Click-outside still closes.
- [ ] Open an `InlineFigure` (single-image MDC component) — no prev/next UI.
- [ ] Lightbox state clears between gallery opens (open gallery A, close, open gallery B → no stale siblings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)