### PR TITLE
Deprecate CLAUDE.md known-waypoints tables in favour of data/*.json (#491)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,30 +407,23 @@ Each entry (~800–1200 words) should weave together:
 
 ## Known Waypoints and Climbs (for segment assignment)
 
-### Major Towns (approximate km)
-- Malemort: km 0
-- Brive-la-Gaillarde: km 3–6
-- Turenne: km 16–18
-- Collonges-la-Rouge: km 22–25
-- Beynat: km 35–40
-- Tulle: km 63–68
-- Naves: km 72–75
-- Chaumeil: km 88–92
-- Treignac: km 115–118
-- Bugeat: km 128–132
-- Meymac: km 155–160
-- Ussel: km 180–185
+Town and climb facts previously listed here have moved to the `data/*.json` files. CLAUDE.md keeps narrative project context; the JSON files are the source of truth for route geometry, town positions, and climb metadata. The pointers below tell you which file to read for which question.
+
+### Major Towns
+- **Per-segment town assignments:** `data/segments.json` — each segment object has a `towns` array naming the towns the route passes through.
+- **Town coordinates and notes:** `data/town-coords.json` — keyed by town name. Includes a `note` field for towns whose city centre sits off the route polyline (e.g., Ussel).
+
+When you need to answer "what town is in segment N?", read `segments.json`. When you need a coordinate for a town, read `town-coords.json`.
 
 ### Categorized Climbs
-- Puy Boubou: 2.8km at 4.1%
-- Côte de Lagleygeolle: 5.2km at 3.9%
-- Côte de Miel: 6.6km at 3.9%
-- Côte des Naves: 2.8km at 6.7%
-- Puy de Lachaud: 3.6km at 5.3%
-- Suc au May: 3.8km at 7.7% (summit ~km 105, elevation 903m)
-- Côte de la Croix de Pey: 7km at 4.9%
-- Mont Bessou: summit 977m (highest point in Corrèze)
-- Côte des Gardes: 2.2km at 4.8%
+- **Climb metadata (segment, summit km, length, gradient, ASO category, points):** `data/competition/points-config.json` — `climbs` array. Single source of truth: `processing/split_gpx.py` imports from here, and `data/segments.json` climb assignments are generated accordingly.
+- **Climb summit coordinates:** `data/town-coords.json` — climbs share the file with towns; `"type": "climb"` distinguishes them.
+
+Two narrative notes that don't fit a JSON shape:
+- **Mont Bessou** is the highest point in Corrèze (summit 977m).
+- **Suc au May** summits around km 105 at approximately 903m elevation.
+
+ASO categorisation (HC, Cat 2, etc.) is on each climb in points-config. Whether the points-config climb list matches the official ASO 2026 Stage 9 categorised-climb list is tracked under issue #492.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary

- Removes the "Major Towns (approximate km)" and "Categorized Climbs" tables from `CLAUDE.md` under "Known Waypoints and Climbs". Replaces both with pointer paragraphs naming the JSON files to consult.
- Retains two narrative claims that don't fit a JSON shape (Mont Bessou highest in Corrèze; Suc au May summit elevation 903m) per publisher checkpoint.
- Files follow-up issues for the two missing-data findings surfaced during audit (#505, #506). Other drift is flagged below for awareness only, per the brief's "JSON wins" policy.

Closes #491. Companion to climb-data strand (#490, #492); no file overlap.

## Audit Table

### Towns (CLAUDE.md vs `data/segments.json` + `data/town-coords.json`)

All 12 CLAUDE.md town rows have a coordinate home in `town-coords.json`. KM positions in CLAUDE.md drift from segments.json across the board because the table assumed 26 × 7.1km buckets; `segments.json` is now 27 segments with variable widths. Per deprecation decision, JSON wins; CLAUDE.md table dropped.

| Town | CLAUDE.md km | segments.json segment | town-coords | Note |
|---|---|---|---|---|
| Malemort | 0 | seg 1 (0–8) | ✓ | match |
| Brive-la-Gaillarde | 3–6 | not in any segment's towns array | ✓ | filed #506 |
| Turenne | 16–18 | seg 2 (8–14) | ✓ | drift |
| Collonges-la-Rouge | 22–25 | seg 3 (14–22) | ✓ | drift |
| Beynat | 35–40 | seg 7 (42–50) | ✓ | drift |
| Tulle | 63–68 | seg 10 (64–70) | ✓ | close |
| Naves | 72–75 | seg 12 (78–84) | ✓ | drift |
| Chaumeil | 88–92 | seg 15 (98–106) | ✓ | drift |
| Treignac | 115–118 | seg 18 (120–126) | ✓ | drift |
| Bugeat | 128–132 | seg 21 (140–148) | ✓ | drift |
| Meymac | 155–160 | seg 25 (168–176) | ✓ | drift |
| Ussel | 180–185 | seg 27 (182–184.8) | ✓ | close |

### Climbs (CLAUDE.md vs `data/competition/points-config.json`)

All 9 CLAUDE.md climb rows have a metadata home in points-config. Gradients drift on 8 of 9. Per deprecation decision, JSON wins; CLAUDE.md table dropped. Two open issues already cover the most material drifts; the remaining 6 gradient drifts are flagged here for awareness only (not filed as new issues).

| Climb | CLAUDE.md | points-config | Note |
|---|---|---|---|
| Puy Boubou | 2.8km @ 4.1% | 2.8km @ 3.6% | drift (awareness) |
| Côte de Lagleygeolle | 5.2km @ 3.9% | 5.2km @ 3.2% | drift (awareness) |
| Côte de Miel | 6.6km @ 3.9% | 2.4km @ 1.8% | major drift, length too (awareness) |
| Côte des Naves | 2.8km @ 6.7% | 2.8km @ 5.6% | tracked by #490 |
| Puy de Lachaud | 3.6km @ 5.3% | 3.6km @ 3.2% | tracked by #492 |
| Suc au May | 3.8km @ 7.7%, summit ~km 105, elev 903m | 3.8km @ 7.1%, km 105.15 | gradient drift (awareness); elev retained inline |
| Côte de la Croix de Pey | 7km @ 4.9% | 7km @ 4.4% | drift (awareness) |
| Mont Bessou | summit 977m (highest in Corrèze) | 5km @ 2.7% | different framing; superlative retained inline |
| Côte des Gardes | 2.2km @ 4.8% | 2.2km @ 4.3% | drift (awareness) |

Bonus: `Côte de Malemort` exists in points-config but was never in the CLAUDE.md table. The new pointer paragraph covers it via the points-config reference.

## Follow-up Issues Filed

- **#505** — Total-distance and segment-count drift between CLAUDE.md narrative ("185km", "26 segments") and `data/segments.json` (27 segments, 184.8 km). Surfaced outside the deprecated tables; out of scope to fix here.
- **#506** — Brive-la-Gaillarde missing from `data/segments.json` towns array (present in town-coords + sprint config only). With CLAUDE.md table removed, segments.json becomes the single source for "what towns are in segment N?" and currently omits Brive.

The `Ussel-as-town in seg 26` concern from the brief is already resolved: `segments.json` now has 27 segments and Ussel is tagged in seg 27.

## Cross-reference Sweep

`grep -rn "Known Waypoints\|Major Towns\|Categorized Climbs"` returned only the CLAUDE.md occurrences themselves. No wiki, doc, brief, code, or memory pointers needed updating.

## Verification

- `python3 processing/validate_points.py` — pass
- `python3 processing/validate_entries.py` — pass
- `npm test` — 26 files, 177 tests pass
- `npm run build` — pass (after seeding rider data per `feedback_ci_seed_ordering.md`)
- `grep -n "km " CLAUDE.md` — only narrative "185km / 26 segments" (covered by #505), the retained Suc au May elevation line, and References cycling history. No table-shape km rows remain.

## Test plan

- [ ] Reviewer confirms the deprecated section now reads as a coherent narrative pointing at the right files.
- [ ] Reviewer confirms the two retained narrative claims (Mont Bessou, Suc au May) are appropriately scoped (publisher decided to retain inline rather than add JSON elevation fields).
- [ ] Reviewer confirms #505 and #506 are problem-shaped per `feedback_issues_describe_problems.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)