### PR TITLE
Source-of-truth drift assertions: attraction categories + town positions (#474)

### DIFF
--- a/components/NearbyAttractions.vue
+++ b/components/NearbyAttractions.vue
@@ -3,7 +3,7 @@
     <h3 class="text-lg font-semibold text-stone-700 mb-4">Nearby Attractions</h3>
     <div class="space-y-3">
       <div v-for="poi in nearby" :key="poi.name" class="flex items-start gap-3">
-        <span class="text-xl shrink-0 mt-0.5">{{ categoryEmoji[poi.category] || '📍' }}</span>
+        <span class="text-xl shrink-0 mt-0.5">{{ emojiFor(poi.category) }}</span>
         <div>
           <span class="font-medium text-stone-800">{{ poi.name }}</span>
           <p class="text-sm text-stone-500 mt-0.5">{{ poi.description }}</p>
@@ -30,16 +30,11 @@ import { computed } from 'vue'
 
 import attractionsData from '~/data/attractions.json'
 import segmentsJson from '~/data/segments.json'
+import { emojiFor } from '~/utils/attractions'
 
 const props = defineProps({
   segment: { type: Number, required: true },
 })
-
-const categoryEmoji = {
-  food: '🍷', cheese: '🧀', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
-  museum: '🏛️', nature: '🌿', bridge: '🌉', archaeology: '🏺',
-  memorial: '🕯️', industrial: '🏭', craft: '🔨',
-}
 
 // Segment boundary tolerance: attractions within 0.5 km of a segment's km_start
 // or km_end also appear in the adjacent segment. This prevents boundary cases

--- a/components/SegmentMap.vue
+++ b/components/SegmentMap.vue
@@ -30,6 +30,7 @@
 import { ref, watch, nextTick, onUnmounted } from 'vue'
 import 'leaflet/dist/leaflet.css'
 import attractionsData from '~/data/attractions.json'
+import { emojiFor } from '~/utils/attractions'
 import townsDetailData from '~/data/towns-detail.json'
 
 const props = defineProps({
@@ -262,11 +263,6 @@ async function initMap(el) {
 
   // Attractions layer
   const attractionsGroup = L.layerGroup()
-  const categoryEmoji = {
-    food: '🍷', cheese: '🧀', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
-    museum: '🏛️', nature: '🌿', bridge: '🌉', archaeology: '🏺',
-    memorial: '🕯️', industrial: '🏭', craft: '🔨',
-  }
 
   // Filter attractions by proximity to current segment
   for (const poi of attractionsData) {
@@ -281,7 +277,7 @@ async function initMap(el) {
       }
     }
 
-    const emoji = categoryEmoji[poi.category] || '📍'
+    const emoji = emojiFor(poi.category)
     const poiIcon = L.divIcon({
       html: `<div style="font-size:18px;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.3))">${emoji}</div>`,
       className: '',

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -20,6 +20,7 @@ export const townKmPositions: Record<string, number> = {
   'Meyssac': 23.70,              // 277m from village
   'Lanteuil': 38.35,             // 115m from village (seg 6)
   'Beynat': 46.23,               // 75m from village (seg 7)
+  'Sainte-Fortunade': 60.02,     // 124m from village; seg 9 (added 2026-05-06 alongside drift assertion)
   'Tulle': 68.72,                // updated 2026-04-25, 120m from cathedral
   'Naves': 78.19,                // updated 2026-04-25, 373m from village; seg 12
   'Chaumeil': 100.30,            // updated 2026-04-25, 35m from village; seg 15

--- a/pages/admin/images.vue
+++ b/pages/admin/images.vue
@@ -107,7 +107,7 @@
           class="text-sm px-3 py-1.5 rounded-full border border-stone-300 hover:border-correze-red hover:text-correze-red transition-colors cursor-pointer"
           @click="searchAttractionWikipedia(poi.name)"
         >
-          {{ categoryEmoji[poi.category] || '📍' }} {{ poi.name }}
+          {{ emojiFor(poi.category) }} {{ poi.name }}
         </button>
       </div>
     </div>
@@ -170,6 +170,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import attractionsData from '~/data/attractions.json'
+import { emojiFor } from '~/utils/attractions'
 import { sanitizeAttributionText } from '~/utils/sanitize'
 
 definePageMeta({ layout: 'admin' })
@@ -268,13 +269,6 @@ async function saveSelection() {
   } finally {
     saving.value = false
   }
-}
-
-// --- Nearby attractions for search suggestions ---
-const categoryEmoji = {
-  food: '🍷', cheese: '🧀', market: '🛒', castle: '🏰', church: '⛪', abbey: '⛪',
-  museum: '🏛️', nature: '🌿', bridge: '🌉', archaeology: '🏺',
-  memorial: '🕯️', industrial: '🏭', craft: '🔨',
 }
 
 // Nearby-attraction suggestions for the Wikipedia search helper. Uses the same

--- a/tests/utils/attraction-categories.test.ts
+++ b/tests/utils/attraction-categories.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+
+import attractionsData from '~/data/attractions.json'
+import { CATEGORY_EMOJI } from '~/utils/attractions'
+
+// Drift detector. CATEGORY_EMOJI must cover every category declared in
+// attractions.json. The same drift had already happened twice before #474:
+// 'geology' and 'heritage' POIs were added to attractions.json without
+// updating the three component-side categoryEmoji maps, so those POIs fell
+// through to the 📍 fallback. Failing here means a new attraction category
+// has landed without an emoji entry — either add the entry or change the
+// POI's category.
+describe('CATEGORY_EMOJI vs attractions.json categories', () => {
+  const declared = new Set<string>(attractionsData.map(p => p.category))
+
+  it('contains every category declared in attractions.json', () => {
+    for (const category of declared) {
+      expect(CATEGORY_EMOJI[category], `missing emoji for category "${category}"`).toBeDefined()
+    }
+  })
+})

--- a/tests/utils/town-positions.test.ts
+++ b/tests/utils/town-positions.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+
+import segmentsJson from '~/data/segments.json'
+import { townKmPositions } from '~/data/town-positions'
+
+// Drift detector. Every town named in segments.json[].towns must have a
+// corresponding km position in townKmPositions, otherwise StageDetails.vue
+// and ElevationChart.vue fall back to seg.km_start (a coarse approximation)
+// when rendering the town. Off-route landmarks (e.g. Brive-la-Gaillarde,
+// which doesn't appear in segments.json[].towns) are intentionally allowed
+// as extras — this is a coverage assertion, not an equality assertion.
+//
+// This was added when #474 surfaced that 'Sainte-Fortunade' (a seg-9 town
+// added in v1.4.x) had no townKmPositions entry and was therefore being
+// rendered at seg.km_start = 56 instead of its actual route km of 60.02.
+describe('townKmPositions vs segments.json', () => {
+  const segmentTowns = new Set<string>(
+    segmentsJson.flatMap((s: { towns?: string[] }) => s.towns ?? []),
+  )
+
+  it('covers every town named in segments.json[].towns', () => {
+    for (const town of segmentTowns) {
+      expect(
+        townKmPositions[town],
+        `missing townKmPositions entry for "${town}"`,
+      ).toBeTypeOf('number')
+    }
+  })
+})

--- a/utils/attractions.ts
+++ b/utils/attractions.ts
@@ -1,0 +1,30 @@
+// Single source of truth for the category-to-emoji mapping used by the
+// nearby-attractions UI. Three components previously kept their own copies
+// (NearbyAttractions.vue, SegmentMap.vue, pages/admin/images.vue) and drifted:
+// 'geology' and 'heritage' POIs in attractions.json fell through to the 📍
+// fallback because the maps had not been updated when those categories were
+// introduced. tests/utils/attraction-categories.test.ts asserts every category
+// declared in data/attractions.json has an entry here.
+export const CATEGORY_EMOJI: Record<string, string> = {
+  abbey: '⛪',
+  archaeology: '🏺',
+  bridge: '🌉',
+  castle: '🏰',
+  cheese: '🧀',
+  church: '⛪',
+  craft: '🔨',
+  food: '🍷',
+  geology: '🪨',
+  heritage: '⚜️',
+  industrial: '🏭',
+  market: '🛒',
+  memorial: '🕯️',
+  museum: '🏛️',
+  nature: '🌿',
+}
+
+export const FALLBACK_EMOJI = '📍'
+
+export function emojiFor(category: string): string {
+  return CATEGORY_EMOJI[category] ?? FALLBACK_EMOJI
+}


### PR DESCRIPTION
Closes #474.

## Summary

Generalises the #422 / #448 worked example. Two new vitest assertions in `tests/utils/` fail when hand-maintained lists in code drift from the JSON source they shadow:

- `tests/utils/attraction-categories.test.ts` — every `category` declared in `data/attractions.json` must have an entry in `CATEGORY_EMOJI`.
- `tests/utils/town-positions.test.ts` — every town declared in `data/segments.json[].towns[]` must have a key in `data/town-positions.ts`'s `townKmPositions`.

Both assertions follow the precedent shape from `tests/utils/stage-totals.test.ts` (PR #448).

## What this PR also fixes (the drift surfaced by the assertions)

- **Attraction categories**: three component-level `categoryEmoji` literals in `NearbyAttractions.vue`, `SegmentMap.vue`, and `pages/admin/images.vue` had drifted. They each held the same 13-key map; `data/attractions.json` declares 15 distinct categories. POIs with `category: geology` (1 POI: Faille de Meyssac discovery centre) and `category: heritage` (3 POIs: Église Saint-Vincent de Meyssac, Halle aux Grains de Meyssac, Commanderie de Puy de Noix) fell through to the 📍 fallback. The three copies are collapsed into a single `utils/attractions.ts` source covering all 15 categories.
- **Town positions**: `Sainte-Fortunade` (declared in seg 9's `towns[]`) had no entry in `townKmPositions`, so the StageDetails card rendered it at `seg.km_start = 56` instead of the actual route km. Added at km 60.02 (closest approach, audited via `processing/audit_segment_data.py`).

## Red-green demonstration

Each assertion was verified to fail when the source was mutated, then green when reverted:

- `attraction-categories`: mutating an attractions.json POI's category to an unknown value triggered `AssertionError: missing emoji for category "rocketry": expected undefined to be defined`. Reverted, green.
- `town-positions`: appending a fake town to `segments.json[0].towns` triggered `AssertionError: missing townKmPositions entry for "Atlantis-sur-Corrèze"`. Reverted, green.

## Survey results / scope

Survey of parallel-source pairs found four candidates plus a fifth flagged late:

1. ✅ **categoryEmoji × 3 files** vs `attractions.json[].category` — landed.
2. ⏭️ **`StageDetails.vue` `climbData`** vs `points-config.json#climbs[]` — deferred to **#486** (value drift between code, points-config, and GPX is deeper than a parallel-source pair; needs a GPX-derivation pipeline).
3. ⏭️ **`ElevationChart.vue` `climbSummitKm`** vs `points-config.json#climbs[]` — deferred to **#486** (same reason).
4. ✅ **`town-positions.ts`** vs `segments.json[].towns[]` — landed.
5. ⏭️ **`town-coords.json` keys** vs segment towns + climb names — deferred to **#487** (filed for completeness; same assertion shape as the ones in this PR).

Per scope discipline: one issue, one PR; no global drift scanner.

## Test plan

- [ ] `npm test` — 135/135 pass (133 baseline + 2 new)
- [ ] `npm run lint` — clean
- [ ] Verify the merged `utils/attractions.ts` is imported by `NearbyAttractions.vue`, `SegmentMap.vue`, and `pages/admin/images.vue`
- [ ] Visual check on a published entry that POIs with `category: geology` (seg 3) and `category: heritage` (segs 3, 7) now show their correct emoji instead of 📍
- [ ] Visual check that the StageDetails card on seg 9 now renders Sainte-Fortunade at km 60.0 instead of km 56.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)