### PR TITLE
v1.4.18 strand briefs: verification, assertions, schema

### DIFF
--- a/docs/strands/strand-a-verify.md
+++ b/docs/strands/strand-a-verify.md
@@ -1,0 +1,104 @@
+# Strand A — Content quality: segs 11-13 data verification (v1.4.18)
+
+**Start here:** [Roadmap → Next → v1.4.18](https://github.com/gneeek/tdf26/wiki/Roadmap#next), then [#477](https://github.com/gneeek/tdf26/issues/477).
+
+## Goal
+
+Complete data verification for segments 11-13 (km 70-92, Naves through Chaumeil) before any seg 11 prose drafting starts. Mirror the seg 9+10 verification (#434 → PR #470) shape: per-claim audit, citations, outcomes documented in the PR body. This is the load-bearing time-sensitive item for v1.4.18 — seg 11 publishes Sun 2026-05-10.
+
+Goal 2 (content quality). Commit-tier.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree. Symlink the agent config from main; copy (do not symlink) the gitignored rider data files because the publish session running in parallel today writes to them.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-seg11-verify main
+cd tdf26-seg11-verify
+ln -s ../tdf26/.claude .claude
+source ~/.nvm/nvm.sh && nvm use --silent
+npm ci
+cp ../tdf26/data/riders/daily-log.json data/riders/
+cp ../tdf26/data/riders/points.json data/riders/
+cp ../tdf26/data/riders/stats.json data/riders/
+[ -d ../tdf26/data/riders/snapshots ] && cp -r ../tdf26/data/riders/snapshots data/riders/
+npx nuxt prepare
+```
+
+When the strand finishes: `git worktree remove tdf26-seg11-verify` from the main checkout.
+
+Branch: `feature/issue-477-segs-11-13-verification`. Verify `git branch --show-current` immediately before each `git add` / `git commit`.
+
+## Target issue
+
+- **[#477](https://github.com/gneeek/tdf26/issues/477)** — Data verification: segments 11-13 (km 70-92, Naves through Chaumeil)
+
+Single issue, single PR.
+
+## Workflow
+
+Per-segment audit for segments 11, 12, 13 (in order):
+
+1. **GPX polyline integrity.** Read `data/segments/segment-NN.gpx`. Confirm continuous polyline, no gaps, total km matches `data/segments.json` `km_start`/`km_end`. Use polyline (not endpoints) for all proximity checks per `feedback_on_route_checks.md`.
+2. **km markers.** Confirm segment boundaries match cumulative distance from `data/master.gpx`.
+3. **Climb summit positions.** Côte des Naves (~km 76.6 per CLAUDE.md), Puy de Lachaud. Verify summit lat/lng against IGN/OSM; verify km position against the segment polyline.
+4. **`segments.json` notable_points/towns/climbs.** Each entry verified against CLAUDE.md canon and IGN/OSM. Each correction documented in PR body.
+5. **`data/attractions.json`.** Each attraction in segs 11-13 verified for proximity (use polyline), category accuracy, and `infoUrl` validity.
+6. **`data/historical-tdf.json`.** Existing entries verified. **NEW research required** for seg 13: 1987 TdF men's Stage 11 + women's Tour Stage 3, both finished at Chaumeil. Source: `https://cyclingflash.com/location/chaumeil`. Add entries keyed to seg 13 with stage number, date, departure point, winner(s), route distance, jersey context. Cite each fact.
+7. **Elevation profile data.** `data/elevation/segment-NN.json` smoothness, gradient calculations match.
+
+**Carryforward content cues** — document explicitly in PR body:
+- **Tintignac** (Gallo-Roman sanctuary, Naves commune) → seg 11 regional content NOT a `data/attractions.json` entry. Document this no-add explicitly so future drafters don't re-discover it.
+- **Auzelou stadium / Stade Alexandre-Cueille** at lat 45.27801 / lng 1.78261 = km 70.93 in seg 11. Add to `data/attractions.json` with cross-link to seg 10's L'Agglomérée mention. Cross-segment caveat: stadium is correctly seg 11 even though seg 10 prose mentions the area.
+
+## Checkpoints with publisher (AskUserQuestion)
+
+This strand is research- and judgment-heavy. Use `AskUserQuestion` at each of these moments rather than guessing — the publisher would rather decide than have you assume:
+
+- **After initial per-segment research, before drafting any changes:** present the per-segment finding summary as one AskUserQuestion. Options: (a) accept all proposed changes, (b) flag specific items for further research, (c) override specific items.
+- **For 1987 Chaumeil research:** when winners + route departures + jersey context are gathered, AskUserQuestion: "What detail level for historical-tdf.json — minimal (winners + dates), medium (+ context), or full (+ narrative)?" Seg 13 prose hasn't been drafted yet, so the data shape should match what seg 13 will pull.
+- **If any verification finds material disagreement with current data** (more than minor coordinate corrections — e.g. a town placement off by km, wrong climb category, wrong attraction category): AskUserQuestion before changing. Material changes affect rendering.
+- **Auzelou stadium attraction entry:** before adding, AskUserQuestion on category (sport / landmark / other) and `infoUrl` choice (lagglomeree.agglo-tulle.fr official cyclosportive page vs. Wikipedia vs. none).
+- **Before opening PR:** AskUserQuestion to confirm the audit-trail PR body covers everything verified (no silent skips), the carryforward cues are documented, milestone v1.4.18 assignment is correct.
+
+If the publisher session is unavailable (away, in another session) and a checkpoint blocks: stop, write what you've found to a `WORK-LOG.md` in the worktree root, exit cleanly. Do not guess past a checkpoint.
+
+## Verification commands
+
+- `source ~/.nvm/nvm.sh && nvm use --silent && npm test && npm run build`
+- `npm run preview` after build — confirm the seg 11/12/13 entries (placeholder content, but data renders) display the updated data
+- `processing/.venv/bin/python processing/validate_entries.py`
+- `processing/.venv/bin/python processing/audit_segment_data.py` — existing audit script; cross-check its output against your manual audit
+
+## Cross-strand sharing notes
+
+- **Strand B** (#474, per-source-of-truth assertions) writes to `tests/utils/`, reads `data/*.json`. **No write overlap.** If B lands first with new assertions, this strand's data corrections must satisfy them — read the assertion test names visible in `tests/utils/` before changing data.
+- **Strand C** (#475, JSON Schema validation) writes new `schemas/` directory and validation wiring, reads `data/*.json`. **No write overlap.** If C lands first with strict schemas, this strand's data corrections must validate; if C's schemas reject what should be correct, file a follow-up issue, do not edit C's PR.
+- **Publish session for seg 10 (parallel today)** writes to `data/riders/*.json` and the seg 10 entry. **No overlap with this strand.** Do not pull mid-strand if avoidable.
+- This strand owns `data/segments.json`, `data/attractions.json`, `data/historical-tdf.json` writes for v1.4.18.
+
+## Scope discipline
+
+- One issue, one PR.
+- File new issues for any data-correctness findings outside segs 11-13. Do not fix inline.
+- File new issues for process improvements (e.g. "audit_segment_data.py needs a --segment flag"). Do not fix inline.
+- Do not modify `processing/` validators or audit scripts to make them more useful — that's #475's territory.
+
+## Memories that apply
+
+- `feedback_on_route_checks.md` (use polyline not endpoints)
+- `feedback_pre_publish_scrutiny.md`
+- `feedback_content_change_rule.md` (the verification IS the prevention of retroactive edits)
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_multi_strand_session_checkpoints.md` (this strand's whole structure embodies the checkpoint discipline)
+- `feedback_bash_nvm_sourcing.md`, `feedback_env_check.md`, `feedback_pr_polling.md`, `feedback_issues_describe_problems.md`
+
+## Stop when
+
+- #477 PR is merged into main.
+- Per-claim audit row format from PR #470 reproduced in PR body.
+- Tintignac no-add documented in PR body.
+- Auzelou stadium added to `data/attractions.json` (or alternative landing decided with publisher).
+- 1987 Chaumeil men's + women's stages added to `data/historical-tdf.json` keyed to seg 13.
+- Worktree removed.

--- a/docs/strands/strand-b-assertions.md
+++ b/docs/strands/strand-b-assertions.md
@@ -1,0 +1,93 @@
+# Strand B — Developer experience: per-source-of-truth assertions (v1.4.18)
+
+**Start here:** [Roadmap → Next → v1.4.18](https://github.com/gneeek/tdf26/wiki/Roadmap#next), then [#474](https://github.com/gneeek/tdf26/issues/474).
+
+## Goal
+
+Generalise the #422/#448 worked example: build vitest assertions that fail when hand-maintained lists in code drift from their declaring JSON source. Survey the codebase for parallel-source pairs; write assertions for the ones the publisher confirms.
+
+Goal 4 (developer experience) and goal 5 (process improvement). Commit-tier — foundational for the v1.4.18 data-layer regime.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-assertions main
+cd tdf26-assertions
+ln -s ../tdf26/.claude .claude
+source ~/.nvm/nvm.sh && nvm use --silent
+npm ci
+cp ../tdf26/data/riders/daily-log.json data/riders/
+cp ../tdf26/data/riders/points.json data/riders/
+cp ../tdf26/data/riders/stats.json data/riders/
+[ -d ../tdf26/data/riders/snapshots ] && cp -r ../tdf26/data/riders/snapshots data/riders/
+npx nuxt prepare
+```
+
+When the strand finishes: `git worktree remove tdf26-assertions` from the main checkout.
+
+Branch: `feature/issue-474-source-of-truth-assertions`. Verify `git branch --show-current` immediately before each `git add` / `git commit`.
+
+## Target issue
+
+- **[#474](https://github.com/gneeek/tdf26/issues/474)** — Data drift: hand-maintained lists in code aren't asserted against their declaring source
+
+## Workflow
+
+1. **Read the precedent.** `tests/utils/stage-totals.test.ts` from PR #448 is the worked example. Internalise the shape before scanning.
+2. **Survey.** Scan the codebase for parallel-source pairs — hand-maintained lists, sets, enums, or arrays in `utils/`, `components/`, `pages/`, `composables/`, `server/` that name strings declared in `data/*.json`. Use `grep` / `rg` to find candidates: list-literals near data file imports.
+   Likely candidates to look for explicitly (not exhaustive):
+   - Rider IDs in code vs `data/riders/rider-config.json`
+   - Segment names referenced in code vs `data/segments.json`
+   - Climb categories in code vs `data/competition/points-config.json`
+   - Attraction categories in code vs `data/attractions.json`
+3. **Checkpoint with publisher** on which pairs to land in this PR vs defer (see Checkpoints).
+4. **For each agreed pair:** write a vitest assertion in `tests/utils/` that derives the expected value from the JSON source and asserts the code-side list matches. Test must fail-red without the assertion, green with it.
+5. **Demonstrate red-green** — temporarily mutate the source-of-truth JSON, run the test, confirm fail, revert. Do not commit the mutation.
+6. **Open PR**, milestone v1.4.18.
+
+## Checkpoints with publisher (AskUserQuestion)
+
+- **After survey:** present the list of parallel-source pairs found as one AskUserQuestion (multi-select). Format options as: "(N) `<code-location>` shadows `<json-source>`". The publisher picks which to assert in this PR vs defer to follow-up issues.
+- **For each ambiguous pair** (where the code-side list might be a deliberate subset/derivation rather than a shadowed copy): AskUserQuestion before writing the assertion. Options: (a) assert exact equality, (b) assert subset, (c) deliberate derivation — document and skip, (d) skip — file follow-up issue.
+- **Before opening PR:** AskUserQuestion to confirm test file names and total assertion count.
+
+If the publisher session is unavailable and a checkpoint blocks: stop, write what you've found to a `WORK-LOG.md` in the worktree root, exit cleanly. Do not guess past a checkpoint.
+
+## Verification commands
+
+The following npm scripts exist in `package.json`:
+- `npm ci`, `npm run lint`, `npm test`, `npm run build`, `npm run generate`, `npm run preview`. There is **no** `npm run typecheck`.
+
+For this strand:
+- `source ~/.nvm/nvm.sh && nvm use --silent && npm test`
+- For each new assertion: temporarily mutate the source JSON, run `npm test -- tests/utils/<name>.test.ts`, confirm red, revert.
+
+## Cross-strand sharing notes
+
+- **Strand A** (#477) writes to `data/*.json`. **No write overlap.** Coordinate: if A's data corrections happen before this strand opens PR, the assertion derivations stay fresh against final data. If after, this strand may need a small post-merge tweak (or A may need to update an assertion if a key changes).
+- **Strand C** (#475) writes new schemas + validation wiring. **No overlap with `tests/utils/`.** Different validation surfaces; both can coexist (vitest assertions catch cross-file consistency; schemas catch shape).
+- **Publish session for seg 10 (parallel today)** writes to `data/riders/*.json`. **No overlap with this strand's writes.** If you assert against `rider-config.json` and the publish session updates it, your assertion holds (rider-config is not changed by publish day).
+- This strand owns `tests/utils/` writes for v1.4.18.
+
+## Scope discipline
+
+- One issue, one PR.
+- File follow-up issues for parallel-source pairs not landed in this PR.
+- **Do not** build the general grep-shaped scanner — per the v1.4.8 retro the per-pair assertion approach explicitly beat the global tool.
+- Do not modify `data/*.json` shape — that's strand A's territory and would conflict.
+
+## Memories that apply
+
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_multi_strand_session_checkpoints.md`
+- `feedback_bash_nvm_sourcing.md`, `feedback_env_check.md`, `feedback_pr_polling.md`, `feedback_issues_describe_problems.md`
+
+## Stop when
+
+- #474 PR is merged into main.
+- At least one new assertion landed (matching the assertion shape from PR #448).
+- Each new assertion demonstrated red-green against a temporary source mutation that was reverted.
+- Worktree removed.

--- a/docs/strands/strand-c-schema.md
+++ b/docs/strands/strand-c-schema.md
@@ -1,0 +1,100 @@
+# Strand C — Developer experience: JSON Schema validation for data/*.json (v1.4.18)
+
+**Start here:** [Roadmap → Next → v1.4.18](https://github.com/gneeek/tdf26/wiki/Roadmap#next), then [#475](https://github.com/gneeek/tdf26/issues/475).
+
+## Goal
+
+Author JSON Schema (or equivalent shape contract) for each `data/*.json` file and wire validation into a canonical run path. Catches shape drift — missing required fields, type changes, accidental field renames — that per-source assertions don't see.
+
+Goal 4 (developer experience). Commit-tier — sister to strands A (verification) and B (per-source assertions) in the v1.4.18 data-layer regime.
+
+## Filesystem posture
+
+**Worktree.** Run in a separate worktree.
+
+```
+cd /home/jhs/code
+git worktree add tdf26-schema main
+cd tdf26-schema
+ln -s ../tdf26/.claude .claude
+source ~/.nvm/nvm.sh && nvm use --silent
+npm ci
+cp ../tdf26/data/riders/daily-log.json data/riders/
+cp ../tdf26/data/riders/points.json data/riders/
+cp ../tdf26/data/riders/stats.json data/riders/
+[ -d ../tdf26/data/riders/snapshots ] && cp -r ../tdf26/data/riders/snapshots data/riders/
+npx nuxt prepare
+```
+
+When the strand finishes: `git worktree remove tdf26-schema` from the main checkout.
+
+Branch: `feature/issue-475-json-schema-validation`. Verify `git branch --show-current` immediately before each `git add` / `git commit`.
+
+## Target issue
+
+- **[#475](https://github.com/gneeek/tdf26/issues/475)** — `data/*.json` files have no shape contract enforced at build time
+
+## Workflow
+
+1. **Library survey.** Candidates to evaluate:
+   - **AJV** (JS, JSON Schema-native, fastest, schemas are JSON files)
+   - **zod** (TypeScript-native, schemas are TS code, can generate JSON Schema)
+   - **Python jsonschema** (the data pipeline is already Python; schemas could live in `processing/`)
+   - **JSON Schema CLI** + npm script (lightest dependency footprint)
+   Consider: runtime cost (build-time only is fine), schema authoring ergonomics, where validation should live (Node test, Node build, Python pipeline, pre-commit), and what already exists in the project's dependency tree.
+2. **Checkpoint with publisher** on library + integration point (see Checkpoints).
+3. **Author schemas.** One schema per `data/*.json` file. Files in scope (verify against current `ls data/*.json data/**/*.json`):
+   - `data/segments.json`
+   - `data/attractions.json`
+   - `data/historical-tdf.json`
+   - `data/competition/points-config.json`
+   - `data/riders/rider-config.json`
+   - others as discovered
+   Start permissive (validate current data). Tighten iteratively only if straightforward.
+4. **Wire validation** into the chosen integration point.
+5. **Confirm** all current `data/*.json` files validate clean.
+6. **Demonstrate the schema catches a shape error** — temporarily mutate one file (rename a required field), run validator, confirm fail, revert.
+7. **Open PR**, milestone v1.4.18.
+
+## Checkpoints with publisher (AskUserQuestion)
+
+- **After library survey:** present the shortlist with tradeoffs (JS-side vs Python-side, runtime, ergonomics, dependency weight). AskUserQuestion: "Which library?" with the shortlist as options.
+- **After library choice:** AskUserQuestion on integration point. Options: (a) `npm test` step (vitest assertion per file), (b) `npm run build` step (fails build on invalid data), (c) pre-commit hook, (d) standalone `npm run validate-data` invoked by `publish.sh`.
+- **For schemas with ambiguous fields** (optional vs required, type strictness, enum values where the current data is permissive): AskUserQuestion before committing the schema. For obvious cases just author and proceed.
+- **Before opening PR:** AskUserQuestion to confirm the validation command name (matches project's npm-script naming) and where it gets invoked.
+
+If the publisher session is unavailable and a checkpoint blocks: stop, write what you've found to a `WORK-LOG.md` in the worktree root, exit cleanly. Do not guess past a checkpoint.
+
+## Verification commands
+
+- `source ~/.nvm/nvm.sh && nvm use --silent && npm test && npm run build`
+- The new validation command (whatever it ends up named) must run clean against all current `data/*.json`.
+- Schema-fail demonstration: temporarily mutate a `data/*.json` (e.g. rename a required field), run validator, confirm fail. Revert before staging.
+
+## Cross-strand sharing notes
+
+- **Strand A** (#477) writes to `data/*.json`. **No write overlap with this strand's files.** If this strand's schemas land first with strict constraints, A's data corrections must validate. To minimise friction: this strand's first-pass schemas should be permissive enough that current data validates without surgery. If A's corrections trip a schema, that's a real signal — coordinate.
+- **Strand B** (#474) writes to `tests/utils/`. **No overlap with this strand.** Different validation surfaces; both coexist.
+- **Publish session for seg 10 (parallel today)** writes to `data/riders/*.json`. If this strand's schemas cover rider-side files: they must permit the publish-day write shape (ratings updated, dates updated, possibly new entries). Read `processing/rider_stats.py` to understand the publish-time write shape before authoring those schemas. If unsure, defer rider-side schemas to a follow-up issue.
+- This strand owns the new `schemas/` directory (or equivalent location) and the validation runner.
+
+## Scope discipline
+
+- One issue, one PR.
+- **Do not** refactor `data/*.json` shapes to suit the schema — schema fits the data, not the other way around. File follow-up issues if shape problems surface.
+- **Defer** [#476](https://github.com/gneeek/tdf26/issues/476) (segment-pinning audit-trail metadata) — sister issue, but needs its own design conversation.
+- Do not touch `processing/validate_entries.py` (existing validator) — out of scope; consolidation is #326.
+
+## Memories that apply
+
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_multi_strand_session_checkpoints.md`
+- `feedback_bash_nvm_sourcing.md`, `feedback_env_check.md`, `feedback_pr_polling.md`, `feedback_issues_describe_problems.md`
+
+## Stop when
+
+- #475 PR is merged into main.
+- All current `data/*.json` files validate against their schemas.
+- Validation runs from at least one canonical path (build / test / publish / pre-commit).
+- Schema-fail demonstrated (and reverted) for at least one file.
+- Worktree removed.


### PR DESCRIPTION
## Summary

- Three parallel-strand briefs for v1.4.18 in `docs/strands/`, each in its own worktree per the v1.4.10 / v1.4.11 strand-brief template.
- Strand A (#477) seg 11-13 data verification, time-sensitive against the Sun 2026-05-10 seg 11 publish.
- Strand B (#474) per-source-of-truth vitest assertions generalising the #422/#448 precedent.
- Strand C (#475) JSON Schema validation for `data/*.json`.

Each brief follows the established 9-section template plus an explicit "Checkpoints with publisher" section calling out where the strand should stop and ask via `AskUserQuestion` rather than guess - applies the rule recorded in `feedback_multi_strand_session_checkpoints.md`.

Briefs note the parallel seg 10 publish session as a fourth actor: `data/riders/` files are snapshotted via `cp` (not symlinked) at strand bootstrap so publish-day writes don't drift into strand worktrees mid-run.

## Test plan

- [ ] Briefs read top-to-bottom and the workflow is clear without prior session context
- [ ] Each Filesystem posture block runs cleanly to a working worktree (manual sanity check on one of the three before strand sessions kick off)
- [ ] Cross-strand sharing notes correctly identify all four actors (the three strands + the publish session)
- [ ] Each Checkpoints section's questions match what the publisher actually wants to be asked about

Once approved and merged, the three strand sessions can `git worktree add ... main` and find the briefs at `docs/strands/strand-{a,b,c}-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)