### PR TITLE
data: climb-data corrections (Naves fix + aso flag)

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -238,7 +238,7 @@ const climbSummitKm = {
   'Puy Boubou': 30.6,
   'Cote de Lagleygeolle': 43.2, 'Côte de Lagleygeolle': 43.2,
   'Cote de Miel': 51.1, 'Côte de Miel': 51.1,
-  'Cote des Naves': 74.8, 'Côte des Naves': 74.8,
+  'Côte de Naves': 74.8,
   'Puy de Lachaud': 85.6,
   'Suc au May': 104.8,
   'Cote de la Croix de Pey': 127, 'Côte de la Croix de Pey': 127,

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -48,7 +48,7 @@ const climbData = {
   'Puy Boubou': { length: 2.8, gradient: 4.1 },
   'Côte de Lagleygeolle': { length: 5.2, gradient: 3.9 },
   'Côte de Miel': { length: 6.6, gradient: 3.9 },
-  'Côte des Naves': { length: 2.8, gradient: 6.7 },
+  'Côte de Naves': { length: 2.8, gradient: 6.7 },
   'Puy de Lachaud': { length: 3.6, gradient: 5.3 },
   'Suc au May': { length: 3.8, gradient: 7.7 },
   'Côte de la Croix de Pey': { length: 7.0, gradient: 4.9 },

--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -40,7 +40,8 @@
       "length_km": null,
       "category": 4,
       "gradient": 3.2,
-      "points": [2, 1, 0, 0]
+      "points": [2, 1, 0, 0],
+      "aso": false
     },
     {
       "name": "Puy Boubou",
@@ -49,7 +50,8 @@
       "length_km": 2.8,
       "category": 3,
       "gradient": 3.6,
-      "points": [4, 3, 2, 1]
+      "points": [4, 3, 2, 1],
+      "aso": false
     },
     {
       "name": "Côte de Lagleygeolle",
@@ -58,7 +60,8 @@
       "length_km": 5.2,
       "category": 4,
       "gradient": 3.2,
-      "points": [2, 1, 0, 0]
+      "points": [2, 1, 0, 0],
+      "aso": false
     },
     {
       "name": "Côte de Miel",
@@ -67,7 +70,8 @@
       "length_km": 2.4,
       "category": 4,
       "gradient": 1.8,
-      "points": [2, 1, 0, 0]
+      "points": [2, 1, 0, 0],
+      "aso": false
     },
     {
       "name": "Côte des Naves",
@@ -76,7 +80,8 @@
       "length_km": 2.8,
       "category": 2,
       "gradient": 5.6,
-      "points": [6, 4, 2, 1]
+      "points": [6, 4, 2, 1],
+      "aso": true
     },
     {
       "name": "Puy de Lachaud",
@@ -85,7 +90,8 @@
       "length_km": 3.6,
       "category": 2,
       "gradient": 3.2,
-      "points": [6, 4, 2, 1]
+      "points": [6, 4, 2, 1],
+      "aso": false
     },
     {
       "name": "Suc au May",
@@ -94,7 +100,8 @@
       "length_km": 3.8,
       "category": "HC",
       "gradient": 7.1,
-      "points": [10, 8, 6, 4]
+      "points": [10, 8, 6, 4],
+      "aso": true
     },
     {
       "name": "Côte de la Croix de Pey",
@@ -103,7 +110,8 @@
       "length_km": 7,
       "category": 3,
       "gradient": 4.4,
-      "points": [4, 3, 2, 1]
+      "points": [4, 3, 2, 1],
+      "aso": true
     },
     {
       "name": "Mont Bessou",
@@ -112,7 +120,8 @@
       "length_km": 5,
       "category": 4,
       "gradient": 2.7,
-      "points": [2, 1, 0, 0]
+      "points": [2, 1, 0, 0],
+      "aso": true
     },
     {
       "name": "Côte des Gardes",
@@ -121,7 +130,8 @@
       "length_km": 2.2,
       "category": 3,
       "gradient": 4.3,
-      "points": [4, 3, 2, 1]
+      "points": [4, 3, 2, 1],
+      "aso": false
     }
   ]
 }

--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -74,12 +74,12 @@
       "aso": false
     },
     {
-      "name": "Côte des Naves",
+      "name": "Côte de Naves",
       "segment": 11,
-      "km": 76.59,
+      "km": 77.45,
       "length_km": 2.8,
       "category": 2,
-      "gradient": 5.6,
+      "gradient": 6.3,
       "points": [6, 4, 2, 1],
       "aso": true
     },

--- a/data/segments.json
+++ b/data/segments.json
@@ -205,7 +205,7 @@
     "notable_points": [],
     "towns": [],
     "climbs": [
-      "Côte des Naves"
+      "Côte de Naves"
     ]
   },
   {

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -97,17 +97,17 @@
     "lng": 1.76101,
     "note": "Summit coordinate updated 2026-05-03 to match the v1.4.8 points-config correction (climb is the small bump at km 56.54, not the older km 49 characterization). Verified via processing/audit_segment_data.py."
   },
-  "Côte des Naves": {
+  "Côte de Naves": {
     "type": "climb",
-    "lat": 45.30396,
-    "lng": 1.78221,
-    "note": "Summit coordinate updated 2026-05-06 (issue #477) to the polyline position at the points-config summit km 76.59. Old coord was identical to the Naves town centre (45.312319, 1.7666474) — that placed it at km 78.19 / segment 12 / 374m off route, which was wrong. Audit-trail: the elevation profile peak is at km 77.32 (424m); CLAUDE.md gradient 6.7% matches the elevation-derived 6.8%; points-config gradient 5.6% diverges and is flagged for follow-up."
+    "lat": 45.308314,
+    "lng": 1.775128,
+    "note": "Summit coordinate updated 2026-05-07 (issue #490) to the polyline position at the points-config summit km 77.45 — the GPX elevation peak (422m). The earlier coord (45.30396, 1.78221) was the polyline position at the old declared summit km 76.59, a rising-flank position ~860m short of the actual peak. Elevation-derived gradient over the 2.8 km span ending at the peak is 6.27% (gain 175.6 m); points-config gradient corrected from 5.6% to 6.3%. Climb name renamed Côte des Naves → Côte de Naves to match ASO/Tourisme Corrèze (#515)."
   },
   "Puy de Lachaud": {
     "type": "climb",
     "lat": 45.37676,
     "lng": 1.80294,
-    "note": "Summit coordinate updated 2026-05-06 (issue #477) to the polyline position at the points-config summit km 87.54. Old coord (45.336, 1.784) sat at km 81.49 / segment 12 / on a descent — diverged from the points-config km by 6 km. Per publisher decision, coord aligned to points-config km. Caveat: Puy de Lachaud is not on the official ASO 2026 Stage 9 categorised-climb list (Côte des Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou); follow-up may revisit whether the climb stays in points-config."
+    "note": "Summit coordinate updated 2026-05-06 (issue #477) to the polyline position at the points-config summit km 87.54. Old coord (45.336, 1.784) sat at km 81.49 / segment 12 / on a descent — diverged from the points-config km by 6 km. Per publisher decision, coord aligned to points-config km. Caveat: Puy de Lachaud is not on the official ASO 2026 Stage 9 categorised-climb list (Côte de Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou); follow-up may revisit whether the climb stays in points-config."
   },
   "Suc au May": {
     "type": "climb",

--- a/processing/geocode_towns.py
+++ b/processing/geocode_towns.py
@@ -30,7 +30,7 @@ CLIMB_SEARCH = {
     "Puy Boubou": "Puy Boubou, Corrèze, France",
     "Côte de Lagleygeolle": "Lagleygeolle, Corrèze, France",
     "Côte de Miel": "Miel, Corrèze, France",
-    "Côte des Naves": "Naves, Corrèze, France",
+    "Côte de Naves": "Naves, Corrèze, France",
     "Puy de Lachaud": "Lachaud, Corrèze, France",
     "Suc au May": "Suc au May, Corrèze, France",
     "Côte de la Croix de Pey": "Croix de Pey, Corrèze, France",

--- a/schemas/competition/points-config.schema.json
+++ b/schemas/competition/points-config.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "tdf26/competition/points-config.schema.json",
   "title": "Sprint and climb point locations",
-  "description": "Single source of truth for climb identity, summit segment, and span. Validated cross-file by processing/validate_points.py.",
+  "description": "Single source of truth for climb identity, summit segment, and span. Validated cross-file by processing/validate_points.py. The `aso` boolean on each climb records whether the climb appears on the official ASO Stage 9 categorised-climb list. Non-ASO regional climbs are first-class entries; UI and per-segment narrative may treat them differently from ASO-categorised climbs but they remain in the data layer and continue to award internal-competition points via processing/calculate_points.py.",
   "type": "object",
   "required": ["sprints", "climbs"],
   "properties": {
@@ -29,7 +29,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "segment", "km", "category", "gradient", "points"],
+        "required": ["name", "segment", "km", "category", "gradient", "points", "aso"],
         "properties": {
           "name": { "type": "string", "minLength": 1 },
           "segment": { "type": "integer", "minimum": 1 },
@@ -46,6 +46,10 @@
             "type": "array",
             "items": { "type": "integer", "minimum": 0 },
             "minItems": 1
+          },
+          "aso": {
+            "type": "boolean",
+            "description": "True if the climb appears on the official ASO Stage 9 categorised-climb list. False for regional climbs that the route passes over but ASO has not categorised."
           }
         },
         "additionalProperties": true

--- a/tests/utils/climb-gradient.test.ts
+++ b/tests/utils/climb-gradient.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import pointsConfig from '~/data/competition/points-config.json'
+import segmentsJson from '~/data/segments.json'
+
+// Per-source-of-truth assertion. For every climb declared in points-config.json
+// with a non-null length_km, the declared gradient must match the gradient
+// derived from data/elevation/segment-NN.json over the declared span
+// [summit_km - length_km, summit_km], within ±0.3 percentage points.
+//
+// This sits alongside processing/validate_points.py invariant 4 (which uses a
+// ±20% relative tolerance, generous enough to admit ~1pp drift on a 5%-grade
+// climb). The TS assertion is the tighter sibling — it catches the case where
+// the gradient field is rounded incorrectly or stale relative to the declared
+// span. It does NOT catch the case where the declared summit km itself is
+// wrong (e.g., on a rising flank past the actual GPX peak); that is a
+// different invariant and the subject of a separate follow-up.
+//
+// Second instance of the per-source-of-truth detector pattern — first instance
+// landed in PR #448 (stage-totals derives uniqueCategorizedClimbs from the
+// same source as CATEGORIZED_CLIMBS, asserting they agree). #490+#492 strand
+// extends the regime to gradient × length × GPX-gain agreement.
+
+interface Segment {
+  segment: number
+  km_start: number
+  km_end: number
+}
+
+interface ElevationFile {
+  distance: number[]
+  elevation: number[]
+}
+
+const repoRoot = resolve(__dirname, '..', '..')
+
+function loadElevation(segNum: number): ElevationFile {
+  const p = resolve(repoRoot, `data/elevation/segment-${String(segNum).padStart(2, '0')}.json`)
+  return JSON.parse(readFileSync(p, 'utf8')) as ElevationFile
+}
+
+function buildTrack(): Array<[number, number]> {
+  const track: Array<[number, number]> = []
+  for (const s of segmentsJson as Segment[]) {
+    const ev = loadElevation(s.segment)
+    for (let i = 0; i < ev.distance.length; i++) {
+      track.push([s.km_start + ev.distance[i], ev.elevation[i]])
+    }
+  }
+  track.sort((a, b) => a[0] - b[0])
+  return track
+}
+
+function elevationAt(track: Array<[number, number]>, km: number): number {
+  if (km <= track[0][0]) return track[0][1]
+  if (km >= track[track.length - 1][0]) return track[track.length - 1][1]
+  for (let i = 0; i < track.length - 1; i++) {
+    if (track[i][0] <= km && km <= track[i + 1][0]) {
+      const span = track[i + 1][0] - track[i][0]
+      const t = span ? (km - track[i][0]) / span : 0
+      return track[i][1] + t * (track[i + 1][1] - track[i][1])
+    }
+  }
+  return track[track.length - 1][1]
+}
+
+const TOLERANCE_PP = 0.3
+
+describe('points-config climb gradient vs GPX elevation', () => {
+  const track = buildTrack()
+
+  for (const climb of pointsConfig.climbs) {
+    if (climb.length_km == null) continue
+    it(`${climb.name}: declared ${climb.gradient}% matches GPX over [${(climb.km - climb.length_km).toFixed(2)}, ${climb.km}] within ±${TOLERANCE_PP}pp`, () => {
+      const summit = elevationAt(track, climb.km)
+      const start = elevationAt(track, climb.km - climb.length_km)
+      const gain = summit - start
+      const derived = (gain / (climb.length_km * 1000)) * 100
+      const diff = climb.gradient - derived
+      expect(
+        Math.abs(diff),
+        `declared ${climb.gradient.toFixed(2)}% vs GPX-derived ${derived.toFixed(2)}% (gain ${gain.toFixed(1)}m / ${climb.length_km}km); diff ${diff >= 0 ? '+' : ''}${diff.toFixed(2)}pp`,
+      ).toBeLessThanOrEqual(TOLERANCE_PP)
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Côte de Naves declared summit moved from km 76.59 (rising-flank) to the GPX peak at km 77.45 (+30 m, ~860 m further along the route); gradient corrected 5.6% → 6.3% over the new 2.8 km span. Climb name renamed Côte des Naves → Côte de Naves to align with ASO and Tourisme Corrèze.
- New `aso: boolean` required field on every climb in points-config records ASO Stage 9 categorised-list membership. 4 ASO climbs (Naves, Suc au May, Croix de Pey, Mont Bessou) per Tourisme Corrèze; 6 regional climbs flagged `aso: false` and remain first-class in the data layer.
- New `tests/utils/climb-gradient.test.ts` per-source assertion: declared gradient must match GPX gain over declared span within ±0.3 pp. Second instance of the per-source-of-truth detector pattern (first instance was PR #448).

Closes #490, #492, #515.

## Per-climb audit table

| Climb | aso | Length km | Declared % | GPX-derived % | Canonical |
|---|---|---|---|---|---|
| Côte de Malemort | false | (point) | 3.20 | n/a | unchanged |
| Puy Boubou | false | 2.80 | 3.60 | 3.64 | unchanged |
| Côte de Lagleygeolle | false | 5.20 | 3.20 | 3.21 | unchanged |
| Côte de Miel | false | 2.40 | 1.80 | 1.78 | unchanged |
| **Côte de Naves** | **true** | **2.80** | **5.6 → 6.3** | **6.27** | **fixed (#490)** |
| Puy de Lachaud | false | 3.60 | 3.20 | 3.23 | unchanged |
| Suc au May | true | 3.80 | 7.10 | 7.07 | unchanged here, see #513 |
| Côte de la Croix de Pey | true | 7.00 | 4.40 | 4.40 | unchanged |
| Mont Bessou | true | 5.00 | 2.70 | 2.66 | unchanged |
| Côte des Gardes | false | 2.20 | 4.30 | 4.39 | unchanged |

GPX-derived column is gain over `[summit_km - length_km, summit_km]` from `data/elevation/segment-NN.json`. All 9 spanning climbs pass the new ±0.3 pp assertion.

## Sources for ASO membership

The official letour.fr stage profile is unreachable from this environment. The 4-climb reading was taken from Tourisme Corrèze's stage announcement, which explicitly enumerates the categorised climbs:

- [Tour de France 2026: A 100% Corrèze Stage — Tourisme Corrèze](https://www.tourismecorreze.com/en/events/tour_de_france_2026_a_100_correze_stage)
- [cyclingstage.com — Stage 9 narrative](https://www.cyclingstage.com/tour-de-france-2026-route/stage-9-tdf-2026/) (used for Naves 6.7% cross-check)

If a future audit confirms a different ASO list from letour.fr directly, the `aso` flag values are easy to flip.

## Red-green demonstrations

**Schema (#492):** removing `aso` from one climb fires `data/climbs/0 must have required property 'aso'`; restoring passes (42 → 41 fail → 42 green on `tests/data/schemas.test.ts`).

**Gradient assertion (#490):** reverting Naves gradient to 5.6 against the new km 77.45 fires `declared 5.60% vs GPX-derived 6.27% (gain 175.6m / 2.8km); diff -0.67pp` on `tests/utils/climb-gradient.test.ts`; restoring 6.3 passes (9 → 8 fail → 9 green).

The artificial revert was applied locally only and not committed, per the v1.4.11 strand-C technique cited in `feedback_strand_worktree_path.md`.

## Cross-strand co-ordination

Folded #515 (Côte de Naves spelling rename) into this PR because `validate_points.py` enforces name agreement across `points-config.json` / `segments.json` / `town-coords.json`; landing the rename in any one file alone fails validation. Issue #515 noted this strand owns the rename.

The rename also needed to reach `components/StageDetails.vue` (key in hardcoded `climbData`), `components/ElevationChart.vue` (collapsed alias keys to canonical), and `processing/geocode_towns.py` (key in geocode dict). These were not in the original brief's owned-write set; without them the rename silently breaks downstream lookups.

## Open follow-ups (out of scope)

- **#513 — Suc au May category/gradient drift** (filed by the segs 14-16 strand). Same shape of problem, different climb; left as the strand intended.
- **StageDetails.vue / ElevationChart.vue hardcoded climb data.** Both components carry their own hardcoded `climbData` / `climbSummitKm` maps parallel to points-config (e.g., `StageDetails.vue` still shows Naves at 6.7%, not the new canonical 6.3%). Source-of-truth duplication; should read from points-config directly. Will file as a separate issue.
- **Summit-km invariant.** The new gradient assertion catches gradient-vs-span drift but not the case where the declared summit km itself sits on a rising flank (the Naves bug class). A sister assertion ("summit km is at GPX local maximum within tolerance") would catch this. Not in this PR; flagging for follow-up.

## Verification

- `npm test`: 186 passed (was 177; +9 from new gradient tests)
- `python3 processing/validate_points.py`: OK
- `python3 processing/validate_entries.py --entries-dir content/entries`: OK
- `npm run build`: complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)