### PR TITLE
Add segs 11-13 block research dossier (km 70-92)

### DIFF
--- a/content/research/segs-11-13-block-research.md
+++ b/content/research/segs-11-13-block-research.md
@@ -1,0 +1,234 @@
+# Block research dossier — segs 11-13 (km 70-92)
+
+> Compiled 2026-05-07 by Strand D research subagent. Feeds drafting strands E/F/G (segs 11/12/13).
+
+## Cross-segment threads
+
+**The Tulle-to-Chaumeil exit.** This 22 km block is the route's transition from the Corrèze river valley onto the upland plateau. It begins on Boulevard Auzelou at the Stade Alexandre-Cueille (km 70.91), climbs Côte des Naves (summit ~km 76.6) to leave the valley, runs through Naves and its surrounding farmland, then climbs Puy de Lachaud across segs 12-13 to set up the run toward Chaumeil and the Monédières (which open in seg 14). It is geographically a "leaving" block — readers should feel the city receding.
+
+**Archaeological depth vs. cycling obscurity.** The block contains one of the most important Celtic finds in France (Tintignac and the seven carnyces, 2004) and almost no Tour de France cycling history. `data/historical-tdf.json` has no entries for segs 11-13. The Tulle-to-Chaumeil corridor was used by the Tour du Limousin in 2017 (the 50th edition, Saint-Pantaléon-de-Larche → Chaumeil, 184.7 km, 4,700 m), but that race took the long way around through Saint-Jal and the Vaysse and is not a direct overlap. The cycling story to lean into is therefore (a) L'Agglomérée 2026, which literally shares the seg 11 starting line, and (b) the broader observation that the 2026 Tour is bringing a famous race for the first time to roads that have been raced almost only by amateurs.
+
+**The cyclosportive in the foreground.** L'Agglomérée 2026 ran on Sun 5 April 2026 — exactly five weeks before seg 11 publishes — from Tulle's Stade Auzelou, on a 85 km / 105 km route that overlapped 40 km of Stage 9 including Suc au May. The amateurs went up the road first; the pros come 99 days later. This is a free narrative gift and it sits at km 70.91. The *Suc au May* hook itself stays reserved for seg 15, but L'Agglomérée's *departure* from Auzelou belongs to seg 11.
+
+**The contested gradient.** The Côte des Naves is given as 2.8 km @ 5.6% in points-config, 6.7-6.8% by elevation profile, and "Cat 4, no published gradient" by the official Tour de France 2026 / Tourisme Corrèze announcement. Climbfinder profiles a longer Tulle-side ascent at 4.6 km / 196 m / 4.3% / summit 418 m — likely starting lower in Tulle than our segment does. The dossier surfaces this; resolution is **not** in scope (#490).
+
+**The non-categorised climb.** Puy de Lachaud is in our points-config (3.6 km @ 3.2%, summit ~km 87.5) but is **not** on the four-climb ASO list (Côte des Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou). It is a real climb the riders crest, just not one ASO will hand a polka-dot point for. Drafters can write it as a "shoulder climb" — the back of the Naves bump that the polka-dot board doesn't notice. Treat the non-ASO status as "present but pending resolution" (#492).
+
+**Geology and language together.** "Naves" is from Latin *Navea* via Occitan *Navas*, glossed by both the official commune site and Wikipedia FR as "fertile valley" — not "ships" (Latin *naves*) as a casual reader might assume. The valley in question is the Corrèze and its tributaries (Solane, Vigne, Vimbelle, Céronne — a four-river basin). Riders cross a granitic Limousin basement here (Carboniferous emplacement, ~360-290 Ma), with bocage hedge-fields and oak/chestnut woods replacing the limestone country south of Tulle.
+
+## Segment 11 (km 70-78) — Tulle exit, Côte des Naves
+
+### Geography & geology
+
+- Departure point is Boulevard Auzelou in Tulle's northern fringe, alongside the Corrèze river. Stade Alexandre-Cueille sits between the road and the river. The boulevard tracks the river before the road bends north-northwest and starts climbing.
+- Geology: this is the southern fringe of the Limousin granitic basement of the Massif Central. Granites and micaschists, Carboniferous-age (360-290 Ma). Soils thin, acidic; visible rock in roadcuts is grey-pink granite, not the limestone of segs 1-5 or the red sandstone of seg 4.
+- The Côte des Naves takes the route from the Corrèze valley floor (~210-220 m at Tulle north) up onto the plateau (Naves bourg sits at ~320 m, with surrounding farms 380-450 m).
+- Elevation range across the Naves commune as a whole: 222-505 m (FR Wikipedia). The commune is "traversée par la Corrèze, la Solane, la Vigne, la Vimbelle et la Céronne" — a four-valley, four-ridge landscape.
+- Land use along the climb: bocage fields (hedge-bordered pasture for cattle), patches of oak-chestnut woodland. The Corrèze is fundamentally cattle country; the chestnut tradition (worked by *feuillardiers* until WWII) is a piece of regional Limousin history that's still visible in roadside woodlots.
+
+### Local history & archaeology
+
+- **Tintignac** is the single dominant archaeological story of the block. The site sits on the *plateau de Naves* roughly between Naves bourg and Puy l'Aiguille; route attractions data places it at 45.3056, 1.7667, 656 m off the race line at km 77.66 — i.e. inside seg 11 by km position, even though the village it serves (Naves) is the "town" of seg 12.
+- Gallo-Roman monumental complex: a *fanum* with double cella, a temple known as the "tribunal," a hemicycle temple, and a theatre (renovated 2016). Lead archaeologist of the modern campaigns: **Christophe Maniquet** (INRAP). Site is open seasonally June-September.
+- The **2004 carnyx discovery**: in November 2004 Maniquet's team uncovered a 1st-century-BC ritual pit (~1.2 m square, ~30 cm deep) inside the sanctuary containing roughly 500 iron and bronze fragments — including seven *carnyces* (Iron Age Celtic war trumpets), ten bronze helmets, swords, scabbards, a cauldron, animal-shaped fittings, and a bronze swan or bird. Six carnyces have boar's heads; the seventh is a serpent. All had been deliberately broken before deposition — "ritually killed."
+- **Why this matters**: before Tintignac, world archaeology had fragments of *five* carnyces. Tintignac yielded *seven more*, including one almost complete. The find rewrote the corpus.
+- **What a carnyx is**, plain-English: a vertical bronze trumpet roughly 1.8 m tall, the bell shaped as an animal head (usually a boar), held upright above the player so the head appeared to bellow out over the line of battle. Polybius described carnyces as producing a noise that terrified Roman troops. The Tintignac instruments have been studied acoustically (Pollens / Maniquet et al., HAL paper); reconstructed carnyces have been played in concert by the Scottish-French musician John Kenny since 1993, and the instrument appears in the soundtracks of *Gladiator* and Pixar's *Brave*.
+- **Where the originals are now**: returned to Naves itself in April 2022 — four of the most spectacular pieces are on display in a dedicated building near the village, with replicas of the boar carnyx and the bird-helmet by J. Boisserie. The previous home, the **Musée du Cloître** in Tulle, closed in January 2022; it was succeeded by the **Cité de l'Accordéon et des Patrimoines** (opened April 2024). For the period between 2022 and the eventual permanent museum on the plateau, the carnyces are at Naves under the care of the Maison du Patrimoine (Place de l'Église).
+- **Stade Alexandre-Cueille** itself: inaugurated 18 August 1929; home of Sporting Club Tulliste rugby. Named for Alexandre Cueille (b. 13 September 1900 Tulle; d. 11 May 1940 in a German bombing) — the club's first WWII fatality. Useful note: this is rugby country, not cycling country. The stage starts in front of a rugby ground.
+
+### Cycling context
+
+- **L'Agglomérée 2026** (cyclosportive) departed from this very location — Stade Auzelou — on Sunday 5 April 2026 at 09h15. Two distances on offer (85 km, 105 km), with 40 km of Stage 9 route shared, including Suc au May. (The cyclosportive lives in seg 11 because seg 11 is where it physically starts; the Suc au May framing is reserved for seg 15.) For drafters: the Stage 9 organisers themselves chose 100-day-out timing for the cyclosportive — it is the locally sanctioned dress rehearsal.
+- **Côte des Naves** as a climb: ASO has classified it Cat 4 but published no length/gradient figure. Three independent numbers exist:
+  - tdf26 points-config: 2.8 km @ 5.6%
+  - tdf26 elevation-profile (and the older CLAUDE.md): 6.7-6.8%
+  - climbfinder.com/en/climbs/cote-de-naves-tulle: a *Tulle-side* ascent at 4.6 km / 196 m / 4.3% avg / summit 418 m (likely starts lower in Tulle than seg 11 begins)
+  - This is issue #490 — surface but do not resolve.
+- The actual Stage 9 categorised climbs per the Tourisme Corrèze announcement: Côte de Naves (Cat 4), Suc au May (Cat 4 or 3, 3.8 km, ~8% max), Côte de la Croix du Pey (Cat 4, "technical and winding"), Mont Bessou (Cat 4, ~1000 m altitude). Note: the announcement spells it *Côte de Naves* (singular) not *Côte des Naves* (with s) — both spellings exist; ASO may pick either on the official roadbook.
+- No prior Tour de France stages have used the exact Tulle-northbound corridor that segs 11-13 use; `data/historical-tdf.json` confirms no segs 11-13 entries. **Candidate addition** to that file from this dossier: **Tour du Limousin 2017 (50th edition), stage 3, Saint-Pantaléon-de-Larche → Chaumeil, 184.7 km, 4,700 m** — climbs included Côte de la Vaysse (2.2 km @ 8.6%), Côte de Lestards, three finishing circuits of Côte des Géants around Chaumeil. The Tour du Limousin route did not climb Côte des Naves but did finish in the same town as Stage 9 will *transit* in seg 14. Not a direct corridor match, but the closest pro-cycling shadow this block has.
+
+### Famous local people
+
+- **Laurent Koscielny** — born 10 September 1985 in Tulle, originally from Naves. France international footballer (Arsenal centre-back, ~50 caps). Married Claire in Naves on 20 June 2015. Family of miners. Useful for a contributor-is-customer angle: a kid from Naves who got out the long way, via Guingamp, Tours, Lorient, Arsenal, Bordeaux — and who carries the village in his press answers. Not directly cycling, but exactly the kind of "the village you're rolling through has produced an internationally recognisable figure" beat.
+- **Élie Vidalin** (1876 Naves – 1939 Tulle). Country doctor, *radical-socialiste* deputy for Corrèze 1914-1919. Sat on the public-hygiene and military-pensions commissions. Did not run again in 1919. Buried in Tulle. Useful only as a reminder that the Third Republic put country doctors into parliament.
+- **Jérôme Naves** (b. 1979). Professional rugby player. Yes, his surname is Naves; this appears to be coincidental rather than a place-name link.
+
+### Culture
+
+- **Église Saint-Pierre-ès-Liens, Naves** (visible from the route, sits in seg 12 by km but the framing belongs near the village's introduction). Houses the **Retable de Naves**, a 1704 walnut Baroque altarpiece, 14 m wide × 12 m high, attributed to the Duhamel brothers (Pierre, Jean-François, Léger; Pierre's signature on the Adoration of the Magi panel). Classed Monument Historique since March 1890. Restored 1956 and 1984 (full disassembly and anti-parasite treatment). One of the most extensive 18th-century retables in Limousin — drafters who want a "what's inside the village church" beat have a real one here.
+- **Maison du Patrimoine**, Place de l'Église, Naves: small heritage building, currently the home of the Tintignac display. Tel +33 5 55 26 60 16.
+- Local cuisine framing (general Corrèze, applies across the block): cattle country, beef ahead of dairy; chestnuts; *farcidure* and *millassou* dumplings; the *clafoutis* tradition is more Limousin than specifically Naves.
+- Festivals / events on or near the route: **L'Agglomérée** 5 April 2026 (already happened); the commune's *Agenda* page exists but is sparse. No documented village festival the dossier could pin to mid-May.
+
+### Literary / musical
+
+- **Marcelle Tinayre** (b. Tulle 1870, d. Grosrouvre 1948), the regional novelist whose *L'Ombre de l'amour* (1909) opens at the Cascades de Gimel and follows that valley before moving to Tulle and the surrounding plateaus. Tinayre is the available *Tulle-area* literary voice for this block — she wrote about the Montane gorge "in its wild state" and saw it tamed by Gaston Vuillier. Drafters: do **not** poach the Monédières framing, but Tinayre's Tulle/Gimel/plateau-farmland frame is fair game in seg 11 because the Cascades de Gimel sit 4.3 km north-east of the route at km 74.44, well inside seg 11's reading distance.
+- The **Cascades de Gimel** themselves: three falls on the Montane (Le Grand Saut 45 m, La Rédole 27 m, Queue de Cheval 60 m, into the Gorges de l'Inferno). Site classified 1912 after a ~20-year campaign. Natura 2000 site (FR7401113, designated 22 August 2006). A founding legend: the warrior Dumine, "touched by misfortune and grace," became a hermit and built the oratory that became the parish church of Saint-Étienne de Braguse. Travelogue-grade material; useable as the "things you can see if you turn off the route" beat.
+- The carnyces themselves are a music-history hook in their own right. John Kenny's 1993 reconstruction performance is the moment a 2,000-year-silent instrument re-entered the world. There is recorded sound of a Tintignac-replica carnyx in concert. This is rich material for a writer who wants a "what does this corridor *sound* like over time" beat.
+
+## Segment 12 (km 78-84) — Naves, into Puy de Lachaud
+
+### Geography & geology
+
+- Naves bourg itself: ~320 m elevation, population 2,281 (FR Wikipedia 2023; *towns-detail.json* gives 2318 — close enough; flag in open questions). 35.93 km² commune area.
+- Etymology: *Navea* (Latin) → *Navas* (Occitan) → Naves. Glossed "fertile valley." **Not** *naves* (Latin "ships"). Drafters: do not let the false etymology slip in.
+- Population history: significant 12% growth in the 15 years to ~2017, attributed to the A89 motorway exit (the viaduct is visible from the village belvédère). Slight decline 2017-2023 (-1.68%).
+- Inhabitants: *Navarois* / *Navaroises*.
+- Beyond Naves the road crosses bocage and rises onto the Puy de Lachaud climb. Land use unchanged: cattle pasture, hedge-lines, oak-chestnut woodlots.
+
+### Local history & archaeology
+
+- **Settlement story**, in three beats:
+  1. **Gallo-Roman**: Tintignac was the regional cult and meeting place. Sat at a Roman-road crossroads — Armorica-Provence axis crossed by Lugdunum-Burdigala (FR Wikipedia, commune presentation).
+  2. **6th century**: Tintignac abandoned. The settlement relocates to today's Naves bourg, organising around a castle (now lost; only the church remains).
+  3. **Carolingian-medieval**: Naves becomes the seat of an important *viguerie* (vicariate). The church name Saint-Pierre-ès-Liens dates from this period. By the 13th century Naves is a *prévôté* under Tulle's chapter, with the *prévôt* exercising religious, administrative and judicial authority. The commune was created from the parish in 1790 and absorbed the commune of Chaunac in 1794.
+- **WWII / Resistance**: the Tulle massacre (9 June 1944, 99 hanged + 149 deported, 213 total dead) happened 5 km south. Naves itself does not show up by name in the Tulle-massacre sources retrieved; the commune presentation page is silent on WWII. The FTP maquis Corrèze under Jacques Chapou ("Kléber") operated through this whole sector. Drafters: the massacre and the maquis are reserved as a Tulle-and-its-shadow frame and may already have been used in segs 9-10 — check before deploying. Naves can be referenced as part of the *Corrèze noire* hinterland without claiming a specific Naves event.
+- **Tintignac visit logistics** (as of 2025-2026): on-site display open June-September (no published 2026 hours retrieved). Carnyces are housed in a dedicated display building near the village, opened April 2022. School tours via Archéologie Paysage; group tours via Tulle Office de Tourisme; general visitor entry via the Maison du Patrimoine on Place de l'Église. Permanent on-site museum is *projected* (France Bleu 2017 article on the project) but not yet built. **Open question**: does a Sunday afternoon visitor on 10 May 2026 get in? Worth a phone call before publish day if seg 11 or 12 wants to recommend a visit.
+
+### Cycling context
+
+- **Puy de Lachaud** climb begins late in seg 12. Length 3.6 km @ ~3.2% (points-config), max gradient 11.7%, summit ~km 87.5 (in seg 13). **Not** on the official ASO Stage 9 categorised list (#492). Treat as a real climb the riders complete but for which there will be no televised polka-dot points. For draft framing: the climb the Tour route includes but the Tour route doesn't *count*.
+- Naves has no Tour de France visit on record. No Tour du Limousin stage finish in Naves itself. The most recent Tour du Limousin pass through the agglo, 21 August 2025, ran Saint-Jal → Masseret through 17 of the 43 communes of Tulle Agglo — Naves may have been one of them but the source did not enumerate.
+- The local cycling club is **Tulle Cyclisme Compétition** (organisers of L'Agglomérée), based in Tulle rather than Naves itself.
+
+### Famous local people
+
+- **Laurent Koscielny** is again the dominant figure for Naves, more naturally introduced in seg 12 (the village segment) than in seg 11 (the stadium-and-climb segment). Family-of-miners background; family still in the Corrèze; his 2015 wedding in Naves was a regional press event (France 3 covered it). Useful angle: Koscielny was a defender's defender, low-glamour, persistent — a cycling-domestique parallel a writer could lean on without forcing it.
+- **Élie Vidalin** as covered above; if the seg 11 draft already used him, skip him in 12.
+
+### Culture
+
+- **Église Saint-Pierre-ès-Liens** and the **Retable de Naves** as covered above — the central village set-piece. Drafters who want a single, compact "step inside" beat for seg 12 should use the retable.
+- Heritage features around Naves include "fontaines, puits et fours à pain" — a regional inventory of small water and bread-oven structures. Country-fabric texture, not headline material.
+- **Highway viaduct**: the A89 viaduct is visible from Naves' belvédère and is genuinely part of how the village understands itself in the post-2002 period (it is what brought the population growth). A modern beat available if a writer wants "the village joined the country in 2002 and is reckoning with what that meant."
+
+### Literary / musical
+
+- The Duhamel brothers' retable is a music-and-craft hook: the retable was made in the years immediately after the building of the great organ tradition of southern French churches. Walnut, polychrome, baroque programme. Drafters: there is honest material here for a "what survives of the 1700s" beat.
+- No documented 19th-century novelist *of* Naves, beyond Marcelle Tinayre's regional positioning (she's Tulle, not Naves).
+- The carnyx-as-musical-instrument frame (not weapon-only) belongs at Tintignac, which is why it lands in seg 11; do not double-spend it in seg 12.
+
+## Segment 13 (km 84-92) — Puy de Lachaud, plateau approach
+
+### Geography & geology
+
+- Climbing through the upper part of the Naves commune territory and into the southern apron of the plateau that runs toward Chaumeil. Average gradient 2.2% across the segment masks the Puy de Lachaud climb at the front and a falling roll at the back.
+- Puy de Lachaud (the geographic feature): Massif Central, 1,188 m elevation per peakvisor — but **note**, this is a different Puy de Lachaud than the one our route crests. The route's Puy de Lachaud summit is ~km 87.5 with a much lower elevation. There are multiple "Puy de Lachaud" toponyms in the Massif Central; cross-reference IGN before drafting any specific summit-elevation claim. **Open question.**
+- The terrain is granitic plateau — Limousin basement rocks, Carboniferous-emplaced, oak-chestnut-pine cover, bocage thinning into more open pasture as you climb. The first hints of the *Plateau de Millevaches* aesthetic appear here: open horizon, hedge-lines, scattered farmhouses, big sky.
+- The Monédières range becomes visible to the north / northwest from the higher ground in seg 13. **DO NOT FRAME the Monédières here** — that work is reserved for segs 14-16. A simple "and the higher ground ahead becomes visible" is the most a seg 13 draft should say about the view forward.
+
+### Local history & archaeology
+
+- This segment's villages are mostly hamlets of Naves and (toward the end) the next commune, Chamboulive. No archaeological set-piece comparable to Tintignac.
+- **Château de Bach** (per attractions data, 941 m off route at km 77.92 — actually inside seg 11 by km, but referenced here because it's a Naves-commune monument the dossier should account for somewhere). 18th-century portal, vestiges of a 14th-century Gothic cloister. A minor noble seat. If seg 11 didn't use it, seg 13 has no claim on it; it's properly a seg 11/12 detail.
+- The relative thinness of seg 13's history is itself a beat: this is *between-places* country, the kind of upland farmland that does not carry a museum because it has been continuously, ordinarily lived in. Drafters can lean into the *between-ness* if they want a quieter middle-block.
+
+### Cycling context
+
+- **Puy de Lachaud** as covered: present in points-config, absent from ASO Cat-4 list (#492). The climb is real (3.6 km, 3.2% avg, 11.7% max). Drafters can write the riders cresting it; should not write the riders being awarded a categorised-climb point.
+- This is the segment where the *cycling* logic of the route shifts from "leaving Tulle" to "approaching the day's hard middle" (Suc au May in seg 15). Seg 13 is geographically the *setup* segment for the back half of the stage. Editorial frame: the camera helicopter pulls higher, the bunch is now strung and warm, and the day stops being about Tulle.
+- Tour du Limousin 2017 stage 3 finished at Chaumeil with three closing circuits of the Côte des Géants. None of those closing circuits sit on segs 13-14 (Chaumeil is in seg 14). So even the Tour du Limousin shadow ends here.
+- No Strava / climbfinder profile retrieved for Puy de Lachaud (route side). climbfinder did profile the Tulle-side Côte des Naves (4.6 km / 196 m / 4.3% / summit 418 m), useful for the seg 11 climb framing but not for seg 13.
+
+### Famous local people
+
+- No documented famous figure born or formed specifically in the seg-13 corridor (between Naves and Chamboulive). The natural draw is back to Koscielny (Naves) or forward to Sainte-Fortunade and Léon Dautrement — and Sainte-Fortunade / Dautrement are **reserved** for segs 14-16. Drafters writing seg 13 should accept that the local-person beat is thinner here.
+
+### Culture
+
+- The cuisine and cattle-and-chestnut land-use story applies here essentially identically to segs 11-12.
+- **Open beat for the drafter**: the Limousin *bocage* itself as a landscape category. Hedge-bordered fields, livestock-led economy, slow dissolution of the *feuillardiers*' chestnut craft after WWII, contemporary *agroforestry* revival around chestnut. Non-headline but writable.
+
+### Literary / musical
+
+- No new literary hooks distinct to seg 13. Tinayre is already spent in seg 11; the Bourrée des Monédières and Léon Dautrement's "morceau de Monédières perdu dans le bas Limousin" are reserved for segs 14-15-16.
+- A possible *quiet* literary beat for seg 13: the upland-French tradition of writing about *between-places* — the *territoires intermédiaires* of post-rural geography. Christophe Guilluy, Pierre Bergounioux. Optional and easy to over-egg; do not deploy unless the draft genuinely needs it.
+
+## Sources
+
+### Wikipedia / Wikimedia (FR + EN)
+- **Naves (Corrèze)** — https://fr.wikipedia.org/wiki/Naves_(Corr%C3%A8ze) — etymology (*Navea*), geography (rivers, elevation 222-505 m), population (2,281, 2023), Gallo-Roman → 6th-century → Carolingian → 1790 history, list of *personnalités* including Koscielny, Vidalin, Naves the rugby player.
+- **Tintignac (EN)** — https://en.wikipedia.org/wiki/Tintignac — site coordinates (45°20′00″N 01°45′28″E), 2004 carnyx find details, archaeologist Christophe Maniquet, restoration in Toulouse, exhibition history.
+- **Site archéologique de Tintignac (FR)** — https://fr.wikipedia.org/wiki/Site_arch%C3%A9ologique_de_Tintignac — fanum + temples + theatre detail, monumental ensemble.
+- **Carnyx** — https://en.wikipedia.org/wiki/Carnyx — instrument history, Polybius reference, John Kenny 1993 reconstruction, *Gladiator* and *Brave* uses.
+- **Retable de Naves** — https://fr.wikipedia.org/wiki/Retable_de_Naves — 1704 Duhamel-brothers walnut retable, 14 × 12 m, MH 1890, restorations 1956 and 1984.
+- **Stade Alexandre-Cueille** — https://fr.wikipedia.org/wiki/Stade_Alexandre-Cueille — 1929 inauguration, Boulevard Auzelou, Alexandre Cueille (b. 1900 Tulle, d. 11 May 1940 in bombing), SCT rugby home.
+- **Tulle massacre** — https://en.wikipedia.org/wiki/Tulle_massacre — 9 June 1944, FTP maquis Corrèze under Jacques Chapou ("Kléber"), 99 hanged + 149 deported.
+- **Maquis du Limousin** — https://en.wikipedia.org/wiki/Maquis_du_Limousin — regional Resistance context.
+- **Suc au May (FR)** — https://fr.wikipedia.org/wiki/Suc_au_May — altitude 908 m, Monédières, Natura 2000 (referenced for cross-segment positioning only; do not draft Monédières material here).
+- **Tour du Limousin** — https://en.wikipedia.org/wiki/Tour_du_Limousin and https://fr.wikipedia.org/wiki/Tour_du_Limousin-Nouvelle-Aquitaine — race history from 1968, amateur until 1974.
+- **Géologie du Limousin** — https://fr.wikipedia.org/wiki/G%C3%A9ologie_du_Limousin — Carboniferous granite emplacement 360-290 Ma.
+- **Élie Vidalin** — https://fr.wikipedia.org/wiki/%C3%89lie_Vidalin — 1876 Naves – 1939 Tulle, doctor, deputy 1914-1919.
+- **Laurent Koscielny** — https://en.wikipedia.org/wiki/Laurent_Koscielny — born Tulle 1985, originally from Naves.
+
+### Official tourism / commune sites
+- **Commune de Naves — présentation générale** — https://www.naves19.fr/la-commune/presentation-generale/ — Latin etymology, Gallo-Roman crossroads, Carolingian *viguerie*, 13th-century *prévôté*, four-river basin, A89 viaduct.
+- **Commune de Naves — Tintignac patrimoine page** — https://www.naves19.fr/la-commune/le-patrimoine/site-archeologique-de-tintignac/ — official commune-side framing of the carnyx find, "carnyx, célèbres trompettes gauloises."
+- **Tourisme Corrèze — Tour de France 2026: A 100% Corrèze stage** — https://www.tourismecorreze.com/en/events/tour_de_france_2026_a_100_correze_stage — official ASO-aligned summary of the four Cat-4 climbs (Côte de Naves, Suc au May, Côte de la Croix du Pey, Mont Bessou), 185 km / ~3,300 m.
+- **Tourisme Corrèze — Retable de l'église Saint-Pierre-ès-Liens** — https://www.tourismecorreze.com/en/tourisme_detail/retable_de_l_eglise_saint-pierre_es_liens.html — visitor-side framing of the 1704 retable.
+- **Office de Tourisme Tulle en Corrèze — Naves** — https://www.tulle-en-correze.com/patrimoine-culturel/naves/ — visitor info (page returned 403 for this dossier; cite as the canonical regional listing).
+
+### Cycling resources
+- **L'Agglomérée — official site** — https://lagglomeree.agglo-tulle.fr/ — 4-5 April 2026 dates, departure Tulle Auzelou, 85 / 105 km routes, Stage 9 overlap, 100-days-out framing.
+- **L'Agglomérée — cyclosportive page** — https://lagglomeree.agglo-tulle.fr/epreuves/cyclosportive/ — route detail (404 / 500 in this dossier; cite as canonical route source).
+- **PJAMM Cycling — Tour de France 2026** — https://pjammcycling.com/grandTour/8.Tour-de-France — independent cycling-database stage profiles.
+- **The Inner Ring — Roads to Ride: Suc au May** — https://inrng.com/2020/09/roads-to-ride-the-suc-au-may/ — corridor cycling description, Corrèze "dense road network" quote, road-surface caveat. (Suc au May framing reserved for seg 15; the *corridor texture* lines are usable in this block.)
+- **Climbfinder — Côte de Naves from Tulle** — https://climbfinder.com/en/climbs/cote-de-naves-tulle — independent profile (4.6 km / 196 m / 4.3% / summit 418 m); fetch returned 403, cite as the third-party gradient counter-example for #490.
+- **Tour du Limousin 2017 stage 3 (Saint-Pantaléon-de-Larche → Chaumeil)** — https://www.francebleu.fr/sports/cyclisme/carte-tour-du-limousin-2017-le-trace-de-la-3e-etape-entre-saint-pantaleon-de-larche-et-chaumeil-1500971833 — 184.7 km, 4,700 m, Côte de la Vaysse 2.2 km @ 8.6%, Côte de Lestards, Côte des Géants finishing circuits.
+
+### Archaeology
+- **The Carnyx from Tintignac (EMA project)** — https://www.emaproject.eu/content/instruments/the-carnyx-from-tintignac.html — instrument-history overview.
+- **HAL — Acoustical evaluation of the Carnyx of Tintignac** — https://hal.science/hal-00810581/document — academic acoustics paper.
+- **TRACES UMR 5608 — Aspects technologiques d'un carnyx et d'un casque** — https://traces.univ-tlse2.fr/accueil/equipes-et-ateliers/les-metaux-economie-et-techniques-par-larcheologie-et-le-laboratoire/aspects-technologiques-dun-carnyx-et-dun-casque-du-depot-gaulois-de-tintignac-%E2%80%93-naves-correze — technological / metallographic study of one carnyx and a helmet.
+- **INRAP — Les Arènes de Tintignac, fouille 2004** — https://www.inrap.fr/les-arenes-de-tintignac-fouille-2004-naves-correze-710 — French institutional record of the 2004 excavation.
+- **Tintignac association site (Wix)** — https://tintignac.wixsite.com/tintignac-naves/site — visitor-facing display detail, contact info, J. Boisserie reconstructions.
+- **The History Blog — A complete original Carnyx** — https://www.thehistoryblog.com/archives/22101 — accessible 2009 popular-archaeology summary.
+
+### Press / regional news
+- **France Bleu — Le projet de musée du site gallo-romain de Tintignac (2017)** — https://www.francebleu.fr/infos/culture-loisirs/le-projet-de-musee-du-site-gallo-romain-de-tintignac-en-correze-ete-presente-1490027470 — projected on-site museum.
+- **France Bleu — Les carnyx et les casques gaulois sont de retour en Corrèze** — https://www.francebleu.fr/infos/culture-loisirs/les-carnyx-et-les-casques-gaulois-de-tintignac-sont-de-retour-en-correze-1576852794 — return of the artifacts to Naves.
+- **France 3 Nouvelle-Aquitaine — Naves se prépare à accueillir le mariage de Koscielny** — https://france3-regions.franceinfo.fr/nouvelle-aquitaine/correze/correze-naves-se-prepare-accueillir-le-mariage-du-footballeur-de-l-equipe-de-france-laurent-koscielny-750855.html — 2015 wedding coverage; useful for the Naves-as-place-someone-comes-home-to beat.
+- **Slate — Tulle, le massacre oublié de l'été 1944** — https://www.slate.fr/story/257011/tulle-massacre-oublie-ete-1944-ss-seconde-guerre-mondiale-das-reich-nazisme-maquis — long-form re-examination.
+
+### Cascades de Gimel / Montane
+- **Détours en Limousin — Cascades de Gimel** — https://www.detours-en-limousin.com/Cascades-de-Gimel — three-falls description, Tinayre and *L'Ombre de l'amour* link, Vuillier purchase, 1912 classification.
+- **DOCOB Natura 2000 — Vallée de la Montane vers Gimel-les-Cascades** — https://www.nouvelle-aquitaine.developpement-durable.gouv.fr/IMG/pdf/DOCOB_montane_2009_allege-1.pdf — site management plan.
+- **INPN — FR7401113 fiche** — https://inpn.mnhn.fr/site/natura2000/FR7401113/tab/documentaion — official Natura 2000 record.
+
+### Other (Limousin landscape / language)
+- **France This Way — Périgord-Limousin Regional Natural Park** — https://www.francethisway.com/tourism/perigord-limousin-parc.php — Bocage Limousin and Massif des Feuillardiers framing.
+- **CNPF Nouvelle-Aquitaine — Guide paysager pour la forêt limousine** — https://nouvelle-aquitaine.cnpf.fr/sites/socle/files/cnpf-old/guide_paysager_foret_limousine_1.pdf — landscape-and-forest reference.
+
+## Carryforwards out of scope
+
+### To segs 14-16 (Monédières / Chaumeil / Suc au May)
+- **Monédières range as a *visible feature*** from the upper part of seg 13 — the mountains come into view on the Puy de Lachaud upper plateau, but framing is reserved.
+- **Bol d'Or des Monédières** at Chaumeil (post-Tour criterium, 1954-2000s, Poulidor 5th in 1959 as an amateur) — Chaumeil-anchored, belongs to seg 14.
+- **Suc au May 2020 Tour de France stage 12 (Chauvigny → Sarran)** — first appearance of Suc au May in the Tour. Seg 15 material. (Likely already a candidate addition for `data/historical-tdf.json` for seg 15.)
+- **Léon Dautrement** "morceau de Monédières perdu dans le bas Limousin" — reserved per #478.
+- **Bourrée des Monédières** — reserved per `project_next_planning_notes.md`.
+- **Tour du Limousin 2017 stage 3 (Saint-Pantaléon-de-Larche → Chaumeil)** — Chaumeil-finish race; the *Côte des Géants* circuits attach to seg 14, not this block. Use the 2017 stage as a Chaumeil-history beat in seg 14 if it isn't already booked.
+- **The Inner Ring "Roads to Ride: Suc au May"** climb-specific quotes — reserved for seg 15 in their climb-specific application; only the "dense road network, few water fountains" Corrèze-corridor lines are fair game in this block.
+
+### To `data/historical-tdf.json`
+- **Tour du Limousin 2017, stage 3** (Saint-Pantaléon-de-Larche → Chaumeil, 184.7 km, 4,700 m, climbs Côte de la Vaysse 2.2 km @ 8.6%, Côte de Lestards, Côte des Géants ×3). Closest pro-cycling shadow on the Stage 9 corridor. Anchor segment for the entry: probably **seg 14** (Chaumeil) rather than segs 11-13. Candidate addition.
+- **Tour du Limousin 2025, stage Saint-Jal → Masseret** (21 August 2025), passing through 17 of 43 communes of Tulle Agglo. May overlap segs 11-14; the source did not enumerate. Worth a follow-up before adding to `historical-tdf.json`.
+- **Tour de France 2020 stage 12** (Chauvigny → Sarran, Suc au May first inclusion) — seg 15 anchor. Confirm whether already present in `data/historical-tdf.json`.
+
+### To `data/attractions.json` (review for inclusion or revision)
+- **Maison du Patrimoine, Naves** (Place de l'Église) — current home of the Tintignac display since April 2022. If the route page wants a "where to actually see the carnyces" pointer, this is the address.
+- **Cité de l'Accordéon et des Patrimoines, Tulle** (opened April 2024) — successor to the Musée du Cloître. Tulle-segment material (segs 9-10), not this block; flag if those entries are still to be revised.
+
+### Reserved (do not use anywhere in this block)
+- **Saintsbury / Mascaron / Meymac abbey** — seg 24.
+
+## Open questions for the publisher / drafters
+
+1. **Côte des Naves gradient (#490).** Three numbers in play: 5.6% (points-config), 6.7-6.8% (elevation-profile / older CLAUDE.md), 4.3% over 4.6 km from Tulle (climbfinder). ASO publishes Cat-4 only with no length/gradient. The dossier surfaces; resolution is not in scope.
+2. **Puy de Lachaud non-categorised status (#492).** Climb is in points-config but not on ASO's four-climb list. Drafters need to know whether to write it as a "real but uncategorised" climb (preferred) or skip it. Recommend: write it as crested but uncounted.
+3. **Naves population.** towns-detail.json says **2318**; FR Wikipedia says **2,281** (2023, with -1.68% since 2017). Difference is small but real. Worth a one-line check against INSEE before publish day if any draft cites a number.
+4. **Puy de Lachaud — geographic vs route summit.** peakvisor.com lists a Massif Central peak named *Puy de Lachaud* at 1,188 m — clearly **not** the same feature as the climb summit our route crests at ~km 87.5 (which sits well below 1,000 m, given seg 13 ends at ~530 m and the climb is short). Multiple toponyms. Drafters should verify against IGN before writing any specific summit elevation.
+5. **Tintignac visit logistics for 10 May 2026 (publish day for seg 11).** Site is open June-September; the carnyx display building near the village may or may not be open earlier. If a draft of seg 11 wants to recommend a Sunday-afternoon visit, phone Maison du Patrimoine (+33 5 55 26 60 16) or the Tulle Office de Tourisme (+33 5 55 26 59 61) before publish to confirm. **Otherwise** frame the carnyces as "what's there to see" and skip the visit-recommend.
+6. **Naves and the Tulle massacre.** No source retrieved names Naves specifically in the 9 June 1944 events, even though Naves is 5 km north and the FTP maquis Corrèze operated through this whole sector. Drafters: if you reach for the WWII frame in seg 11 or 12, attach it to *Tulle* or *the Corrèze maquis*, not to Naves itself. If Naves-specific Resistance research surfaces later, it would belong with this block.
+7. **Côte de Naves spelling.** ASO/Tourisme Corrèze writes *Côte de Naves* (no s); tdf26 internal data uses *Côte des Naves* (with s). Both are defensible (s = plural of nave / fertile valleys; no s = "of Naves the village"). Pick one and stick with it across the block — and check whether seg 14+ data needs aligning.
+8. **Ride-day carryforward.** L'Agglomérée 2026 ran 5 April 2026, two days after seg 1 published. By the time seg 11 publishes (10 May 2026), the local press should have results, photos, perhaps interviews. Worth a 5-minute press scan before draft hand-off — the cyclosportive is uniquely well-positioned to give seg 11 a current-events hook.

--- a/content/research/segs-11-13-block-research.md
+++ b/content/research/segs-11-13-block-research.md
@@ -203,7 +203,7 @@
 
 ### To segs 14-16 (Monédières / Chaumeil / Suc au May)
 - **Monédières range as a *visible feature*** from the upper part of seg 13 — the mountains come into view on the Puy de Lachaud upper plateau, but framing is reserved.
-- **Bol d'Or des Monédières** at Chaumeil (post-Tour criterium, 1954-2000s, Poulidor 5th in 1959 as an amateur) — Chaumeil-anchored, belongs to seg 14.
+- **Bol d'Or des Monédières** at Chaumeil (post-Tour criterium founded 1952 by accordionist Jean Ségurel; ran 1952–1967, revived 1981–2002. Poulidor 3rd in 1959 — behind Gérard Saint and Ercole Baldini — as an amateur). Chaumeil-anchored, belongs to seg 15 per `data/segments.json` (the seg 14/15 line is at km 99.4; Chaumeil sits at km 100.30).
 - **Suc au May 2020 Tour de France stage 12 (Chauvigny → Sarran)** — first appearance of Suc au May in the Tour. Seg 15 material. (Likely already a candidate addition for `data/historical-tdf.json` for seg 15.)
 - **Léon Dautrement** "morceau de Monédières perdu dans le bas Limousin" — reserved per #478.
 - **Bourrée des Monédières** — reserved per `project_next_planning_notes.md`.

--- a/docs/strands/strand-d-content-research.md
+++ b/docs/strands/strand-d-content-research.md
@@ -1,0 +1,93 @@
+# Strand D — Content research: km 70-92 block (segs 11/12/13)
+
+**Start here:** Roadmap → Now → Content. This brief decided at planning session 2026-05-07 in advance of seg 11 publication on Sun 2026-05-10.
+
+## Goal
+
+Produce a single research dossier across the 22km block from km 70 (post-Tulle, just past the Auzelou stadium) to km 92 (transition toward Chaumeil approach). The dossier is consumed by three downstream draft strands (E/F/G — one per segment, publisher-paced). Research lands first; drafting strands consume it.
+
+This is the second instance of the block-research-then-N-drafts technique (first instance: seg 8/9/10 under v1.4.10 strand-a-content). The technique is currently a light-tier watch-item under date-gated experiment evaluation; today's session counts as the next data point — work cleanly so the evaluation has signal.
+
+## Filesystem posture
+
+- **Worktree path (parent dir):** `git -C /home/jhs/code/tdf26 worktree add -b feature/v1.4.18-content-research /home/jhs/code/tdf26-research main`. Run from `/home/jhs/code` or use the absolute path form. Do NOT use `git worktree add tdf26-research main` from inside the repo (nests inside repo and trips "branch already checked out elsewhere").
+- **No `.claude` symlink** — `.claude/` is tracked; the worktree already has it from checkout.
+- **Branch verification:** before each `git add`/`git commit`, run `git branch --show-current` and confirm it matches the feature branch (`feedback_shared_tree_branch_verification.md`).
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-research` once the dossier has merged or been pulled into the parent.
+
+## The 22km block
+
+| Segment | Km range | Towns (data/segments.json) | Climbs | Known content cues |
+|---------|----------|----------------------------|--------|---------------------|
+| 11 | 70-78 | (none in segments.json; Tulle outskirts behind, en route to Naves) | Côte des Naves | Stade Alexandre-Cueille / Auzelou stadium at km 70.91 (cyclosportive-departure, amateur-cycling angle, "99-100 days before stage" framing); Tintignac Gallo-Roman sanctuary nearby (Celtic carnyx find, well-documented; in `data/attractions.json` at km 77.66, 656m off route) |
+| 12 | 78-84 | Naves | Puy de Lachaud (starts) | Naves itself; Côte des Naves gradient open question (#490) — points-config 5.6% disagrees with CLAUDE.md / ASO / elevation-derived 6.7-6.8% (the drafter should know this is contested but should not resolve it; the resolution is a separate strand) |
+| 13 | 84-92 | (none in segments.json; transitional toward Chaumeil approach) | Puy de Lachaud (continues; spans seg 12 + 13 per `validate_points.py` invariant) | Puy de Lachaud is **not** on the official ASO climb list (#492) — open question whether to keep as non-ASO regional climb; the drafter should treat it as present-but-non-Categorised pending the resolution |
+
+The route enters the Monédières range starting around segs 14-16 — **do not** spend Monédières framing in segs 11-13. The Sainte-Fortunade / Léon Dautrement "morceau de Monédières perdu dans le bas Limousin" line is reserved for segs 14/15/16 drafting (per #478 and the planning ledger).
+
+## Workflow
+
+1. **Spawn a single research subagent** (general-purpose Agent) with a self-contained prompt covering all three segments. Target ~5-10 minutes of research, similar shape to the v1.4.10 seg 8/9/10 research call.
+2. The research subagent should cover, per segment and across the block:
+   - **Geography and geology** — Corrèze plateau leaving the river valley, Naves basin, approach to the Monédières foothills.
+   - **Local history** — Naves Roman heritage (the commune name traces to a Roman context); Tintignac as the major archaeological landmark; medieval/early-modern parish notes; Resistance / WWII traces if any.
+   - **Cycling context** — Côte des Naves and Puy de Lachaud profiles; any historic Tour de France passages through this corridor (`data/historical-tdf.json` already contains some — research should check for gaps); the L'Agglomérée cyclosportive's relationship to the corridor (its 40km route uses Stage 9 roads including Suc au May further on).
+   - **Famous local people** — search broadly for Naves and the surrounding communes.
+   - **Culture** — local cuisine, festivals, anything that grounds the route between Tulle (seg 10, just shipped) and Chaumeil (seg 14+, ahead).
+   - **Possible literary or musical references** — per the music-thread ledger in `project_next_planning_notes.md`, the Bourrée des Monédières is reserved for segs 14/15. Don't poach it. But check whether smaller local musical traditions exist between Tulle and the Monédières.
+3. **Write the dossier** to `content/research/segs-11-13-block-research.md` (create directory if absent — gitignored at `content/research/` if needed; check `.gitignore` first and update if necessary). Structure:
+   - Per-segment section (seg 11 / 12 / 13) with the research findings cleanly grouped by topic.
+   - A "cross-segment threads" section listing arcs that span the block (e.g., the cyclosportive narrative starting at Auzelou and reflecting on the actual stage 99 days out).
+   - A "sources" section listing every URL the dossier draws on (the dossier is the source-of-record for the eventual `## Sources` blocks in each entry — see `feedback_sources_section.md`).
+   - A "carryforwards out of scope" section listing anything found that belongs in segs 14+, segs 17+, or in `data/historical-tdf.json` for the Tour-history feature.
+4. **Read sources directly, not through CLAUDE.md transcription.** When the dossier cites a km position, town location, or climb gradient, read `data/segments.json`, `data/town-coords.json`, `data/points-config.json`, and the segment polylines — not CLAUDE.md (per `feedback_source_of_truth_framing.md` and the v1.4.18 Strand A finding).
+5. **Open a PR** when the dossier is ready. PR body: short summary of what's in the dossier + which segs each section serves. Link to the issue if one is filed (file one if the publisher hasn't already — title `Block research dossier for segs 11-13 (km 70-92)`).
+
+## Target issues
+
+File a single tracking issue at start: `Block research dossier for segs 11-13 (km 70-92)`, milestone v1.4.18. PR closes it.
+
+## Verification commands
+
+These exist in this repo and should run clean before PR:
+
+- `npm test` — must pass.
+- `node scripts/validate_entries.py` — must pass (no new entry frontmatter touched, but defensive).
+- `python3 processing/validate_points.py` — must pass (no points-config touched, but defensive against any drift).
+
+If the dossier needs a new directory under `content/research/`, confirm `.gitignore` posture: if `content/research/` is gitignored, the dossier still ships in the PR by adding an exception or by moving to `docs/research/`. Decide at PR time.
+
+## Cross-strand sharing notes
+
+- **What this strand owns (write):** `content/research/segs-11-13-block-research.md` (or `docs/research/...` if .gitignore forces it).
+- **What this strand reads:** `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/points-config.json`, `data/historical-tdf.json`, `data/segments/segment-11.gpx` / `segment-12.gpx` / `segment-13.gpx`.
+- **What this strand must NOT touch:** `content/entries/*.md` (drafting strands E/F/G own these). `data/*.json` (any data corrections discovered are filed as new issues, not fixed inline).
+- **Cross-strand collisions:** none expected. The downstream draft strands (E/F/G) have not been spawned yet; they spawn after this dossier lands.
+
+## Scope discipline
+
+- **Do not draft prose for any segment in this strand.** Output is a research dossier, not narrative.
+- **Do not fix data inline.** If research surfaces a contradiction between an attraction location and the route, file a new issue. Examples already known: #490 (Côte des Naves gradient), #492 (Puy de Lachaud non-ASO).
+- **Do not poach segs 14+ content.** Sainte-Fortunade / Monédières framing, Bourrée des Monédières, 1987 Chaumeil double-finish, Mont Bessou — all reserved.
+- **Do not transcribe CLAUDE.md.** Read `data/*` directly. CLAUDE.md known-waypoints km ranges are stale (per #491).
+
+## Memories that apply
+
+- `feedback_source_of_truth_framing.md` — read polylines + JSON, not CLAUDE.md
+- `feedback_on_route_checks.md` — use segment GPX polyline, not segments.json endpoints, when testing if a coord is on the race route
+- `feedback_sources_section.md` — the dossier's sources section is the seed for each entry's `## Sources`
+- `feedback_literary_footnotes.md` — if literary references surface, capture bibliographic context (forward-only from seg 6)
+- `feedback_content_change_rule.md` — published entries are fixed; the dossier should not propose retroactive edits to segs 1-10
+- `feedback_pre_publish_scrutiny.md` — verify geography, attribution, image rights before publish; the dossier flags anything dubious so seg 11 drafting catches it
+- `project_disclosure_practice.md` — drafts (downstream) carry pair-writing footers
+- `project_barthes_callback.md` — seg 12 is the "tightens" beat (argument becoming visible) of the seg 6/12/15 arc; the dossier should surface anything in seg 12's research that feeds this beat without spending it
+- `project_meymac_voice.md` — seg 24 reserved for Saintsbury voice; do not poach Mascaron, abbey, etc.
+
+## Stop when
+
+- Dossier file exists at the target path.
+- Sources section is complete (every factual claim in the dossier traces to a URL or named source).
+- Carryforwards-out-of-scope section names anything the research found that belongs to segs 14+ or 17+ or to `data/historical-tdf.json`.
+- PR open and tagged on milestone v1.4.18.
+- Worktree removed (run cleanup yourself, do not hand off).
+- Final report posted to publisher: dossier path, PR link, any open questions surfaced for downstream draft strands.


### PR DESCRIPTION
## Summary

Strand D of v1.4.18. Research dossier for the 22 km block from km 70 (post-Tulle, just past Stade Auzelou) to km 92 (transition toward Chaumeil approach). Feeds three downstream draft strands (E/F/G — one per segment).

Closes #497.

## What's in the dossier

- **Cross-segment threads** — six arcs that span the block, including the Tintignac/carnyx archaeological depth vs cycling obscurity contrast, the L'Agglomérée 2026 cyclosportive sharing seg 11's start line, the contested Côte des Naves gradient (#490), and the non-categorised Puy de Lachaud (#492).
- **Per-segment sections** (seg 11 / 12 / 13) — six subsections each: geography & geology, local history & archaeology, cycling context, famous local people, culture, literary & musical.
- **Sources** — grouped by Wikipedia / official tourism / cycling resources / archaeology / press / Cascades de Gimel / Limousin landscape. Seeds each entry's eventual `## Sources` block.
- **Carryforwards out of scope** — what belongs to segs 14+ (Monédières / Chaumeil / Suc au May), to `data/historical-tdf.json` (Tour du Limousin 2017 stage 3 most prominently), and to `data/attractions.json`.
- **Open questions** — eight items the publisher / drafters need visibility on before committing prose.

## What this PR does NOT do

- Does not draft any segment prose (E/F/G strands' job).
- Does not resolve #490 or #492 — the dossier surfaces both contests but the resolution lives in separate strands.
- Does not modify `data/*.json` — any data corrections discovered are deferred to issues.

## Which sections serve which segment

- **Seg 11** (Tulle exit, Côte des Naves): Stade Auzelou + L'Agglomérée + Tintignac archaeology + Cascades de Gimel + Marcelle Tinayre.
- **Seg 12** (Naves, into Puy de Lachaud): village settlement story + Retable de Naves + Laurent Koscielny + A89 viaduct framing.
- **Seg 13** (Puy de Lachaud, plateau approach): granitic plateau geology + the *between-places* texture beat + carryforward gating to keep Monédières framing reserved.

## Test plan

- [x] `npm test` — 177 tests passing across 26 files.
- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — all entries valid.
- [x] `python3 processing/validate_points.py` — points-config / segments / GPX agree.
- [ ] Publisher reviews dossier and confirms it's adequate for downstream draft strands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)