### PR TITLE
data: seg 14-16 verification (closes #478)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -602,6 +602,66 @@
     "nearest_distance_m": 249
   },
   {
+    "name": "Église Saint-Augustin de Saint-Augustin",
+    "category": "church",
+    "lat": 45.42442,
+    "lng": 1.83625,
+    "description": "13th-century parish church at the centre of the Saint-Augustin bourg, the village the Stage 9 route runs through at km 94.5. Inscribed Monument Historique on 28 December 1929. Houses a 17th-century retable carved by Pierre Duhamel of Tulle. The Tourondel hamlet (1.3 km off-route, also in seg 14) is associated with an old wooden chapel that locally is said to have inspired the church's nave vault.",
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/%C3%89glise_Saint-Augustin_de_Saint-Augustin",
+        "label": "Wikipédia"
+      },
+      {
+        "url": "https://www.pop.culture.gouv.fr/notice/merimee/PA00099811",
+        "label": "Mérimée (Monument Historique)"
+      }
+    ],
+    "nearest_km": 94.52,
+    "nearest_distance_m": 9,
+    "source": "https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) and Mérimée database PA00099811 (verified 2026-05-07). Coord = bourg centre per OSM place=village; the church sits in the bourg square."
+  },
+  {
+    "name": "Suc au May Table d'orientation",
+    "category": "nature",
+    "lat": 45.4714,
+    "lng": 1.8425,
+    "description": "Panoramic table d'orientation at the 908m summit of the Suc au May, the highest point of the Monédières range. The oldest table d'orientation in the Limousin, inaugurated 25 August 1935 by Henry de Jouvenel — the same Henry de Jouvenel who lived at the Maison de la Sirène in Collonges-la-Rouge (seg 4). On clear days the panorama reaches the Monts d'Auvergne to the east, the Plateau de Millevaches to the north, and the Bas-Limousin valleys to the south. A 15-minute footpath climbs to the summit from a small parking area on the D26 just below the road's high point. Modern paragliding launch site. The road itself peaks ~440m short of the actual summit at km 105.15 (elev 889m on the road, 908m at the summit).",
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Suc_au_May",
+        "label": "Wikipédia"
+      },
+      {
+        "url": "https://www.tourisme-egletons.com/Annuaire/le-suc-au-may.html",
+        "label": "Tourisme Egletons"
+      }
+    ],
+    "nearest_km": 105.48,
+    "nearest_distance_m": 442,
+    "source": "https://fr.wikipedia.org/wiki/Suc_au_May (verified 2026-05-07; Henry de Jouvenel inauguration date cross-checked via Tourisme Egletons). Callback to seg 4 Maison de la Sirène (Henry de Jouvenel + Colette)."
+  },
+  {
+    "name": "Musée du Président Jacques Chirac",
+    "category": "museum",
+    "lat": 45.44262,
+    "lng": 1.91898,
+    "description": "Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). Sarran was the Chirac family home; Chirac is buried in the Sarran communal cemetery. The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.",
+    "links": [
+      {
+        "url": "https://www.museepresidentjcchirac.fr/",
+        "label": "Museum site"
+      },
+      {
+        "url": "https://fr.wikipedia.org/wiki/Mus%C3%A9e_du_pr%C3%A9sident_Jacques-Chirac",
+        "label": "Wikipédia"
+      }
+    ],
+    "nearest_km": 99.7,
+    "nearest_distance_m": 3172,
+    "source": "https://www.museepresidentjcchirac.fr/ and Wikipédia (verified 2026-05-07). 3.17 km off route is within the precedent set by Cascades de Gimel (4.3 km, kept in PR #470)."
+  },
+  {
     "name": "Stele des Maquisards",
     "category": "memorial",
     "lat": 45.6,

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -44,13 +44,48 @@
     ]
   },
   {
-    "segments": [14, 15, 16],
+    "segments": [15],
+    "events": [
+      {
+        "year": 1987,
+        "stage": "Stage 11 (men's)",
+        "route": "Poitiers to Chaumeil",
+        "description": "255 km finish at Chaumeil on Saturday 11 July 1987. Martial Gayant (Système U) won solo from a breakaway 13 km out, ahead of Laudelino Cubino and Kim Andersen. Charly Mottet, Gayant's Système U teammate, lost the yellow jersey on the same stage. The same day saw the women's Tour de France Féminin Stage 3 also finish in Chaumeil — the only year both editions of the Tour finished a stage in the village on the same day."
+      },
+      {
+        "year": 1987,
+        "stage": "Stage 3 (women's, Tour de France Féminin)",
+        "route": "Linards to Chaumeil",
+        "description": "72.5 km finish at Chaumeil on Saturday 11 July 1987, the same day as the men's stage. Roberta Bonanomi (Italy) won the stage ahead of Maria Canins and Jeannie Longo, taking the yellow jersey. Longo went on to win the overall race (8–26 July 1987). The Tour de France Féminin ran in parallel with the men's race from 1984 to 1989."
+      },
+      {
+        "year": 2017,
+        "stage": "Tour du Limousin Stage 3 (50th edition)",
+        "route": "Saint-Pantaléon-de-Larche to Chaumeil",
+        "description": "184.7 km Chaumeil finish on Thursday 17 August 2017, the queen stage of the 50th-anniversary Tour du Limousin. Won by Cyril Gautier (AG2R-La Mondiale). The stage climbed Côte de la Vaysse and Côte de Lestards before three finishing circuits over the Côte des Géants in Chaumeil — the closest pro-cycling shadow on the Stage 9 corridor before the 2026 Tour."
+      },
+      {
+        "year": 2020,
+        "stage": "Stage 12",
+        "route": "Chauvigny to Sarran",
+        "description": "First Tour de France appearance of the Suc au May. 218 km — the longest stage of the 2020 Tour — on Thursday 10 September 2020. Marc Hirschi (Sunweb) won solo, his winning move launched on the Suc au May descent. The stage was dedicated to Raymond Poulidor through Saint-Léonard-de-Noblat. The finish at Sarran (4 km off the Stage 9 route at km 99.7) was a tribute to the Chirac family home."
+      },
+      {
+        "year": null,
+        "stage": "Bol d'Or des Monédières (criterium series)",
+        "route": "Chaumeil",
+        "description": "Post-Tour criterium founded in 1952 by Chaumeil-born accordionist Jean Ségurel and run on a circuit around Chaumeil. Held annually 1952–1967, then revived 1981–2002. Winners read like a roll-call of the post-war peloton: Coppi (1953), Anquetil (1955, 1962), Géminiani (1956–58), Poulidor (1963, 1967, with a 3rd place behind Gérard Saint and Ercole Baldini in 1959), Hinault (1982). The criterium is the reason the village punches well above its 350-resident weight in French cycling memory; the Côte des Géants (the climb the 2017 Tour du Limousin used as its finishing-circuit challenge) takes its name from these post-Tour exhibitions."
+      }
+    ]
+  },
+  {
+    "segments": [22],
     "events": [
       {
         "year": 2024,
         "stage": "Stage 11",
-        "route": "Evaux-les-Bains to Le Lioran",
-        "description": "211km through the Massif Central with 4,350m climbing. Vingegaard vs Pogacar on terrain very similar to Stage 9's second half. The battle on these hills foreshadowed what the 2026 peloton will face."
+        "route": "Évaux-les-Bains to Le Lioran",
+        "description": "211 km Massif Central stage finishing at Le Lioran in the Cantal, ~60 km east of Stage 9's Mont Bessou. The route did not share roads with the 2026 Stage 9 corridor but climbed Puy Mary (1589 m) — the highest-altitude parallel for Mont Bessou (977 m), Stage 9's roof. Vingegaard distanced Pogačar on the day's final climbs in his first big GC move after returning from his pre-Tour crash. Re-keyed from segs 14-16 to seg 22 during the seg 14-16 verification (#478): the original keying was based on a soft 'terrain similar' framing that fits the Mont Bessou cresting beat better than the Monédières approach."
       }
     ]
   },

--- a/data/segments.json
+++ b/data/segments.json
@@ -259,7 +259,9 @@
     "min_elevation": 520,
     "max_elevation": 570,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Saint-Augustin"
+    ],
     "climbs": []
   },
   {

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -60,6 +60,12 @@
     "lat": 45.4555541,
     "lng": 1.8808583
   },
+  "Saint-Augustin": {
+    "type": "town",
+    "lat": 45.42442,
+    "lng": 1.83625,
+    "source": "https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) (verified 2026-05-07; OSM place=village confirms). Bourg sits 9m off the polyline at km 94.52 (seg 14). Added during seg 14-16 verification (#478) — the route runs through the village; previously absent from town-coords.json and segments.json towns array."
+  },
   "Treignac": {
     "type": "town",
     "lat": 45.5365916,

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -23,6 +23,7 @@ export const townKmPositions: Record<string, number> = {
   'Sainte-Fortunade': 60.02,     // 124m from village; seg 9 (added 2026-05-06 alongside drift assertion)
   'Tulle': 68.72,                // updated 2026-04-25, 120m from cathedral
   'Naves': 78.19,                // updated 2026-04-25, 373m from village; seg 12
+  'Saint-Augustin': 94.52,       // 9m from village (route runs through bourg); seg 14 (added 2026-05-07, #478)
   'Chaumeil': 100.30,            // updated 2026-04-25, 35m from village; seg 15
   'Treignac': 121.95,            // updated 2026-04-25, 22m from village; seg 18
   'Bugeat': 143.67,              // updated 2026-04-25, 23m from village; seg 21


### PR DESCRIPTION
## Summary

Closes #478. Data verification for segments 14-16 (km 92-112, Saint-Augustin through Chaumeil and the Suc au May summit, with the descent to seg 17) ahead of the seg 14 publish on Sun 2026-05-24. Mirrors PR #470 (segs 9-10) and PR #489 (segs 11-13). Strand brief at `docs/strands/strand-i-verify-segs-14-16.md`.

## Per-claim audit table

| Claim | Source | Current value | Audit finding | Action |
|---|---|---|---|---|
| Suc au May summit on the road | points-config + town-coords + GPX profile | km 105.15, 889 m road / 908 m mountain | road peak +0.36 km from coord-derived computed km (within ±0.5 tolerance); the published 903–908 m elevations refer to the mountain summit which is ~440 m off-route on a footpath | unchanged in this PR; clarification flagged in #491 |
| Suc au May points-config gradient | points-config 7.1% vs CLAUDE.md 7.7% vs Tourisme Corrèze ~8% vs profile 5.7%/7-8% | 7.1% | three sources disagree | filed #513 (sister to #490) |
| Suc au May points-config category | points-config "HC" vs Tourisme Corrèze "Cat 4 or 3" + points array `[10,8,6,4]` matches Cat 1 not HC | HC | three fields mutually inconsistent | filed #513 |
| Saint-Augustin on-route position (NEW) | OSM `place=village` (45.42442, 1.83625) | absent from data | route runs 9 m from the bourg at km 94.52 — the village was missing from town-coords, town-positions, and segments.json towns array | ✅ added in this PR |
| Église Saint-Augustin (NEW) | Mérimée PA00099811, Wikipédia | absent from data | Monument Historique inscribed 1929, 13th-c., 17th-c. Pierre Duhamel retable, ~9m off route at km 94.52 | ✅ added to attractions.json |
| Suc au May Table d'orientation (NEW) | Wikipédia, Tourisme Egletons | absent from data | oldest table d'orientation in Limousin, inaugurated 25 Aug 1935 by Henry de Jouvenel — same Henry de Jouvenel as Maison de la Sirène in Collonges (seg 4), strong literary callback | ✅ added (442 m off-route, seg 15) |
| Musée du Président Jacques Chirac (NEW) | museum site, Wikipédia | absent from data | 3.17 km off route at km 99.7 — within the 4.3 km Cascades de Gimel precedent (PR #470) | ✅ added (seg 15) |
| Maquis de Chaumeil Memorial | attractions.json | km 96.76, 249 m off | matches stored | unchanged |
| Chaumeil town | town-positions.ts, town-coords.json, segments.json | km 100.30, seg 15, 35 m off | matches stored | unchanged |
| 1987 men's TdF Stage 11 keying | PR #489 deferral; PCS / memoire-du-cyclisme | not in data | 255 km Poitiers→Chaumeil, Sat 11 Jul 1987, Gayant solo, Mottet (teammate) lost yellow | ✅ added to historical-tdf, keyed to seg 15 |
| 1987 women's TdF Féminin Stage 3 winner | PR #489 deferral said "winner not in PCS" | not in data | corrected: PCS *does* have it — Roberta Bonanomi (Italy) won, took yellow; Longo won overall | ✅ added to historical-tdf, keyed to seg 15 |
| Bol d'Or des Monédières keying | Strand D #501 said "belongs to seg 14" | not in data | Strand D's keying was wrong (CLAUDE.md staleness on Chaumeil km); Chaumeil is in seg 15 | ✅ added to seg 15 |
| Bol d'Or operational years | Strand D dossier "1954-2000s" | not in data | Wikipedia: founded 1952, ran 1952–1967 then revived 1981–2002 (founder Jean Ségurel) | ✅ corrected in description |
| Poulidor 1959 Bol d'Or | Strand D dossier "5th in 1959" | not in data | Wikipedia EN/FR: **3rd** in 1959, behind Gérard Saint and Ercole Baldini | ✅ corrected; flagged on PR #501 |
| 2020 TdF Stage 12 | Strand D forward (Chauvigny→Sarran, Hirschi, first Suc au May) | not in data | verified — 218 km, 10 Sep 2020, Hirschi solo, first TdF inclusion of Suc au May | ✅ added, keyed to seg 15 |
| 2017 Tour du Limousin Stage 3 | Strand D forward | not in data | verified — 184.7 km Saint-Pantaléon→Chaumeil, 50th edition queen stage, Cyril Gautier (AG2R) winner | ✅ added, keyed to seg 15 |
| 2024 TdF Stage 11 keying | historical-tdf.json `[14,15,16]` | "terrain similar to Stage 9's second half" | route went Évaux-les-Bains → Bourg-Lastic → Bort-les-Orgues → Le Lioran via Cantal; **never came near Chaumeil/Monédières/Suc au May**, no road overlap with segs 14-16; the Puy Mary parallel is for Mont Bessou (seg 22), not these three segments | ✅ re-keyed [14,15,16] → [22], description tightened |
| Strand D "Château de la Morguie near Chaumeil" | Strand D dossier (cherry microclimate framing) | not in data | the Château de la Morguie is in **Sainte-Fortunade** (Mérimée PA00099855), 18 km south of seg 15 — not a candidate for the Monédières corridor | not added; flagged on PR #501 |
| Sarran (Chirac home) as on-route town | candidate during audit | not in data | bourg sits 3.17 km off the polyline at km 99.7 — adjacent, not on-route | not added as town; added as attraction (museum) |

## Data changes

### `data/town-coords.json`
- **Saint-Augustin** added (`type: "town"`, lat/lng from OSM `place=village`, 9 m from polyline at km 94.52). The route runs through the bourg.

### `data/town-positions.ts`
- **Saint-Augustin** added between Naves and Chaumeil at km 94.52.

### `data/segments.json`
- **Seg 14** `towns` array now `["Saint-Augustin"]` (was `[]`).

### `data/attractions.json`
- **Église Saint-Augustin de Saint-Augustin** added (`category: church`, km 94.52, 9 m off, MH PA00099811).
- **Suc au May Table d'orientation** added (`category: nature`, km 105.48, 442 m off, summit panorama, Henry de Jouvenel 1935 — callback to seg 4 Maison de la Sirène).
- **Musée du Président Jacques Chirac** added (`category: museum`, km 99.7, 3.17 km off, Sarran).

### `data/historical-tdf.json`
- New `segments: [15]` grouping with five events: 1987 men's Stage 11, 1987 women's Féminin Stage 3, 2017 Tour du Limousin Stage 3, 2020 Stage 12 (first Suc au May TdF appearance), Bol d'Or des Monédières (criterium series 1952–2002).
- 2024 Stage 11 re-keyed from `[14, 15, 16]` to `[22]` with revised description (terrain adjacency, not road overlap; the Puy Mary parallel fits Mont Bessou).

## Items verified but unchanged

- Seg 14/15/16 `km_start`/`km_end`/lat-lng boundaries — match GPX polyline.
- Seg 14/15/16 `elevation_gain`/`elevation_loss`/`min_elevation`/`max_elevation` — small smoothing-method drift vs `data/elevation/segment-NN.json` summaries (consistent with PR #489's finding), not material.
- Seg 15 `Chaumeil` town keying and `Suc au May` climb keying — clean (35 m and 445 m off, both within tolerance).
- Seg 14 `Maquis de Chaumeil Memorial` attraction — clean (249 m off).
- `validate_points.py` spanning-climb invariant — clean (Suc au May appears only in seg 15 segments.json; the climb does not span).

## Out of scope (deferred — filed as separate issues / comments)

- **Suc au May points-config drift** (gradient 7.1 vs 7.7-8, category HC vs Cat 4, points array vs category mismatch). Filed as **#513**, sister to #490. Strand B territory per the v1.4.18 split.
- **CLAUDE.md known-waypoints staleness** — Saint-Augustin missing entirely; Suc au May elevation-source ambiguity (road 889 m vs mountain summit 908 m, the 903 m number CLAUDE.md uses sits between). **Comment added to #491.**
- **Strand D dossier corrections.** Three errors caught during audit, comment posted on **PR #501**: (a) Poulidor 1959 was 3rd not 5th; (b) Château de la Morguie is at Sainte-Fortunade not Chaumeil; (c) 1987 women's Stage 3 winner was Roberta Bonanomi (PCS does have it).
- **The `segments: [25, 26, 27]` grouping in historical-tdf.json references a non-existent seg 27** (route only has 26 segments). Pre-existing; out of this strand's write set.

## Carryforwards for downstream drafting strands (E/F/G or similar)

These belong to drafting, captured for awareness — verification confirms but does not consume:

- **Saint-Augustin → Tourondel** narrative bridge (seg 14): the church's nave vault is locally said to be modeled on an old wooden chapel at the Tourondel hamlet, 1.3 km off-route also in seg 14.
- **Sainte-Fortunade / Monédières framing** (Léon Dautrement quote; Bourrée des Monédières / Boreïa de las botelhas, 1950, René Lafeuille). Drafter chooses placement among segs 14/15/16. Verified: the Léon Dautrement framing is right; the *Sainte-Fortunade château* anchor is not (it's in seg 9 territory).
- **Henry de Jouvenel callback**: the Suc au May table d'orientation (1935) was inaugurated by him — pairs with seg 4's Maison de la Sirène. Strong cross-segment callback potential for seg 15.
- **Sarran adjacency** (Musée Chirac, Chirac family home, burial site). Pairs with Ussel (seg 25-26) where Chirac began his political career. Book-end potential.
- **Bol d'Or des Monédières → Côte des Géants name** — the climb the 2017 Tour du Limousin used as its finishing-circuit challenge takes its name from these post-Tour exhibitions (per the Bol d'Or description in this PR).
- **Suc au May elevation clarification**: the road peaks at 889 m (km 105.15), the mountain summits at 908 m (442 m off-route via footpath, where the table d'orientation sits). 19 m gap between the road and the peak.

## Verification commands

```bash
npm test                                                                       # 177/177 pass
python3 processing/validate_points.py                                          # OK
python3 processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
python3 processing/audit_segment_data.py --segment 14                          # clean
python3 processing/audit_segment_data.py --segment 15                          # clean
python3 processing/audit_segment_data.py --segment 16                          # clean
```

## Test plan

- [ ] `npm test` green (177/177)
- [ ] `processing/audit_segment_data.py` clean for segs 14, 15, 16
- [ ] `processing/validate_points.py` OK
- [ ] `processing/validate_entries.py` OK (non-interactive)
- [ ] dev preview: seg 14 page renders Saint-Augustin in towns / Église Saint-Augustin in nearby attractions
- [ ] dev preview: seg 15 page renders Suc au May Table d'orientation and Musée Chirac in nearby attractions
- [ ] dev preview: seg 22 (Mont Bessou) page now shows the 2024 Stage 11 historical reference; segs 14/15/16 no longer do

🤖 Generated with [Claude Code](https://claude.com/claude-code)
