### PR TITLE
data: seg 11-13 verification (closes #477)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -749,5 +749,29 @@
     ],
     "nearest_km": 7.92,
     "nearest_distance_m": 10990
+  },
+  {
+    "name": "Stade Alexandre-Cueille",
+    "category": "sport",
+    "lat": 45.27801,
+    "lng": 1.78261,
+    "description": "Tulle's main stadium on Boulevard Auzelou, inaugurated 18 August 1929. Home of the Sporting club tulliste rugby team; also has an athletics track. Stage 9 of the 2026 Tour de France passes the stadium at km 70.9 as the route leaves Tulle northbound. Annually the departure point of L'Agglomérée cyclosportive (organised by Tulle Cyclisme Compétition), which in 2026 covered 40 km of the actual Stage 9 route including Suc au May.",
+    "links": [
+      {
+        "url": "https://lagglomeree.agglo-tulle.fr/",
+        "label": "L'Agglomérée cyclosportive"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Stade_Alexandre-Cueille",
+        "label": "Wikipédia"
+      },
+      {
+        "url": "https://tullecyclisme.fr/",
+        "label": "Tulle Cyclisme Compétition"
+      }
+    ],
+    "nearest_km": 70.91,
+    "nearest_distance_m": 65,
+    "source": "https://fr.wikipedia.org/wiki/Stade_Alexandre-Cueille (verified 2026-05-06; lat/lng from OSM cross-check at boulevard Auzelou, Tulle)"
   }
 ]

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -99,13 +99,15 @@
   },
   "Côte des Naves": {
     "type": "climb",
-    "lat": 45.312319,
-    "lng": 1.7666474
+    "lat": 45.30396,
+    "lng": 1.78221,
+    "note": "Summit coordinate updated 2026-05-06 (issue #477) to the polyline position at the points-config summit km 76.59. Old coord was identical to the Naves town centre (45.312319, 1.7666474) — that placed it at km 78.19 / segment 12 / 374m off route, which was wrong. Audit-trail: the elevation profile peak is at km 77.32 (424m); CLAUDE.md gradient 6.7% matches the elevation-derived 6.8%; points-config gradient 5.6% diverges and is flagged for follow-up."
   },
   "Puy de Lachaud": {
     "type": "climb",
-    "lat": 45.336,
-    "lng": 1.784
+    "lat": 45.37676,
+    "lng": 1.80294,
+    "note": "Summit coordinate updated 2026-05-06 (issue #477) to the polyline position at the points-config summit km 87.54. Old coord (45.336, 1.784) sat at km 81.49 / segment 12 / on a descent — diverged from the points-config km by 6 km. Per publisher decision, coord aligned to points-config km. Caveat: Puy de Lachaud is not on the official ASO 2026 Stage 9 categorised-climb list (Côte des Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou); follow-up may revisit whether the climb stays in points-config."
   },
   "Suc au May": {
     "type": "climb",

--- a/utils/attractions.ts
+++ b/utils/attractions.ts
@@ -21,6 +21,7 @@ export const CATEGORY_EMOJI: Record<string, string> = {
   memorial: '🕯️',
   museum: '🏛️',
   nature: '🌿',
+  sport: '🏟️',
 }
 
 export const FALLBACK_EMOJI = '📍'


### PR DESCRIPTION
## Summary

Closes #477. Data verification for segments 11-13 (km 70-92, Naves through Chaumeil) ahead of the seg 11 publish on Sun 2026-05-10. Mirrors the seg 9+10 verification (#434 → PR #470).

## Geo verification (audit-script + manual checks)

| Place | Entry | Computed | Verdict |
|---|---|---|---|
| Côte des Naves (stored coord) | seg 11 | **was km 78.19, seg 12, 374m off** | ❌ stale — coord identical to Naves town centre. Fixed in this PR. |
| Côte des Naves (corrected coord) | seg 11 | km 76.62, seg 11, 0m | ✓ aligned with points-config km 76.59 |
| Naves town | seg 12 | km 78.19, seg 12, 374m | ✓ correctly stored (no change) |
| Puy de Lachaud (stored coord) | seg 13 | **was km 81.49, seg 12, on descent** | ❌ 6 km off points-config km 87.54. Fixed in this PR. |
| Puy de Lachaud (corrected coord) | seg 13 | km 87.57, seg 13, 0m | ✓ aligned with points-config km 87.54 |
| Puy de Lachaud spans seg 12+13 | seg 12, seg 13 | length 3.6 km at km 87.54 | ✓ correctly listed in both segments.json `climbs` arrays per validate_points.py spanning rule (initial speculative removal from seg 12 reverted) |
| Stade Alexandre-Cueille (NEW) | seg 11 | km 70.92, seg 11, 64m | ✓ added |
| Tintignac Gallo-Roman Sanctuary | seg 11 | km 77.66, seg 11, 654m | ✓ kept (publisher override of planning "no-add" — Tintignac is well-documented and 656m off route is well within nearby-attraction range) |
| Cascades de Gimel | seg 11 | km 74.44, seg 11, 4293m | ✓ kept as-is (4.3 km off route — pre-existing) |
| Chateau de Bach | seg 11 | km 77.92, seg 11, 939m | ✓ kept as-is (pre-existing) |

GPX integrity clean for all three segments (seg 11: 8.000 km, seg 12: 6.003 km, seg 13: 7.996 km). Boundaries match `segments.json` to 0.0m at every transition. Master cumulative 184.837 km consistent with stored 185 km.

## Data changes

### `data/town-coords.json`
- **Côte des Naves** lat/lng updated `(45.312319, 1.7666474) → (45.30396, 1.78221)`. Old coord was identical to Naves town centre, placing the climb 1.6 km off its actual on-route position. New coord aligns with points-config summit km 76.59. Verification note added inline.
- **Puy de Lachaud** lat/lng updated `(45.336, 1.784) → (45.37676, 1.80294)`. Old coord at km 81.49 / segment 12 / on a descent (elev 353m) diverged from points-config summit km 87.54 by 6 km. Per publisher decision, coord aligned with points-config km. Verification note added inline.

### `data/attractions.json`
- **Stade Alexandre-Cueille** added with `source` field. Category: `sport` (new category). Three links: L'Agglomérée cyclosportive page, Wikipédia, Tulle Cyclisme Compétition home. Cross-link to seg 10's L'Agglomérée mention closes the carryforward cue from PR #470.

## Items verified but unchanged

- `data/segments.json` for segs 11/12/13: km boundaries, town/climb assignments, elevation values — all verified, no edits.
- Naves town placement in seg 12: correct (audit confirms km 78.19, 374m off). CLAUDE.md's "Naves: km 72–75" is stale relative to current GPX — flagged for follow-up but not fixed here.
- Puy de Lachaud appearing in BOTH seg 12 and seg 13 climbs arrays: correct, not a duplicate. `validate_points.py` enforces that spanning climbs are listed in every segment they cross. The 3.6 km Puy de Lachaud climb (km 83.94–87.54) crosses seg 12 (78–84) and seg 13 (84–92).

## Out of scope (deliberately deferred — not in this strand's owned write-set, file follow-ups)

- **Côte des Naves gradient mismatch**: points-config has 5.6%; CLAUDE.md and ASO sources say 6.7%; elevation profile measurement gives 6.8%. Fix in points-config. Follow-up issue filed.
- **Puy de Lachaud not on official ASO climb list**: ASO 2026 Stage 9 lists only 4 categorised climbs (Côte des Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou). cyclingstage.com narrative includes Puy de Lachaud (3.6 km / 5.3%) but tourismecorreze.com and discoverfrance.com do not. Decision to keep as a non-ASO regional climb deferred. Follow-up issue filed.
- **CLAUDE.md staleness**: "Naves: km 72–75" actual is 78.19; "Chaumeil: km 88–92" actual is 100.27. Update CLAUDE.md known-waypoints km ranges. Follow-up issue filed.
- **`segments.json` elevation_gain/loss vs elevation summary**: 3–6m differences (smoothing-method divergence). Not material if rendering reads one consistent source.
- **1987 Tour de France men's Stage 11 + women's Stage 3 at Chaumeil**: research completed (men's: Sat 11 Jul 1987, Poitiers→Chaumeil 255 km, Martial Gayant winner from breakaway over teammate Charly Mottet who lost yellow; women's: same day, Linards→Chaumeil 72.5 km, Longo overall race winner, stage winner not in PCS database). However, **Chaumeil's actual closest-approach is km 100.27 (seg 15)**, not seg 13 as the strand brief assumed (CLAUDE.md "Chaumeil: km 88–92" is stale). The 1987 entries belong with seg 15 work. Deferred to #478 (segs 14-16, v1.4.19); research notes preserved in WORK-LOG and via #478 comment.

## Verification commands

```bash
processing/audit_segment_data.py --segment 11   # all clean
processing/audit_segment_data.py --segment 12   # all clean
processing/audit_segment_data.py --segment 13   # all clean
processing/validate_points.py                    # OK
processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
npm test                                          # 133/133 pass
npm run build                                     # build complete
```

## Test plan

- [ ] `npm test` green (133/133)
- [ ] `npm run build` clean
- [ ] `processing/audit_segment_data.py` clean for segs 11/12/13
- [ ] `processing/validate_points.py` OK
- [ ] `processing/validate_entries.py` OK
- [ ] dev preview: seg 11 page renders Stade Alexandre-Cueille in nearby-attractions card
- [ ] dev preview: seg 11 map shows Côte des Naves marker at the corrected position (no longer at Naves town centre)
- [ ] dev preview: seg 13 map shows Puy de Lachaud marker at the corrected position (no longer in seg 12 descent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)