### PR TITLE
chore(docs): commit in-flight strand briefs + planning continuation

### DIFF
--- a/docs/planning/NEXT.md
+++ b/docs/planning/NEXT.md
@@ -1,0 +1,147 @@
+# Planning session continuation — 2026-05-07
+
+> **Singleton convention:** this file lives at `docs/planning/NEXT.md`. At most one open planning continuation exists at a time; if a session is in progress, this is where its handoff state lives. When the session it tracks closes, rename to a date-stamped archive (e.g. `docs/planning/2026-05-07-archive.md`) or delete. New planning sessions that need a continuation overwrite or replace this file.
+
+This note hands off mid-session state to a future Claude Code session that will resume the 2026-05-07 planning. Read this first; cross-references point at the durable artifacts (issues, strand briefs, the original agenda).
+
+## How to resume
+
+1. **Read this note** in full.
+2. **Read the original agenda** at `/home/jhs/.claude/plans/inherited-enchanting-cascade.md` for the topic-by-topic structure and the per-topic context. Today's session worked through topics 1, 2, 3, 4, 5, 6, 7, 10, 12 in that order. Remaining topics: **8, 9, 11, 13, 14, 15** (in suggested order; the publisher may reshuffle).
+3. **Confirm the current strand status with the publisher** before authoring more strand briefs — strand status changes between sessions and the table below is a snapshot.
+4. **Use the `/strand-brief` skill** for any new strand briefs. The skill landed in this session and reads `docs/strands/STRAND-BRIEF-TEMPLATE.md` at invocation time.
+5. **At session close**, run the "items to record in `project_next_planning_notes.md`" checklist (below).
+
+## Session state at handoff
+
+- **Date:** 2026-05-07.
+- **Context:** post Retro v1.4.17 (filed earlier today). Session shapes the back half of v1.4.18 (seg 11 publishes Sun 2026-05-10, deadline now cleared by the publish.sh fail-fast strand) and seeds v1.4.19 / v1.4.20.
+- **Workflow in use:** topic-by-topic, no time boxes. Decisions captured via AskUserQuestion. Strand briefs written when work is clear and independent; spawned strands run in parallel during the session.
+- **Strands completed in-session (4):** content research km 70-92, CLAUDE.md known-waypoints deprecation, `/strand-brief` skill, publish.sh fail-fast.
+- **Strand-brief template** lives at `docs/strands/STRAND-BRIEF-TEMPLATE.md`; the publisher edited it during the session — that edit is intentional, do not revert.
+
+## Decided topics (this session)
+
+| # | Topic | Outcome |
+|---|---|---|
+| 1 | Publication: segs 11/12/13 by Sun afternoon | Block-research + 3 publisher-paced drafting strands |
+| 2 | Data verification: #478 + segs 17-26 gap | #498/#499/#500 filed (v1.4.20 placeholder); #478 brief written |
+| 3 | publish.sh fail-fast | #496 expanded to fail-fast policy per failure mode; brief written; ✅ shipped |
+| 4 | CLAUDE.md known-waypoints + data-layer regime expansion | Deprecate path; #490/#491/#492 → v1.4.19; #491 ✅ shipped; #490+#492 brief written |
+| 5 | Strand-brief template | Path C (file + skill); template + README + skill ✅ shipped; unfold#40 filed |
+| 6 | Tour-history feature scoping | Dedicated `/tour-history` route + homepage card; soft-launch URL early, prominent launch pre-stage; #502 + #503 filed; research strand brief written |
+| 7 | Content / voice forward-looking | Auzelou seg 11 (cyclosportive primary), Sainte-Fortunade seg 14 (Monédières establishment), music ledger keep-prose, Mascaron deferred pending #500 |
+| 10 | Date-gated experiment evaluations | Block-research + register-shifts both hold light-tier; tracking-issue-per-deploy watch-item closed (unfold#36 comment added) |
+| 12 | Testing infrastructure | bats harness #508 filed (v1.4.20); worktree bootstrap #509 filed (v1.4.20); 3 light-tier carryforwards held |
+
+## Strand status at handoff
+
+Status legend: ✅ done · 🚀 spawned (running) · 📝 brief written, ready to spawn · ✏️ writeable, decisions made · 🚧 blocked
+
+| Status | Brief / Strand | Milestone | Notes |
+|---|---|---|---|
+| ✅ | `strand-d-content-research.md` | v1.4.18 | Block research km 70-92 (segs 11-13) |
+| ✅ | `strand-claude-md-deprecation.md` (#491) | v1.4.19 | CLAUDE.md known-waypoints tables → JSON pointers |
+| ✅ | `strand-skill-strand-brief.md` (`/strand-brief` skill) | v1.4.18 | Skill is callable in any tdf26 session |
+| ✅ | `strand-publish-sh-fail-fast.md` (#496) | v1.4.18 | Three publish.sh fixes shipped; Sun deadline cleared |
+| 📝 | `strand-i-verify-segs-14-16.md` (#478) | v1.4.19 | Spawn ~1 week (after seg 13 stabilises) |
+| 📝 | `strand-climb-data.md` (#490 + #492) | v1.4.19 | Anytime in v1.4.19 |
+| 📝 | `strand-tour-history-research.md` (#502) | v1.4.20 | Research-only; runs for days |
+| ✏️ | `strand-verify-segs-17-19.md` (#498) | v1.4.20 | Spawn ~3 weeks; can scaffold via `/strand-brief` |
+| ✏️ | `strand-verify-segs-20-22.md` (#499) | v1.4.20 | Spawn ~5 weeks; can scaffold via `/strand-brief` |
+| ✏️ | `strand-verify-segs-23-26.md` (#500) | v1.4.20 | Spawn ~6 weeks; can scaffold via `/strand-brief` |
+| ✏️ | Seg 11 drafting strand | v1.4.18 | Auzelou framing decided; voice register at draft time |
+| 🚧 | Seg 12 drafting strand | v1.4.19 | Voice + seg 11 publication learnings |
+| 🚧 | Seg 13 drafting strand | v1.4.19 | Voice |
+
+## Issues filed / updated this session
+
+**Filed (tdf26):**
+- [#498](https://github.com/gneeek/tdf26/issues/498) — Data verification segs 17-19 (Treignac, Côte de la Croix de Pey), v1.4.20
+- [#499](https://github.com/gneeek/tdf26/issues/499) — Data verification segs 20-22 (Plateau de Millevaches, Mont Bessou), v1.4.20
+- [#500](https://github.com/gneeek/tdf26/issues/500) — Data verification segs 23-26 (Meymac, Ussel finish), v1.4.20
+- [#502](https://github.com/gneeek/tdf26/issues/502) — Tour-history feature umbrella, v1.4.20
+- [#503](https://github.com/gneeek/tdf26/issues/503) — `historical-tdf.json` segment-27 drift, v1.4.19
+- [#508](https://github.com/gneeek/tdf26/issues/508) — Shell scripts have no test harness, v1.4.20
+- [#509](https://github.com/gneeek/tdf26/issues/509) — Worktree bootstrap fragility, v1.4.20
+
+**Updated (tdf26):**
+- [#496](https://github.com/gneeek/tdf26/issues/496) — retitled to fail-fast policy per failure mode; milestone v1.4.18; planning decision recorded as comment
+- [#490](https://github.com/gneeek/tdf26/issues/490), [#491](https://github.com/gneeek/tdf26/issues/491), [#492](https://github.com/gneeek/tdf26/issues/492) — moved to v1.4.19; planning-decision comments added
+
+**Filed (unfold):**
+- [#40](https://github.com/gneeek/unfold/issues/40) — heavy-tier note candidate: strand-brief template shape
+
+**Comment added (unfold):**
+- [#36](https://github.com/gneeek/unfold/issues/36) — tracking-issue-per-deploy worked-example list updated; tdf26 watch-item closed
+
+## Remaining topics — suggested order
+
+| # | Topic | Why this slot now |
+|---|---|---|
+| 8 | **Publisher / developer-experience contract** | Wiki-edit strand candidate. Becomes urgent when second publisher arrives (per `project_publisher_onboarding.md`); currently implicit because publisher and developer are the same person. Natural home: How-We-Work wiki page alongside late-add/hotpatch policy. |
+| 9 | **OODA alignment (versioning + planning-Decide artifact + retro-scope)** | Discussion-heavy; not parallelisable. Three items plausibly resolve as one conversation. Likely interacts with #481 (planning-shape design) and decisions about how this very planning session was run. |
+| 11 | **Process / wiki / older retro carryforwards** | Batch-decide. Items: slip-rate tally artifact, How-We-Work → docs/strands link, full-lifecycle release checklist, drafter-as-first-fresh-reader, pre-locked decision tables, pair-writing disclosure forwards-consistency, cultural-threads ledger format (already pinned at Topic 7), verify-then-mutate-with-scope-first rule, class-of-bug residue, end-to-end render verification, parallel-source-of-truth detector, audit completeness. |
+| 13 | **Strand C carryforwards + Voices project / unfold pending** | Batch. Items: EntryCard duplication, "One improvement only" rule, Voices project design questions (4 open), content lints, status check on unfold#35/#36. |
+| 14 | **Backlog sweep** | Unmilestoned: #309, #339, #364, #387, #441, #473, #482. Decide schedule / defer / close per issue. |
+| 15 | **Sweep / clear** | Session close — clear RESOLVED items from `project_next_planning_notes.md`; record new items per the checklist below. |
+
+## Items to record in `project_next_planning_notes.md` at session close
+
+This is the checklist the new session runs at session close. Add as durable lines in the planning-notes file (under appropriate sections).
+
+**Decisions to record:**
+- Topic 1: block-research + 3 publisher-paced drafting strands chosen for segs 11-13. Strand D landed.
+- Topic 2: segs 14-16 verification (#478) v1.4.19; segs 17-26 split into #498/#499/#500 v1.4.20 placeholder; #478 brief written today.
+- Topic 3: publish.sh fail-fast policy per failure mode landed (#496 closed); chore-deploy wrapper deferred (no instance fired this cycle); pre-publish PR pattern still deferred for codification.
+- Topic 4: CLAUDE.md known-waypoints deprecate path chosen; #491 landed; #490+#492 paired in v1.4.19 brief written.
+- Topic 5: strand-brief template Path C; both file (`docs/strands/STRAND-BRIEF-TEMPLATE.md`) and skill (`/strand-brief`) shipped; unfold#40 filed as heavy-tier candidate.
+- Topic 6: Tour-history feature = dedicated `/tour-history` route + homepage card; soft-launch URL early, prominent launch pre-stage; #502 umbrella + #503 data-drift fix filed; research strand brief written.
+- Topic 7: Auzelou seg 11 frame = cyclosportive primary; Sainte-Fortunade Monédières framing lands at seg 14 entry with cherry detail; music threads ledger stays as planning-notes prose; Mascaron seg-24-vs-25 deferred pending #500.
+- Topic 10: block-research-then-N-drafts holds light-tier; register-shifts holds light-tier; tracking-issue-per-deploy watch-item **closed** (unfold#36 covers it).
+- Topic 12: bats harness #508 filed (v1.4.20); worktree bootstrap #509 filed (v1.4.20); 3 light-tier carryforwards continue (external tooling supplies test spec; red-demonstration via physical breakage; v1.4.11 Strand C smoke-vs-deletion).
+
+**Carryforwards to remove from the planning-notes file** (since they're decided):
+- Image frontmatter convention (already RESOLVED 2026-05-06; clearable)
+- Data-layer stability regime (already RESOLVED 2026-05-06; clearable)
+- Late-add + hotpatch policy (already RESOLVED 2026-05-06; clearable)
+- All Topic 1-7 + 10 + 12 items above (now decided this session; clearable)
+- Tracking-issue-per-deploy watch-item (Topic 10 closed it)
+- Date-gated 2026-05-07 evaluations (Topic 10 held both light-tier; new evaluation date depends on segs 11-13 reader signal — re-flag at the next planning if the publisher wants explicit re-evaluation)
+
+**New carryforwards to add:**
+- Mascaron / Saintsbury voice may need to shift from seg 24 to seg 25 per `data/segments.json`; awaiting #500 verification.
+- Music threads ledger format pinned as planning-notes prose; promotion criteria recorded (ledger > 6 threads / lookup cost bites / rendering surface needs data).
+- Sainte-Fortunade Monédières framing lands at seg 14 entry (Dautrement quote + cherry-15-days-earlier microclimate detail together).
+- Auzelou seg 11 frame: cyclosportive-departure primary, "99-100 days before stage" as one rhetorical beat, amateur-cycling embedded.
+- Six new issues filed today (#498/#499/#500/#502/#503/#508/#509); all v1.4.19 or v1.4.20 placeholder; reshuffle as milestones shape.
+- Five strand briefs in `docs/strands/` ready to spawn; four already shipped.
+
+**Memory update items** (potentially):
+- `project_meymac_voice.md` may need an edit to reflect "seg 24 OR seg 25 pending #500"; do not change today.
+- `project_barthes_callback.md` says seg 6/12/15; verify against current `data/segments.json` if #500 surfaces a similar drift.
+
+## Open carryforwards from the original agenda not yet addressed
+
+These are in the agenda but not yet decided. They live in topics 8, 9, 11, 13, 14, 15. The new session covers them. Highlights:
+
+- **OODA alignment (Topic 9):** versioning scheme, planning-Decide → retro-Observe artifact, retro-scope convention. Three items, likely one conversation. Cross-link [#481](https://github.com/gneeek/tdf26/issues/481).
+- **Publisher / developer-experience contract (Topic 8):** how-we-work edit; becomes social fact when second publisher arrives.
+- **Backlog sweep (Topic 14):** #309, #339, #364, #387, #441, #473, #482.
+- **Strand C carryforwards (Topic 13):** EntryCard duplication, "one improvement only" rule.
+- **Voices project (Topic 13):** four open design questions.
+
+## Notes for the new session's first actions
+
+- The `/strand-brief` skill is now available. Use it for #498/#499/#500 brief scaffolding when those are written.
+- The strand-brief template at `docs/strands/STRAND-BRIEF-TEMPLATE.md` was edited mid-session by the publisher; the section structure may differ from the version in this note. Read the actual file at invocation time.
+- Four strand briefs are uncommitted and live on `main`: `STRAND-BRIEF-TEMPLATE.md`, `README.md` (in docs/strands), four shipped briefs (D, deprecation, skill, publish-sh-fail-fast — these may have been committed by the strands themselves), and the not-yet-spawned briefs (i-verify-14-16, climb-data, tour-history-research). Confirm git state at the start of the new session.
+- This continuation note itself is uncommitted. The publisher decides whether to commit + push before the new session, or hand the path to the new session directly.
+
+## Pointers
+
+- Original agenda: `/home/jhs/.claude/plans/inherited-enchanting-cascade.md`
+- Strand briefs directory: `/home/jhs/code/tdf26/docs/strands/`
+- Planning-notes file (durable input/output): `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/project_next_planning_notes.md`
+- Memory index: `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/MEMORY.md`
+- This continuation note: `/home/jhs/code/tdf26/docs/planning/NEXT.md` (singleton convention — there is at most one open planning continuation under this name; rename to a date-stamped archive when the planning session it tracks closes, or delete if no archive is needed)

--- a/docs/strands/strand-claude-md-deprecation.md
+++ b/docs/strands/strand-claude-md-deprecation.md
@@ -1,0 +1,113 @@
+# Strand — CLAUDE.md known-waypoints deprecation (#491)
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md). Closes [#491](https://github.com/gneeek/tdf26/issues/491).
+
+## 1. Goal
+
+Deprecate the `CLAUDE.md` "Known Waypoints and Climbs (for segment assignment)" section — specifically the "Major Towns (approximate km)" and "Categorized Climbs" subsection tables — in favour of `data/*.json` as the source of truth. For each fact in the tables, locate a JSON home or file a follow-up issue to add it; then remove the tables and replace with pointers to the JSON files. CLAUDE.md keeps narrative project context (architecture, tech stack, directory structure, conventions); it loses tabular data that has demonstrated drift.
+
+Milestone v1.4.19. Companion to the climb-data strand (#490 + #492). Cross-link [unfold#40](https://github.com/gneeek/unfold/issues/40) for awareness; do not open unfold work from inside this strand.
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-491-deprecate-known-waypoints /home/jhs/code/tdf26-claude-md main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+This strand's job is to **make** `data/*.json` the single source of truth for route geometry, town positions, and climb data. It reads:
+
+- `data/segments.json` — town/climb assignments per segment
+- `data/town-coords.json` — town coordinates
+- `data/attractions.json` — attractions, including some cycling-context info
+- `data/points-config.json` — climbs, gradients, lengths, ASO categorisation (the climb-data strand may be modifying this concurrently — coordinate)
+- `data/historical-tdf.json` — historical Tour stage references
+- `data/segments/*.gpx` — polylines
+
+It writes only to `CLAUDE.md`. Any *missing* data discovered (e.g., Ussel not currently tagged as a town in segments.json seg 26 despite being the stage finish) is filed as a new issue per `feedback_issues_describe_problems.md` — this strand does not add data inline.
+
+## 4. Target issues
+
+- **Closes [#491](https://github.com/gneeek/tdf26/issues/491)** — single tracking issue, milestone v1.4.19.
+- **Files new follow-up issues** for any datum in the deprecated tables that has no current JSON home. Expected examples (preliminary, verify during audit):
+  - Ussel as a town in `data/segments.json` seg 26 (surfaced by #500 issue body)
+  - Total-distance reconciliation: 182 km (segments.json) vs 185 km (CLAUDE.md text); decide which is canonical
+  - Cycling-context paragraphs per climb (gradient narrative, summit notes) — if any survive the audit as JSON-shape-resistant, document a home (e.g., a new `data/climb-narrative.json` keyed by climb id, or accept they stay in CLAUDE.md as inline narrative).
+- **Companion issues** (do NOT touch but be aware of): #490 (Côte des Naves gradient — climb-data strand owns), #492 (Puy de Lachaud non-ASO — climb-data strand owns).
+
+## 5. Workflow
+
+1. **Inventory pass.** Read CLAUDE.md sections "Major Towns (approximate km)" and "Categorized Climbs". For each row, capture: the row's claim, the candidate JSON home, the current value in JSON, drift if any. Build an audit table.
+2. **Per-claim resolution.** For each row:
+   - **Has JSON home, JSON value matches CLAUDE.md (or is the better value):** mark for table removal.
+   - **Has JSON home, JSON value drifts from CLAUDE.md:** mark for table removal; the JSON wins (per the deprecation decision); flag drift in PR body for awareness only.
+   - **No JSON home:** file a follow-up issue describing the missing data (problem-shaped per `feedback_issues_describe_problems.md`); mark CLAUDE.md fact for retention until the follow-up resolves, OR remove and let the follow-up restore — decide per fact via AskUserQuestion at material checkpoints.
+3. **Edit CLAUDE.md.** Remove the two tables. Replace each subsection with a pointer paragraph:
+   - "Major Towns": pointer to `data/segments.json` (towns per segment) + `data/town-coords.json` (coordinates).
+   - "Categorized Climbs": pointer to `data/points-config.json` (climb metadata) + brief note that non-ASO regional climbs are documented in points-config schema after #492 lands.
+   - Keep any cycling-context paragraphs that pre-date or outlive the tables (verify nothing in the route narrative or development-notes sections references the deleted tables; update cross-references as needed).
+4. **Cross-reference sweep.** `grep -rn "Known Waypoints" /home/jhs/code/tdf26/` to find any links to the deprecated tables in wiki, docs, briefs, or memories. Update or remove pointers. Most likely callers: existing strand briefs (e.g., `strand-d-content-research.md`, `strand-i-verify-segs-14-16.md`, `strand-verify-segs-17-19.md`-through-`-23-26.md` if they exist) — these explicitly tell their agents NOT to transcribe CLAUDE.md known-waypoints; that text becomes obsolete once the tables are gone, but keeping it is harmless. Do not modify completed strand briefs from past releases.
+5. **Validators.** Run repo validators; confirm nothing depends on the table contents at parse time.
+6. **AskUserQuestion checkpoints** — expect 1-3, around:
+   - Whether to remove a table entry whose follow-up issue isn't resolved yet (lose the data temporarily vs keep until follow-up lands).
+   - Whether to absorb cycling-context paragraphs into JSON or leave them in CLAUDE.md as inline narrative.
+   - Total-distance reconciliation (182 vs 185 km).
+
+## 6. Verification commands
+
+- `npm test` — must pass.
+- `python3 processing/validate_points.py` — must pass.
+- `python3 scripts/validate_entries.py` — must pass.
+- `npm run build` — must pass (a CLAUDE.md edit shouldn't break build, but the audit-script + segment-data validations run on build path; defensive).
+- After edits: `grep -n "km " CLAUDE.md` confirms no table-shape km references remain in deprecated sections (cycling-history references like "1951 Tour, Stage 11" are fine and should remain).
+
+Demonstrate read-fidelity: render the deprecated section once before edit, once after; confirm the after-version compiles to a coherent narrative without the tables.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `CLAUDE.md` (the deprecation edits)
+- **What this strand reads:**
+  - `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/points-config.json`, `data/historical-tdf.json`, `data/segments/*.gpx`
+  - `docs/strands/*.md` (cross-reference sweep; do not modify completed briefs)
+  - Wiki content if the cross-reference sweep surfaces wiki references
+- **What this strand must NOT touch:**
+  - `data/*.json` files — adding/correcting data is out of scope; file new issues. (The climb-data strand will be touching `data/points-config.json` concurrently for #490/#492; coordinate by not touching that file.)
+  - `data/segments/*.gpx` — the master geometry; no edits.
+  - Existing strand briefs — they're working artifacts of their own releases.
+- **Cross-strand collisions:**
+  - **Climb-data strand (#490 + #492)** runs concurrently in v1.4.19 and modifies `data/points-config.json` + schema + tests. This strand only **reads** points-config; no file overlap. If the climb-data strand lands first, this strand's pointer paragraph for "Categorized Climbs" should reference the new ASO flag posture (cite #492's outcome). If this strand lands first, the climb-data strand's PR can update the pointer paragraph as part of its work. Either order is fine; the second strand to land does the small text update.
+  - **Verification strands (#498/#499/#500)** read CLAUDE.md narrative for context. They explicitly do not transcribe the deprecated tables — that's already in their briefs. After this strand lands, those briefs' "do not transcribe" caveat becomes redundant but not wrong.
+
+## 8. Scope discipline
+
+- **Do NOT add new data inline.** File follow-up issues for missing-data facts. The data-layer regime says JSON is canonical; adding data is the verification strands' job, not this one's.
+- **Do NOT remove project-context narrative.** Tech Stack, Directory Structure, Phase 1/2/3/4 sections, Publication Schedule, Development Notes, References — these stay. Only the two tabular subsections under "Known Waypoints and Climbs" are in scope.
+- **Do NOT modify the existing strand briefs** even if their "do not transcribe CLAUDE.md" caveats become stale. They're release-bound working artifacts.
+- AskUserQuestion at material disagreements (3 expected per Workflow step 6).
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md` — this strand IS the resolution of one source-of-truth-framing case
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_issues_describe_problems.md` — follow-up issues describe problems, not solutions
+- `feedback_unfold_tdf26_work_fit.md` — capture observations for unfold but do not open unfold work from inside
+- `feedback_explicit_mechanics.md` — when documenting the new pointer paragraphs, prefer explicit human-understandable explanations
+- `project_unfold_legible_model.md` — light-tier observations during this strand may go to memory; heavy-tier portable patterns wait for the unfold note
+
+## 10. Stop when
+
+- CLAUDE.md tables removed; pointer paragraphs in place.
+- Follow-up issues filed for every missing-data fact (Ussel-as-town, total-distance reconciliation, cycling-context-paragraph homes, others surfaced).
+- Cross-reference sweep complete; obsolete pointers updated or accepted as harmless.
+- All verification commands green.
+- Audit table in PR body listing every deprecated row, its resolution (JSON home / follow-up issue #), and any drift flagged for awareness.
+- PR open against milestone v1.4.19 closing #491.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-claude-md` once the PR has merged.
+- Final report posted to publisher: PR link, audit-table summary, follow-up issues filed, any open questions surfaced.

--- a/docs/strands/strand-climb-data.md
+++ b/docs/strands/strand-climb-data.md
@@ -1,0 +1,137 @@
+# Strand — Climb data corrections (#490 + #492)
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md). Closes [#490](https://github.com/gneeek/tdf26/issues/490) and [#492](https://github.com/gneeek/tdf26/issues/492).
+
+## 1. Goal
+
+Two paired data-layer corrections for climb data, bundled because they share the same files and the same per-source-assertion pattern:
+
+- **#490** — Resolve the Côte des Naves gradient discrepancy (`data/points-config.json` says 5.6%; CLAUDE.md and ASO sources say ~6.7%; elevation-derived value should win). Add a per-source assertion that points-config climb gradients must match elevation-derived gradient within tolerance — extending the #474 pattern.
+- **#492** — Add an `aso: true|false` flag to the points-config schema; document non-ASO regional climbs as first-class. Puy de Lachaud is the worked example (regional climb, on the route, not on the ASO categorised list).
+
+Milestone v1.4.19. Companion to the CLAUDE.md deprecation strand (#491). Together these three issues are the data-layer regime expansion (#474/#475/#476 set the regime; #490/#491/#492 expand it).
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-490-492-climb-data /home/jhs/code/tdf26-climb-data main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+- Read `data/elevation/segment-*.json` and `data/segments/segment-*.gpx` directly to compute elevation-derived gradients. These are the bedrock for #490's resolution.
+- Read `data/points-config.json` for current values. **Do not** treat the points-config gradient as canonical when in doubt — that's exactly the source-of-truth framing problem at the heart of #490.
+- Read CLAUDE.md "Categorized Climbs" only for cross-reference (treat as drift-prone per #491).
+- Read external ASO climb data via web (the official Tour de France 2026 Stage 9 climb list, or per-stage announcements) only as a tie-breaker — capture the URL in the PR body.
+- Verify against the segment polyline per `feedback_on_route_checks.md` when checking climb start/summit positions.
+
+## 4. Target issues
+
+- **Closes [#490](https://github.com/gneeek/tdf26/issues/490)** — Côte des Naves gradient + per-source assertion
+- **Closes [#492](https://github.com/gneeek/tdf26/issues/492)** — `aso` flag schema + non-ASO posture
+- **Read-only awareness** of #491 (CLAUDE.md deprecation, separate strand) and #474/#475/#476 (data-layer regime — assertions, schema, audit-trail). #475's schema work is the home for #492's `aso` flag.
+
+## 5. Workflow
+
+### #490 — Côte des Naves gradient
+
+1. **Locate the climb in elevation data.** From `data/segments.json`, Côte des Naves is on segment 11 (km 70-78). Read `data/elevation/segment-11.json` for the climb's km span.
+2. **Compute the elevation-derived gradient.** Climb start and summit positions per CLAUDE.md content notes / ASO references; use the polyline + elevation pairs to compute average gradient over the climb span. Document the math in PR body.
+3. **Compare:**
+   - `data/points-config.json` claims 5.6%
+   - CLAUDE.md (drift-prone) claims 6.7% (text)
+   - Elevation-derived: compute
+   - ASO 2026 Stage 9 official: research; capture URL
+4. **Decide canonical value.** Likely the elevation-derived value wins. If ASO disagrees significantly, flag as material disagreement (AskUserQuestion checkpoint) — could indicate climb-span definition disagreement (where does Côte des Naves start vs summit), not gradient error.
+5. **Update `data/points-config.json`** with the canonical value.
+6. **Add per-source assertion** in `tests/utils/` (mirrors PR #448's `tests/utils/stage-totals.test.ts` pattern):
+   - For each climb in points-config, the assertion: `points_config[climb].gradient` must match elevation-derived gradient within tolerance (suggested ±0.3 percentage points; tune empirically).
+   - Test fires red against pre-fix Naves value (5.6% vs ~6.7%); green after fix.
+
+### #492 — `aso: true|false` flag
+
+1. **Update points-config schema** (`tests/data/points-config.schema.json` or wherever #475 landed schemas — verify location) to add `aso: boolean` as a required field on each climb.
+2. **Update `data/points-config.json`** with the flag for every climb. Determine ASO membership by checking the official ASO 2026 Stage 9 climb list:
+   - On ASO list (set `aso: true`): expect to include Côte de Lagleygeolle, Côte de Miel, Côte des Naves, Suc au May, Côte de la Croix de Pey, Mont Bessou, Côte des Gardes (verify each).
+   - Not on ASO list (set `aso: false`): Puy Boubou (verify), Puy de Lachaud (the worked example for #492).
+3. **Update any code that consumes points-config** to handle the new field. Likely callers:
+   - `utils/stage-totals.ts` (per PR #448's per-source assertion territory)
+   - `processing/validate_points.py` (the spanning-climb invariant)
+   - Any code that displays climb categorisation in the UI (search for `CATEGORIZED_CLIMBS` / `points-config` usage)
+4. **Document non-ASO posture.** A short paragraph in the schema description, the relevant code's docstring, or the project wiki — pick the venue based on existing convention. Suggested text: "Non-ASO regional climbs are first-class entries in points-config; UI and per-segment narrative may treat them differently from ASO-categorised climbs (e.g., omit from the official KOM points display) but they remain in the data layer."
+
+### Both — verification
+
+5. Run validators; demonstrate red-green for both new assertions.
+
+## 6. Verification commands
+
+- `npm test` — must pass; specifically the new `tests/utils/<gradient>.test.ts` (or wherever the assertion lands).
+- `python3 processing/validate_points.py` — must pass; spanning-climb invariant unaffected.
+- `python3 scripts/validate_entries.py` — defensive (no entry frontmatter touched).
+- `npm run build` — must pass (UI may consume points-config; defensive against the new schema field breaking things).
+
+**Demonstrate red-green for both assertions:**
+
+- #490: revert `data/points-config.json` Naves gradient to 5.6%, run gradient-tolerance test → red. Restore canonical value → green.
+- #492: revert one climb's `aso` field, run schema validation → red. Restore → green.
+
+Do not commit the artificial breakage — temporary local revert + rerun, restore before commit (per `feedback_strand_worktree_path.md` brief-rendering of the v1.4.11 Strand C technique).
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `data/points-config.json` — gradient correction + `aso` field on all climbs
+  - `tests/data/points-config.schema.json` (or wherever #475 schemas live) — schema with new `aso` required field
+  - `tests/utils/<new-gradient-assertion>.test.ts` — per-source assertion extending PR #448's pattern
+  - `utils/stage-totals.ts` (only if it needs to consume the new `aso` field; likely yes)
+  - Any documentation home for the non-ASO posture (schema description, README, or wiki)
+- **What this strand reads:**
+  - `data/segments.json`, `data/segments/segment-*.gpx`, `data/elevation/segment-*.json` — for elevation-derived gradient
+  - CLAUDE.md "Categorized Climbs" — drift-prone, cross-reference only
+  - External ASO climb list — research
+  - `tests/utils/stage-totals.test.ts` — pattern reference
+- **What this strand must NOT touch:**
+  - `CLAUDE.md` — the deprecation strand (#491) owns it; do not edit even if the gradient narrative becomes stale.
+  - `data/segments.json` — not in scope; if drift surfaces, file follow-up issue.
+  - `data/elevation/segment-*.json` — read only (elevation source data does not change here).
+  - `data/segments/segment-*.gpx` — master geometry, no edits.
+- **Cross-strand collisions:**
+  - **CLAUDE.md deprecation strand (#491)** runs concurrently in v1.4.19. It only reads `data/points-config.json` and writes CLAUDE.md. No file overlap with this strand. If the deprecation strand lands first, this strand's PR doesn't need to update CLAUDE.md (it's already pointer-only). If this strand lands first, the deprecation strand's pointer paragraph for "Categorized Climbs" should mention the new `aso` flag posture — that's a small text update on the second strand's side.
+  - **Verification strands (#478, #498, #499, #500)** all run validate_points.py; if this strand's per-source-assertion test changes the points-config schema, the verification strands inherit the new requirement. Acceptable — they should be updating climb data anyway, and the assertion catches drift.
+
+## 8. Scope discipline
+
+- **Do not touch CLAUDE.md.** That's the deprecation strand's job.
+- **Do not add or remove climbs from points-config.** Only correct the gradient on Côte des Naves and add the `aso` flag to all existing climbs. New climbs (e.g., a regional climb the route passes over that isn't currently in points-config) → file new issue.
+- **Do not extend the per-source assertion to other gradient drift this strand notices.** Document the drift in PR body or new follow-up issues; the gradient-tolerance assertion catches all drift once it's in place anyway.
+- AskUserQuestion at material disagreements:
+  - Elevation-derived gradient differs significantly from ASO official.
+  - Climb-span definition disagreement (e.g., where does Côte des Naves start).
+  - Canonical posture for non-ASO climbs in UI (display them with the same chip as ASO? different style? omit?).
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_on_route_checks.md` — polylines for spatial checks
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_issues_describe_problems.md` — any new gradient drift surfaced gets filed as a problem, not fixed inline
+- Per-source-of-truth detector (v1.4.8 retro rule, first instance landed in PR #448 — this strand's assertion is the second instance; worth naming in PR body)
+
+## 10. Stop when
+
+- `data/points-config.json` Côte des Naves gradient corrected to canonical (elevation-derived) value.
+- `data/points-config.json` has `aso: true|false` on every climb; values verified against ASO official Stage 9 climb list.
+- Schema (`tests/data/points-config.schema.json` or equivalent) updated with `aso` required boolean.
+- Per-source assertion test exists in `tests/utils/`; demonstrates red-green against both #490 and #492 broken states.
+- Non-ASO posture documented in agreed venue.
+- All verification commands green.
+- PR body audit table: per climb, ASO-or-not, current gradient, elevation-derived gradient, canonical value.
+- PR open against milestone v1.4.19 closing #490 and #492.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-climb-data` once the PR has merged.
+- Final report posted to publisher: PR link, audit-table summary, any open questions surfaced (e.g., further gradient drift caught by the new assertion).

--- a/docs/strands/strand-i-verify-segs-14-16.md
+++ b/docs/strands/strand-i-verify-segs-14-16.md
@@ -1,0 +1,107 @@
+# Strand I — Data verification: segments 14-16 (km 92-112)
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md). Closes [#478](https://github.com/gneeek/tdf26/issues/478).
+
+## 1. Goal
+
+Verify the data layer (route geometry, town/attraction positions, climb data, historical-tdf entries) for segments 14, 15, 16 — covering km 92-112, the Monédières heath through the Suc au May summit. Output is a single PR landing audit-row corrections plus a per-claim audit table in the PR body, mirroring PR #470 (segs 9-10) and PR #489 (segs 11-13).
+
+Verification must land before seg 14 drafting starts. Seg 14 publishes Wed 2026-05-20 per twice-weekly cadence. Milestone v1.4.19.
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-478-segs-14-16-verify /home/jhs/code/tdf26-verify-14-16 main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+- Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/points-config.json`, `data/historical-tdf.json`, `data/segments/segment-14.gpx` / `segment-15.gpx` / `segment-16.gpx` directly.
+- **Do NOT use CLAUDE.md's known-waypoints km positions as canon.** That table has confirmed staleness per [#491](https://github.com/gneeek/tdf26/issues/491) — segs 17-26 issue-filing today (2026-05-07) surfaced fresh evidence: Bugeat ~12 km drift, Meymac ~13 km drift, Ussel not tagged, total km 182 vs 185. Treat CLAUDE.md narrative project context as fine; treat its tabular data as drift-prone.
+- Use polylines (not segment endpoints) for proximity checks per `feedback_on_route_checks.md`.
+- The `validate_points.py` spanning-climb invariant (`Suc au May` and any other multi-segment climb must appear in every segment whose km range overlaps the climb span) is enforced. Run it.
+
+## 4. Target issues
+
+- **Closes [#478](https://github.com/gneeek/tdf26/issues/478)** — single tracking issue, milestone v1.4.19.
+- Findings outside the audit's owned write-set (e.g., points-config gradient drift in seg 14-16 corridor) → file new issues, do not fix inline.
+
+## 5. Workflow per issue
+
+The verification follows the audit-script + manual-cross-check pattern (3rd worked instance: PR #470, PR #489, this PR).
+
+1. **Mechanical pass:** run `python3 processing/audit_segment_data.py --segments 14,15,16` (or equivalent flag — verify the script's CLI; if no segment-filter flag exists, run full and grep). Capture output.
+2. **Manual elevation-profile pass:** read `data/elevation/segment-14.json` / `segment-15.json` / `segment-16.json`. Cross-check Suc au May summit position (~km 105, elevation 903m, 3.8km at 7.7% per CLAUDE.md content notes — verify against actual elevation data, not the table).
+3. **Manual polyline pass:** for every town in `data/segments.json`'s towns list and every attraction in `data/attractions.json` for segs 14-16, confirm position against the segment GPX polyline.
+4. **Cross-source check:** `data/historical-tdf.json` for any Suc au May / Monédières TdF history. Verify 2024 Stage 11 Vingegaard/Pogačar adjacency keying (per CLAUDE.md it's segs 14-16 terrain — this is one of the keying claims to confirm).
+5. **Build per-claim audit table** in the PR body, same shape as PR #489: claim, source, current value, audit finding, action.
+6. **Apply corrections** to the data files; do not change the elevation source data without comment.
+7. **Use AskUserQuestion at material disagreements** — the seg 11-13 strand surfaced override calls (Tintignac, 1987 Chaumeil seg keying); expect 1-2 such checkpoints in this strand.
+
+## 6. Verification commands
+
+- `npm test` — must pass.
+- `python3 processing/validate_points.py` — must pass; runs the spanning-climb invariant.
+- `python3 scripts/validate_entries.py` — defensive (no entry frontmatter touched, but verifies nothing leaked).
+- `python3 processing/audit_segment_data.py` — the mechanical pass; output drives the audit table.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `data/segments.json` (segs 14, 15, 16 entries only)
+  - `data/attractions.json` (only attraction entries with km in 92-112 range)
+  - `data/historical-tdf.json` (additions / corrections for the segs 14-16 corridor — 1987 Chaumeil men's + women's TdF entries keyed to **seg 15** per #478 deferral comment from PR #489)
+  - PR body audit table
+- **What this strand reads:**
+  - All `data/*` for cross-reference
+  - `content/research/segs-11-13-block-research.md` if Strand D has landed (for any cross-segment notes flagged for segs 14-16)
+  - `data/elevation/segment-14.json` / `15.json` / `16.json`
+  - `data/segments/segment-14.gpx` / `15.gpx` / `16.gpx`
+  - CLAUDE.md *narrative* sections only (not the known-waypoints table).
+- **What this strand must NOT touch:**
+  - `data/segments.json` outside segs 14-16 (#491 / #498 / #499 / #500 own those).
+  - `data/points-config.json` (per-source assertions are Strand B's territory; if drift surfaces here in seg 14-16 climbs, file a new issue).
+  - `content/entries/14-*.md` / `15-*.md` / `16-*.md` (drafting strands own these; do not touch beyond verifying frontmatter is internally consistent).
+  - CLAUDE.md (the staleness fix is #491's job).
+- **Cross-strand collisions:** Strand D content research touches `content/research/`, no overlap. Strand E/F/G drafting strands haven't been spawned. If any sibling strand modifies `data/historical-tdf.json` mid-flight (unlikely), rebase and resolve by additive merge.
+
+## 8. Scope discipline
+
+- **Findings outside scope go to new issues, not inline fixes.** Examples expected: points-config gradient drift in seg 14-16 climbs (sister to #490); CLAUDE.md known-waypoints km drift confirmation (joins #491); attraction proximity outliers.
+- Override decisions (e.g., publisher chooses to keep an attraction the audit would deprecate) get an AskUserQuestion checkpoint with documented reasoning in PR body.
+- Do not poach segs 17+ content (Treignac, Plateau de Millevaches, Mont Bessou, Meymac, Ussel) — those belong to #498 / #499 / #500.
+- Do not draft prose for any segment in this strand. Prose is the drafting strand's job.
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_on_route_checks.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_content_change_rule.md`
+- `feedback_pre_publish_scrutiny.md`
+- `project_meymac_voice.md` (seg 24 reservation; not these segs but informs surrounding planning — and #500 flagged that Meymac may actually be in seg 25 not 24, so the voice plan could shift; do not act on that here)
+- `project_barthes_callback.md` (seg 6/12/15 arc — seg 15 is the "develops" beat; the verification surfaces but does not consume Sainte-Fortunade / Monédières framing)
+
+## 10. Stop when
+
+- PR open against milestone v1.4.19 closing #478.
+- Per-claim audit table in PR body.
+- All verification commands green.
+- 1987 Chaumeil men's + women's TdF entries added to `data/historical-tdf.json` keyed to **seg 15** (NOT seg 13 — CLAUDE.md staleness corrected at PR #489 time, captured in #478).
+- Any new findings filed as separate issues with sister-issue cross-links.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-verify-14-16` once the PR has merged.
+- Final report posted to publisher: PR link, audit-table summary, any open questions surfaced for the segs 14-16 drafting strands (which spawn after seg 13 drafting completes).
+
+## Carryforwards reserved for downstream drafting strands
+
+These belong to drafting, not verification — capture in the audit table for awareness but do **not** consume them in this strand:
+
+- **Sainte-Fortunade / Monédières framing** (Léon Dautrement: "un morceau de Monédières perdu dans le bas Limousin"; cherry microclimate near Château de la Morguie ripens 15 days earlier than southern reaches). Drafter chooses placement among segs 14/15/16.
+- **Bourrée des Monédières** / *Boreïa de las botelhas* (1950, René Lafeuille) — music thread for seg 14 or 15.
+- **Suc au May** as the Monédières summit (~km 105, 903m, 3.8km at 7.7%) — marquee climb of the segment block, content peak for seg 15 prose.
+- **2024 Stage 11 Vingegaard/Pogačar** terrain adjacency — verify keying during audit; drafter consumes for the cycling-context section of the relevant entry.

--- a/docs/strands/strand-publish-sh-fail-fast.md
+++ b/docs/strands/strand-publish-sh-fail-fast.md
@@ -1,0 +1,176 @@
+# Strand — `publish.sh` fail-fast policy per failure mode (#496)
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md). Closes [#496](https://github.com/gneeek/tdf26/issues/496) (scope-expanded at planning).
+
+## 1. Goal
+
+Apply three fixes to `scripts/publish.sh` so that the seg 11 publish on Sun 2026-05-10 does not recur the three failure modes that fired during the v1.4.17 publish on Wed 2026-05-06. Fixes ship in one PR with the policy framing documented at top-of-file: **first-fire is a feature; recurrence is a bug; surface vs. autonomous-recovery is decided per failure mode.**
+
+**Hard deadline:** PR must merge before Sun 2026-05-10 afternoon. Seg 11 publish window. Milestone v1.4.18.
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-496-publish-sh-fail-fast /home/jhs/code/tdf26-publish-sh main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+Source-of-truth posture is light for this strand because the work is code-only (no segment data or content involved). Read:
+
+- `scripts/publish.sh` — the production publish path; treat with care
+- `scripts/create-release.sh` — sibling tag/release script (for understanding the post-merge step)
+- The v1.4.17 publish-day log if it's preserved in the WORK-LOG or wiki — for failure-mode evidence (timestamps, exact error strings)
+- Any shell utilities `publish.sh` sources
+
+Per `feedback_no_regex_in_bash.md`: regex backreferences in bash-embedded Python produce control chars; if a fix needs string manipulation, prefer pure bash or a small Python script over shell-piped `sed`/`awk`/`python -c` with backreferences.
+
+## 4. Target issues
+
+- **Closes [#496](https://github.com/gneeek/tdf26/issues/496)** — scope expanded at planning to fail-fast policy per failure mode; covers all three failure modes from this cycle.
+- No new follow-up issues expected (the chore-deploy script wrapper carryforward stays deferred per planning decision; do not bundle it).
+
+## 5. Workflow
+
+### Fix 1: Idempotent `gh pr merge --squash`
+
+**Failure:** during v1.4.17 publish, PR #495 was auto-merged at 22:10:04Z (seconds after the script pushed the branch); script's `gh pr merge --squash` then failed because the PR was no longer in a mergeable state, and `set -e` killed Step 10 before tag/release could run.
+
+**Fix:**
+- Locate the `gh pr merge --squash` call in `scripts/publish.sh` (Step 9).
+- Wrap the call so that "already merged" is treated as success. Two reasonable approaches:
+  - Pre-check: `gh pr view <PR_NUMBER> --json state` and only call `gh pr merge --squash` if state is `OPEN`.
+  - Post-check: call `gh pr merge --squash`, capture exit code; on non-zero, re-check state via `gh pr view`; if `MERGED`, return 0; otherwise propagate the error.
+- Pre-check is cheaper (one extra API call only when relevant); post-check handles a wider race window. Either works for this fix; pre-check probably wins.
+- Print a clear message ("PR #N was already merged before our merge call — treating as success.") so future debug logs make the path obvious.
+
+### Fix 2: `dataCutoff` non-interactive fallback
+
+**Failure:** Step 3's `read -rp "Enter dataCutoff: " DATA_CUTOFF` returned non-zero with no TTY (background invocation); `set -e` killed the script before the fallback `DATA_CUTOFF=$(date +%Y-%m-%d)` could fire.
+
+**Fix:**
+- Locate the `read -rp` line (Step 3).
+- Replace the conditional so that read failure (no TTY OR empty input) falls through to the fallback. Two patterns:
+  - `read -rp "..." DATA_CUTOFF || true` followed by `DATA_CUTOFF=${DATA_CUTOFF:-$(date +%Y-%m-%d)}` — single-line idiom.
+  - Test for TTY first: `if [ -t 0 ]; then read -rp "..." DATA_CUTOFF; fi` then `DATA_CUTOFF=${DATA_CUTOFF:-$(date +%Y-%m-%d)}` — avoids the `|| true` swallow.
+- Pattern 2 is cleaner because it explicitly says "interactive only if TTY"; pattern 1 is one fewer line.
+
+### Fix 3: SSH agent stutter
+
+**Failure:** benign — `sign_and_send_pubkey: signing failed for ED25519 ...: agent refused operation` printed before `Deploy complete.` on the next line. Deploy succeeded; the noise was misleading in publish-day logs.
+
+**Fix:**
+- Locate the `rsync` / `ssh` call(s) in Step 8.
+- Either:
+  - `|| true` on the offending command (simplest; risk: also swallows real failures unless we're careful) — only acceptable if the deploy itself has its own success-confirmation that runs after.
+  - Pipe stderr through a filter to drop the known benign line: `2> >(grep -v 'agent refused operation' >&2)`. More precise; preserves real errors.
+- Filter is preferred. Document in code comment why this stderr filter exists, citing the v1.4.17 publish.
+
+### Top-of-file policy comment
+
+After the three fixes, add a short comment block at the top of `scripts/publish.sh` capturing the policy:
+
+```
+# publish.sh fail-fast policy
+# - First-time failure modes surface and halt the script (set -e by default).
+# - Recurrence-class failures become autonomous-recovery: the script handles them
+#   without halting because publisher investigation is complete.
+# - Specific recurrence-handled cases (per #496):
+#   1. PR auto-merged before script's own merge call.
+#   2. read -rp with no TTY for dataCutoff.
+#   3. SSH agent benign-noise stutter on deploy.
+# - When a new failure mode fires for the first time, halt and surface; promote to
+#   autonomous-recovery in the next planning if it recurs.
+```
+
+### Test pass
+
+For each fix, demonstrate red-green where possible:
+
+- **Fix 1:** simulate "already merged" by manually merging a test PR before invoking the merge call. Confirm script returns 0 and continues to Step 10.
+- **Fix 2:** invoke publish.sh in a non-interactive shell (`bash -c './scripts/publish.sh ...'` or via cron / nohup). Confirm fallback fires.
+- **Fix 3:** harder to reproduce the agent stutter on demand; instead confirm filter doesn't swallow real SSH errors by deliberately breaking the rsync target.
+
+Do not commit artificial breakage. Document the test method in PR body so the publisher can re-verify.
+
+## 6. Verification commands
+
+- `npm test` — must pass (publish.sh isn't covered by JS tests, but defensive).
+- `bash -n scripts/publish.sh` — syntax check; must pass.
+- `shellcheck scripts/publish.sh` — if shellcheck is installed; lint warnings should not regress vs main. Not a hard requirement.
+- **Dry-run test:** `./scripts/publish.sh --help` (or whatever flag exists for help / dry-run) should still work and print expected text.
+- **Three fix demonstrations** as outlined in Workflow step "Test pass" — manual but documented in PR body.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `scripts/publish.sh`
+- **What this strand reads:**
+  - `scripts/create-release.sh` (for context on what comes after the merge step)
+  - Any shell utilities sourced from publish.sh (e.g., common helpers if any)
+  - The v1.4.17 publish-day log / WORK-LOG.md / wiki Retro v1.4.17 page for failure-mode evidence
+- **What this strand must NOT touch:**
+  - `scripts/create-release.sh` — separate sibling script; chore-deploy wrapper deferred per planning.
+  - `processing/*.py` — out of scope.
+  - `data/*.json`, `content/entries/*.md` — out of scope.
+- **Cross-strand collisions:**
+  - **No concurrent strands touch `scripts/publish.sh`.** The CLAUDE.md deprecation, climb-data, segs-14-16 verification, and skill-creation strands all stay clear of `scripts/`.
+  - **Seg 11 publish on Sun depends on this strand merging first.** If this strand slips past Sun morning, the seg 11 publish either re-fires the three failures or has to be done with manual workarounds (the same workarounds that worked for v1.4.17). Plan: PR open by Fri evening, merged by Sat afternoon at latest.
+
+## 8. Scope discipline
+
+- **Three fixes only.** Do not refactor publish.sh structure; do not introduce new features (chore-deploy wrapper deferred).
+- **Do not bundle in unrelated cleanup.** If shellcheck flags pre-existing issues outside the three fixes, leave them; file a follow-up issue.
+- **AskUserQuestion at material disagreements** — likely candidates:
+  - Pattern 1 vs pattern 2 for the dataCutoff fix (the brief recommends pattern 2; if implementation reveals a wrinkle, surface).
+  - Pre-check vs post-check for the auto-merge race (brief recommends pre-check; surface if the gh CLI behaves unexpectedly).
+  - Stderr filter shape for the SSH stutter (brief recommends grep-based filter; surface if it hides real errors).
+
+## 9. Memories that apply
+
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_no_regex_in_bash.md` — relevant if any fix considers shell-piped Python with regex backreferences (avoid)
+- `project_publisher_onboarding.md` — the publish.sh fix is publisher-experience; the second publisher arriving after April 14 should not be the one to discover these failure modes
+- `feedback_pre_publish_scrutiny.md` — the publish-window context that the policy framing reflects
+
+## 10. Stop when
+
+- Three fixes landed in `scripts/publish.sh`.
+- Top-of-file policy comment captures the framing.
+- Each fix demonstrated to behave correctly (test method documented in PR body).
+- Verification commands green.
+- PR open against milestone v1.4.18 closing #496.
+- **PR merged before Sun 2026-05-10 afternoon.** This is a hard deadline; the strand is not "done" until merged in time for seg 11 publish.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-publish-sh` once the PR has merged.
+- Final report posted to publisher: PR link, three-fix demonstration summary, any open questions surfaced for the seg 11 publish window.
+
+## 11. Notes for next retro (post-execution, 2026-05-07)
+
+PR opened as #512. Worktree removed before merge per publisher request; recreate with the explicit-path form from §2 if review feedback lands.
+
+### What went well
+- Brief was specific enough to execute end-to-end without surfacing material disagreements. The three "pattern A vs pattern B" decisions in §8 all resolved to the brief's recommendation.
+- Filter-precision smoke for Fix 3 (synthesize a stderr stream containing the benign line + two real-error lines, pipe through `grep -v <signature> >&2`, confirm only benign was dropped) caught the question "does this swallow real errors" cheaply, without needing the actual race condition.
+- Red-green smoke for Fix 2 (`bash -c '...' < /dev/null` with and without the TTY gate) gave a clean before/after exit code in two runs.
+- Worktree explicit-path form from `feedback_strand_worktree_path.md` worked first try.
+
+### What was challenging / surprising
+- **Brief drift from code.** §5 Fix 3 said "locate the rsync / ssh call(s) in Step 8"; actual code is `tar | ssh`, no rsync. Filter still applies, but the placement (inside `if ! ( set -o pipefail; … )`) was non-trivial. Worth noting for future briefs that the source-of-truth scan should sample the actual file before committing to terminology.
+- **Self-induced GPG snag.** I added `-c commit.gpgsign=true` to the commit invocation unprompted; local config doesn't enforce signing, and the forced sign tripped on a missing secret key. Removing the flag resolved it. Lesson: do not add git flags that aren't in the brief or current config.
+- **git config / memory mismatch.** Local `user.email` is `gneeek@gmail.com`; auto-memory says `gneeek@proton.me`. The commit went through with the gmail address. Worth a one-line confirm at next planning: is the gmail address intentional for tdf26 commits?
+- **Worktree needs its own `npm install`.** Not surprising, but adds ~30s to first-test for any fresh worktree. If multi-strand worktree work continues, a shared `node_modules` symlink or pnpm-style store would shave that.
+
+### What we learned
+- **Anchor stderr filters on the full benign signature, not the trailing fragment.** `'sign_and_send_pubkey: signing failed.*agent refused operation'` is small enough to be cheap and specific enough that "agent refused operation" appearing in some other context (real auth failure, key revocation) won't be silently swallowed. Template for future filters in publish.sh.
+- **`if [ -t 0 ]; then read; fi` beats `read … || true`.** Both work, but the explicit TTY check reads at-a-glance as "interactive only," whereas `|| true` reads as "swallow any failure" — same behavior, worse intent signal. Apply to any future non-interactive-aware prompts.
+- **Pre-check is the right shape for race-class fixes.** One extra API call only when the race could matter; no swallowed errors. Better than retry-on-failure in a place where the expected outcome is success.
+
+### What we lack
+- **No CI coverage for publish.sh.** Three of these fixes (the `gh pr` race, the no-TTY read, the ssh stderr stutter) cannot be exercised in a JS/Vitest run. Fix 1 in particular gets its first live verification on the seg 11 publish 2026-05-10 — that's a production-only test. A thin smoke harness (mock `gh`, mock `ssh`, drive publish.sh through its decision branches with set fixtures) would shorten the loop on future publish.sh fixes. Candidate carry-debt item.
+- **shellcheck not installed locally.** Brief listed it as soft requirement; couldn't run. Next planning could decide whether it goes in the dev-env bootstrap.
+- **The auto-merge race fix cannot be unit-tested without faking `gh`.** This is a sub-case of the publish.sh-CI gap above; calling it out separately because it's the one that bit us in v1.4.17 and the next time it bites it will reveal a different fault we don't currently have coverage for.

--- a/docs/strands/strand-publisher-contract.md
+++ b/docs/strands/strand-publisher-contract.md
@@ -1,0 +1,78 @@
+# Strand: Publisher / developer-experience contract
+
+Wiki-edit strand. Authored at the 2026-05-07 planning session (Topic 8a). Not yet spawned.
+
+## 1. Goal
+
+Land a "Publisher / developer-experience contract" section on the How-We-Work wiki page. The contract has been implicit because the publisher and developer are the same person; it becomes a social fact when a second publisher is active (per `project_publisher_onboarding.md`). The deliverable is wiki text that a new publisher can read once and operate from. Milestone: v1.4.20 placeholder; promote to v1.4.19 if the second publisher's first ship arrives sooner.
+
+## 2. Filesystem posture
+
+This strand does not touch the tdf26 repo's source tree. It edits the GitHub wiki (separate git repo at `gneeek/tdf26.wiki.git`).
+
+- Clone the wiki repo:
+  ```
+  git clone https://github.com/gneeek/tdf26.wiki.git /home/jhs/code/tdf26-wiki
+  ```
+- Edit `How-We-Work.md` (or whatever the existing page is named — verify on first checkout).
+- No worktree against the main repo is needed.
+
+## 3. Source-of-truth posture
+
+The wiki is the canonical home for process documentation. Cross-link from in-repo docs/strands/README.md or CLAUDE.md only when readers need a process pointer; do not duplicate the contract text.
+
+## 4. Target deliverables
+
+One wiki edit. Optionally one in-repo `docs/strands/README.md` cross-link.
+
+No corresponding GitHub issue at brief time; if scope grows, file an umbrella issue per `feedback_issues_describe_problems.md`.
+
+## 5. Workflow
+
+1. Read the current How-We-Work page; identify the existing structure and where the contract section fits.
+2. Draft the contract sections inline (see "Contract content" below).
+3. Apply the late-add / hotpatch policy carryforward from Topic 11 if it lands as part of this strand (otherwise leave a placeholder + link).
+4. Commit and push to the wiki.
+5. Update the planning-notes file's "next planning" carryforward to remove the publisher-contract line once the wiki edit lands.
+
+## 6. Verification
+
+- Open the wiki page in a browser; read the new section as if you were a new publisher onboarding.
+- Have the publisher review the draft before final push (this strand should run in publisher-paced single-strand mode — see `feedback_multi_strand_session_checkpoints.md` and Topic 8b sharpening).
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `tdf26.wiki.git`'s How-We-Work page section on the contract.
+- **Reads:** `feedback_multi_strand_session_checkpoints.md`, `feedback_carry_debt_reading.md`, `feedback_pre_publish_scrutiny.md`, `feedback_content_change_rule.md`, `project_contributor_is_customer.md`, `project_publisher_onboarding.md`, `feedback_issues_describe_problems.md`, `feedback_roadmap_style.md`.
+- **Must not touch:** in-repo files except a possible one-line cross-link in `docs/strands/README.md`.
+
+## 8. Scope discipline
+
+Contract content (what the contract should cover):
+
+1. **Publisher's promises to the developer / agents:** scope decisions made before strand spawn; AskUserQuestion checkpoints answered within the session window; out-of-scope items filed as issues rather than inlined; retro participation.
+2. **Developer's / agents' promises to the publisher:** issues describe problems (not solutions); strand briefs declare ownership and read-set; PRs include test plan; visible/blast-radius actions confirmed before execution; pair-writing disclosure on content entries (per `project_disclosure_practice.md`).
+3. **Workflow expectations:** publication cadence (twice weekly Sun/Wed mornings per `project_schedule.md`); pre-publish scrutiny window (per `feedback_pre_publish_scrutiny.md`); content-change rule (published entries are fixed; corrections forward, per `feedback_content_change_rule.md`); strand-brief template (per `docs/strands/STRAND-BRIEF-TEMPLATE.md`).
+4. **Decision authority:** Tully owns tdf26 tie-breaking; Piers owns unfold tie-breaking (per `feedback_agent_ownership.md`); both voices contribute on every decision.
+5. **Late-add / hotpatch policy:** carryforward from Topic 11 (already RESOLVED 2026-05-06 per planning-notes). Lift the existing policy text into the contract and add a one-line cross-reference if the policy lives elsewhere.
+6. **Retro / planning rhythm:** retro filed after each tag; planning continuation per `docs/planning/NEXT.md` singleton convention; planning-notes file (`memory/project_next_planning_notes.md`) is the durable input/output.
+
+Out of scope:
+- New process invention. The contract is descriptive of current practice, not aspirational.
+- Code or data changes.
+- Slip-rate tally artifact (Topic 11 sub-item, separate strand candidate).
+
+## 9. Memories that apply
+
+Loaded above (§7). Most load-bearing for content authoring:
+
+- `feedback_multi_strand_session_checkpoints.md` (post-2026-05-07 sharpening; wiki-edit strand should run publisher-paced)
+- `project_publisher_onboarding.md` (verify currency before drafting; second-publisher status changes)
+- `feedback_explicit_mechanics.md` (unpack vocabulary; human publishers are part of the audience)
+
+## 10. Stop when
+
+- Wiki page edit pushed; URL handed to publisher.
+- Planning-notes file's publisher-contract carryforward line removed.
+- One GitHub issue filed if scope grew beyond the wiki edit (per `feedback_issues_describe_problems.md`).
+- No worktree to clean up (wiki repo lives outside `/home/jhs/code/tdf26-*`).

--- a/docs/strands/strand-seg-11-drafting.md
+++ b/docs/strands/strand-seg-11-drafting.md
@@ -1,0 +1,99 @@
+# Strand: Seg 11 drafting
+
+Drafting strand for segment 11 of the tdf26 travelogue. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Land a draft of `content/entries/11-*.md` ready for the publisher's pre-publish review window before Sun 2026-05-10 morning. Segment 11 covers km 70–77 (Tulle exit through Côte de Naves, Stade Auzelou departure to Naves approach). Milestone: **v1.4.18**. Hard deadline: Sat 2026-05-09 evening, so the publisher has Sunday morning for pre-publish review and the publish.sh window.
+
+This strand runs in **publisher-paced single-strand mode** — checkpoint via AskUserQuestion at editorial micro-decisions (image picks, prose corrections, frontmatter choices, voice register), per `feedback_multi_strand_session_checkpoints.md` (sharpening 2026-05-07: publisher-paced is the validated counter-instance to the auto-mode rule).
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/seg-11-draft /home/jhs/code/tdf26-seg-11 main
+```
+
+- Run from outside the repo (or via `git -C`); see `feedback_strand_worktree_path.md`.
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: before each `git add` / `git commit`, run `git branch --show-current` and confirm `feature/seg-11-draft` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+- For all factual claims about route geometry, Tulle / Naves coordinates, Côte de Naves climb data: read `data/segments.json`, `data/town-coords.json`, `data/competition/points-config.json`, `data/segments/segment-11.gpx` directly.
+- Read `data/historical-tdf.json` for any TdF history claims keyed to seg 11 — the segs 11-13 verification (PR #489) and the seg 14-16 verification (PR #514) have populated this file; trust the data layer over CLAUDE.md narrative.
+- **Do not transcribe CLAUDE.md known-waypoints km positions** — the table was deprecated in PR #507. CLAUDE.md narrative project context remains useful; CLAUDE.md tabular data is not bedrock.
+- The seg 11-13 block research dossier `content/research/segs-11-13-block-research.md` (committed via PR #501, with the Bol d'Or correction landed today) is your primary content source. Treat as research input, not as authoritative for facts you'll publish — verify cited sources against the URLs given.
+- Per `feedback_brief_content_is_carryforward.md` (drafted today): facts cited in this brief are scaffolding; verify against authoritative sources before writing them into prose.
+
+## 4. Target deliverable
+
+One markdown entry at `content/entries/11-*.md` (slug TBD; suggest `11-tulle-exit-auzelou` or similar):
+
+- **Frontmatter**: `segment: 11`, `title`, `subtitle`, `publishDate: 2026-05-10`, `kmStart`, `kmEnd`, `gpxFile`, `elevationData`, `images: []` (publisher fills at publish time), `weather: null`, `draft: true`.
+- **Body**: ~800–1200 words narrative weaving the eight content topics from CLAUDE.md, with the carryforwards below.
+- **Sources section**: `## Sources` per `feedback_sources_section.md`. List external URLs backing factual claims.
+- **Disclosure footer**: per `project_disclosure_practice.md` — pair-writing + voice register.
+
+## 5. Workflow
+
+The strand does not re-do block research (Strand D's dossier covers seg 11). It selects beats from the dossier, drafts, and verifies sources.
+
+1. **Read the dossier section for seg 11** in `content/research/segs-11-13-block-research.md`. Note the primary frame (Auzelou cyclosportive departure, 99–100 days before the stage, amateur-cycling embedded), the cultural anchors (Tintignac carnyx archaeology), the climb (Côte de Naves at km 77.45), and reserved-for-later items (Sainte-Fortunade / Monédières / Bourrée — those are seg 14+).
+2. **Voice register checkpoint** (AskUserQuestion). The publisher chooses voice at draft time. Sample candidates: `tdf26-voice` skill provides options. Do not start drafting until voice is fixed.
+3. **Draft the entry** in the chosen voice. Keep the Auzelou frame primary; embed the L'Agglomérée 2026 cyclosportive (which ran 5 April 2026, two days after seg 1 published) as the connective tissue; surface Tintignac as the cultural depth; treat Côte de Naves as the climbing beat.
+4. **Verify factual claims**. Names, dates, distances, attributions — every one cited in the dossier should be re-checked against its source URL before going into prose. Per `feedback_brief_content_is_carryforward.md` — the dossier is research input, not bedrock.
+5. **AskUserQuestion checkpoints** (publisher-paced). Trigger at: voice register pick (step 2); image pick (publisher selects after draft lands; the strand does not pick images); any factual call where two reasonable readings exist; any forward-looking thread (the Barthes seg-12 callback per `project_barthes_callback.md` opens at seg 12; do not plant in seg 11).
+6. **Sources section** — list the external URLs the prose stands on. Per `feedback_sources_section.md`.
+7. **Disclosure footer** — voice register + pair-writing per `project_disclosure_practice.md`.
+8. **Open a PR** against `main`. Title: `seg 11 draft: <subtitle>`. Body: voice picked, dossier sources used, AskUserQuestion checkpoints fired, any out-of-scope items filed as new issues.
+
+## 6. Verification
+
+- `npm test` — 186+ tests pass against the new entry (existing assertions guard frontmatter shape).
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — entry passes shape checks.
+- `python3 processing/validate_points.py` — no regression.
+- Dev preview at `/entries/seg-11-*`: render renders, ElevationChart shows the Naves climb, image gallery placeholder renders without errors.
+- **Pre-publish scrutiny window** — per `feedback_pre_publish_scrutiny.md`: verify geography, attribution, image rights before publish.sh runs Sunday morning.
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `content/entries/11-*.md`. Possibly small additions to `data/historical-tdf.json` if the dossier surfaces a missing event keyed to seg 11 — but default is to file an issue per `feedback_issues_describe_problems.md`.
+- **Reads:** `content/research/segs-11-13-block-research.md`, `data/segments.json`, `data/historical-tdf.json`, `data/town-coords.json`, `data/competition/points-config.json`, `data/segments/segment-11.gpx`, `data/elevation/segment-11.json`.
+- **Must NOT touch:** any `content/entries/12-*.md` or `content/entries/13-*.md` (separate drafting strands). Sainte-Fortunade / Monédières / Léon Dautrement / Bourrée des Monédières — reserved for seg 14+. Suc au May, Mont Bessou, Meymac voices, Saintsbury — out of scope.
+- **Cross-strand collisions:** other strands (`tdf26-tour-history`, `tdf26-publisher-contract`) running in parallel do not modify the same files. No expected collision.
+
+## 8. Scope discipline
+
+- File new issues for: factual gaps surfaced during draft (e.g., a dossier claim that fails source verification), images that need licensing chase, dev-preview render bugs.
+- Do **not** retroactively edit prior entries (per `feedback_content_change_rule.md`). Corrections forward.
+- Do **not** poach seg 12 / 13 content. The dossier marks these explicitly.
+- The Barthes-arc seg-6/12/15 callback: seg 11 is not in that arc — do not plant. Seg 12 is the "tightens" beat (per `project_barthes_callback.md`).
+- Literary references after seg 6 use proper footnotes per `feedback_literary_footnotes.md`. Seg 11 is post-6, so apply.
+
+## 9. Memories that apply
+
+- `feedback_content_workflow.md` — research-then-discuss-then-draft (research = dossier; discussion = voice + checkpoint AskUserQuestion calls; draft last)
+- `feedback_multi_strand_session_checkpoints.md` (post-2026-05-07 sharpening — this strand is publisher-paced)
+- `feedback_brief_content_is_carryforward.md` (verify dossier facts; brief is scaffolding)
+- `feedback_source_of_truth_framing.md`
+- `feedback_on_route_checks.md`
+- `feedback_pre_publish_scrutiny.md`
+- `feedback_literary_footnotes.md`
+- `feedback_sources_section.md`
+- `feedback_content_change_rule.md`
+- `project_disclosure_practice.md`
+- `project_barthes_callback.md` (don't plant in seg 11)
+- `project_meymac_voice.md` (out of scope; awareness only)
+- `project_contributor_is_customer.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_strand_worktree_path.md`
+
+## 10. Stop when
+
+- Draft committed to `feature/seg-11-draft`, PR opened against `main`.
+- All AskUserQuestion checkpoints fired and answered; publisher has reviewed prose at least once.
+- `npm test` + entry validators green.
+- Dev preview rendered without error.
+- **Cleanup (you run this, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-seg-11` once the PR has merged. The strand owns its own worktree teardown; do not leave it for the publisher to discover.
+- Final report posted to publisher: PR link, voice picked, AskUserQuestion checkpoints fired, any open issues filed.

--- a/docs/strands/strand-skill-strand-brief.md
+++ b/docs/strands/strand-skill-strand-brief.md
@@ -1,0 +1,106 @@
+# Strand — `/strand-brief` skill creation
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md).
+
+## 1. Goal
+
+Build a `/strand-brief` skill that generates a strand-brief markdown file populated from `docs/strands/STRAND-BRIEF-TEMPLATE.md`. The skill asks the publisher for strand specifics (id, type, target issues, milestone, sibling strands) and writes the file at `docs/strands/strand-<id>.md` with template sections pre-filled with sensible defaults for the strand's type.
+
+This is the path-C skill half of the strand-brief template work decided at planning. The file template already exists; this strand adds the skill that consumes it.
+
+Milestone: v1.4.18 (decided 2026-05-07; if scope lands cleanly during the session it can ship in the same release as the template file). If it slips, move to v1.4.19.
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/strand-brief-skill /home/jhs/code/tdf26-skill main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+- The template file `docs/strands/STRAND-BRIEF-TEMPLATE.md` is the authoritative section structure. The skill MUST read it at invocation time, not bake the structure into the skill prompt — that way the file remains the single source of truth and edits to the template don't require skill changes.
+- Read existing strand briefs (`docs/strands/strand-*.md`) for examples of how each section gets filled. Particularly: `strand-d-content-research.md` (research-only), `strand-a-verify.md` (data verification), `strand-a-content.md` (research+drafts).
+
+## 4. Target issues
+
+File a single tracking issue at start: `Build /strand-brief skill (path C complement to STRAND-BRIEF-TEMPLATE.md)`, milestone v1.4.18. PR closes it.
+
+## 5. Workflow
+
+1. **Decide skill location.** Existing tdf26 skills (`retro`, `tdf26-voice`) live at user-level `/home/jhs/.claude/skills/`. Default to that location: `/home/jhs/.claude/skills/strand-brief/SKILL.md`. If the publisher wants project-level scoping at strand spawn time, route to `/home/jhs/code/tdf26/.claude/skills/strand-brief/SKILL.md` instead.
+2. **Skill design.** The skill should:
+   - Read `docs/strands/STRAND-BRIEF-TEMPLATE.md` from the working directory.
+   - Prompt the publisher (via AskUserQuestion or skill arguments) for:
+     - Strand identifier (e.g., `e-seg11-draft`, `i-segs-14-16-verify`).
+     - Strand type, picked from: research-only / data-verification / content-draft / code / mixed.
+     - Goal (one paragraph, free text).
+     - Target issue numbers (comma-separated).
+     - Milestone (e.g., `v1.4.18`, `v1.4.19`, `v1.4.20`).
+     - Sibling strands running in parallel (for cross-strand sharing notes, free text or skip).
+     - Worktree absolute path (default suggested based on identifier: `/home/jhs/code/tdf26-<strand-letter>`).
+     - Branch name (default: `feature/<strand-id>`).
+   - Generate the brief file at `docs/strands/strand-<id>.md`, pre-filled per strand type:
+     - Filesystem posture: standard form with the chosen worktree path + branch.
+     - Source-of-truth posture: standard for this repo.
+     - Target issues: rendered from the input.
+     - Workflow per issue: type-specific stub (research = research-plan stub; data = audit-pass stub; content-draft = draft-cadence stub with publisher checkpoints; code = workflow-per-issue stub).
+     - Verification commands: type-specific stub (data → `npm test` + `python3 processing/validate_points.py`; content → `python3 scripts/validate_entries.py`; code → `npm test` + `npm run build`).
+     - Cross-strand sharing notes: stub with the load-bearing reminder, populated with sibling-strand info if provided.
+     - Scope discipline: standard text.
+     - Memories that apply: type-specific defaults.
+     - Stop when: standard cleanup sub-bullet + a placeholder for type-specific exit criteria.
+3. **Test the skill.** Run it once to generate a sample brief; visually compare against `strand-d-content-research.md` and `strand-a-verify.md` for shape. Iterate until output matches the template structure cleanly.
+4. **Document the skill.** Add a short usage example to `docs/strands/README.md` (one line under the Template section pointing at the skill), and to the skill's own description.
+
+## 6. Verification commands
+
+- Skill invocation produces a valid markdown file at the expected path.
+- Generated file passes a simple grep for all 10 section headers from the template (`### 1. Goal`, `### 2. Filesystem posture`, etc.).
+- Generated file's defaults match the template's recommendations (worktree command form, no `.claude` symlink, cleanup-ownership sub-bullet).
+- Existing repo tests still pass: `npm test`, `python3 scripts/validate_entries.py`.
+
+Demonstrate red-green: generate a brief; intentionally remove section 7 from the template; re-generate and confirm the missing section shows in the output (template-driven, not hardcoded). Then restore template.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `/home/jhs/.claude/skills/strand-brief/SKILL.md` (or `.claude/skills/strand-brief/SKILL.md` if project-scoped)
+  - Optional small additions to `docs/strands/README.md` (one-line usage example).
+- **What this strand reads:**
+  - `docs/strands/STRAND-BRIEF-TEMPLATE.md` (template source of truth)
+  - `docs/strands/strand-*.md` (existing brief examples)
+  - Existing skills under `/home/jhs/.claude/skills/{retro,tdf26-voice}/SKILL.md` for skill-authoring conventions.
+- **What this strand must NOT touch:**
+  - `docs/strands/STRAND-BRIEF-TEMPLATE.md` (source of truth; do not edit during skill work — if the template needs an edit, file a separate issue and do it as a sibling or follow-up strand).
+  - Existing `docs/strands/strand-*.md` working briefs.
+- **Cross-strand collisions:** none expected. The publication-cycle strands (D content research, future E/F/G drafting strands, future I segs-14-16 verification strand) are all consumers of the template, not editors.
+
+## 8. Scope discipline
+
+- **Skill should not enforce policy** (e.g., "always use worktree X for letter Y"). It generates the brief; the publisher reviews.
+- **Skill should not bake structure into prompt.** Read the template file each invocation.
+- **No retroactive update of existing briefs.** They are working artifacts; per `docs/strands/README.md` lifecycle, they're removed when their release ships.
+- File new issues for any template improvements surfaced during skill testing rather than edit `STRAND-BRIEF-TEMPLATE.md` from this strand.
+- AskUserQuestion checkpoints are appropriate at material-disagreement points only; do not rubber-stamp every section.
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md` — template is the source; skill reads it.
+- `feedback_strand_worktree_path.md` — explicit-path form is what the skill should suggest by default.
+- `feedback_shared_tree_branch_verification.md` — generated brief should include the verification rule.
+- `feedback_explicit_mechanics.md` — skill output should be human-readable; no clever abstractions hiding the structure.
+- `feedback_unfold_tdf26_work_fit.md` — this strand is tdf26-craft; cross-link the unfold note candidate ([unfold#40](https://github.com/gneeek/unfold/issues/40)) for awareness but don't open new unfold work from inside this strand.
+
+## 10. Stop when
+
+- Skill exists at agreed location and is callable.
+- Sample invocation produces a brief that visually matches the template structure.
+- Section-presence test passes (all 10 section headers appear in generated output).
+- One-line skill usage hint added to `docs/strands/README.md`.
+- PR open and tagged on milestone v1.4.18.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-skill` once the work has merged.
+- Final report posted to publisher: PR link, sample brief output snippet, any open questions for the publisher to refine the skill's defaults.

--- a/docs/strands/strand-tour-history-research.md
+++ b/docs/strands/strand-tour-history-research.md
@@ -1,0 +1,124 @@
+# Strand — Tour-history feature research (#502)
+
+**Start here:** [Roadmap → Now](https://github.com/gneeek/tdf26/wiki/Roadmap). This brief decided at planning session 2026-05-07. Follows [STRAND-BRIEF-TEMPLATE.md](STRAND-BRIEF-TEMPLATE.md). Feeds [#502](https://github.com/gneeek/tdf26/issues/502) (umbrella); does not close it.
+
+## 1. Goal
+
+Produce a research dossier for the `/tour-history` feature — phase 1 of the research-then-discuss-then-draft sequence decided at the 2026-05-07 planning. The dossier expands the existing `data/historical-tdf.json` corpus by surfacing new corridor-relevant Tour de France history, regional race history (Tour du Limousin, Paris-Corrèze, L'Agglomérée cyclosportive), photo/video source candidates, and any race-radio / commentary material that survives under licences compatible with this project.
+
+The dossier feeds the design-discussion phase (next planning session: layout, hero image, story arc, prominent-launch timing) and the subsequent draft phase (a sister strand that builds the `/tour-history` route page).
+
+Milestone v1.4.20 (placeholder; reshuffles when the prominent-launch timing pins a specific milestone).
+
+## 2. Filesystem posture
+
+Use the explicit-path worktree form:
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-502-tour-history-research /home/jhs/code/tdf26-tour-history main
+```
+
+Run from outside the repo. Do not symlink `.claude/`. Verify branch with `git branch --show-current` before each `git add`/`git commit`.
+
+## 3. Source-of-truth posture
+
+- **Read `data/historical-tdf.json` directly** as the starting corpus. It currently has 4 segment-group entries (segs [1,2], [10], [14,15,16], [25,26,27] — note the [25,26,27] entry has a known segment-27 bug filed as #503; the dossier should reference #503's resolution, not the buggy data).
+- **Read CLAUDE.md "References: Cycling History Along the Route"** for the catalogued URL bibliography. CLAUDE.md is the primary source of pre-vetted URLs for this corpus; the deprecation strand (#491) does NOT touch this section, only the "Known Waypoints and Climbs" tables, so this reference stays canonical.
+- **Read CLAUDE.md "References: Creative Commons Image Sources"** for image-source candidates per segment.
+- For any factual claim the dossier captures, cite the URL in the dossier's sources section.
+- Cross-check segment keying against `data/segments.json` (per `feedback_on_route_checks.md`) — if a Tour stage finished in Tulle, verify which segment Tulle is in **today** rather than transcribing CLAUDE.md.
+- Per `feedback_source_of_truth_framing.md`: this dossier itself is hand-curated and will be downstream of `data/historical-tdf.json` in the long run; the dossier should NOT become a parallel source-of-truth. Any addition that lands in `data/historical-tdf.json` does so via a separate strand (filed as a follow-up issue), not via this dossier.
+
+## 4. Target issues
+
+- **Feeds [#502](https://github.com/gneeek/tdf26/issues/502)** — umbrella for the Tour-history feature; this strand does not close it (subsequent draft + launch strands do).
+- **References [#503](https://github.com/gneeek/tdf26/issues/503)** — Paris-Corrèze segments-27 drift; flag in dossier; do not fix here.
+- **References [#483](https://github.com/gneeek/tdf26/issues/483)** — observability/instrumentation research sprint; the prominent launch is the measurement moment.
+- **Files new follow-up issues** for any new factual entries that should land in `data/historical-tdf.json`. Each follow-up describes the data-add as a problem ("X stage's connection to corridor segment Y is currently undocumented in `data/historical-tdf.json`") per `feedback_issues_describe_problems.md`.
+
+## 5. Workflow
+
+1. **Research subagent pass(es).** Spawn one or more general-purpose Agent subagents to research, structured by topic:
+   - **Tour de France stages with corridor connections.** Stages that started, finished, or passed within ~30 km of any segment 1-26. Targets: Brive (segs 1-2), Tulle (seg 10), Ussel (seg 26), Limoges/Périgueux (south-west adjacency), Aurillac/Clermont-Ferrand (south-east adjacency, including 2026 Stage 10 Aurillac→Le Lioran the day after Stage 9). Sources: bikeraceinfo.com, procyclingstats, Wikipedia stage pages, ASO archives. Look beyond the entries already in `data/historical-tdf.json`.
+   - **Tour du Limousin** — UCI 2.1 stage race since 1968, recently renamed Tour du Limousin-Périgord-Nouvelle-Aquitaine. Notable winners, route history through Corrèze, photographic / archival material.
+   - **Paris-Corrèze** — defunct UCI 2.1 race, 2000s. Final-edition results, Corrèze finishes, narrative arc of why it folded. Resolve the segment keying in the existing corpus entry (currently `[25, 26, 27]` — see #503).
+   - **L'Agglomérée cyclosportive (Apr 5 2026)** — amateur sportive on 40 km of the Stage 9 route including Suc au May. Most recent edition (just three months ago at planning time). Worth a callout in the dossier as a recent-amateur-event-on-the-actual-route hook.
+   - **2025 Tour de France** — most recent edition; check whether any stages had corridor relevance, and if so capture for the dossier.
+   - **Famous riders from Corrèze** — riders born in or strongly associated with Corrèze; their Tour records.
+   - **Resistance-era racing / post-war narrative** — the 1944 Tulle massacre is in seg 10's content; the post-war Tour's 1947 return and the corridor's role in restoring civic life is potential background colour. Bonus content if it surfaces.
+   - **Photo / video sources by event.** For each event in the dossier, name CC-licensed photo candidates (Wikimedia Commons by event/place categories) and video sources (Dailymotion ASO channel, YouTube CC reels, INA archive — note INA has GDPR cookie banner inside iframe per `reference_european_video_embeds.md`; prefer YouTube/Vimeo-hosted versions).
+   - **Race-radio / commentary quotes.** These are often hardest to source under CC. Capture promising URLs even if licensing is unclear; flag licensing as an open question per item.
+2. **Write the dossier** to `content/research/tour-history-research.md` (create directory if absent — gitignored at `content/research/` likely; check `.gitignore` first and update if necessary). Structure:
+   - **Per-event section** for every Tour-history event the dossier surfaces (existing + new). Include: year, stage / race, route or corridor connection, segment keying (verified against `data/segments.json`), summary narrative, source URLs, photo/video candidates with licence notes, any race-radio quote candidates with licence flag.
+   - **Regional race section** — Tour du Limousin, Paris-Corrèze, L'Agglomérée. Same per-event shape.
+   - **Story arcs** — the dossier's editorial recommendation for narrative threads the eventual `/tour-history` page could organise around (chronological, geographic, rider-centric, race-history-centric, etc.). 2-4 candidate arcs with brief rationale; decision deferred to design phase.
+   - **Hero-image candidates** — 3-6 candidate images with licence + attribution + URL, suitable for a feature-route hero. Decision deferred to design phase.
+   - **Sources** — every URL the dossier draws on, in one consolidated list (the dossier is the source-of-record for the eventual page's Sources surface).
+   - **Carryforwards out of scope** — anything the research surfaces that belongs in `data/historical-tdf.json` as a data-add (file follow-up issues for these), or in a future segment's content draft.
+3. **Open a PR** when the dossier is ready. PR body: short summary of what's in the dossier + which arcs the research recommends + links to follow-up issues filed.
+
+## 6. Verification commands
+
+These exist in this repo and should run clean before PR:
+
+- `npm test` — must pass.
+- `python3 scripts/validate_entries.py` — defensive (no entry frontmatter touched).
+- `npm run build` — defensive.
+
+If the dossier needs a new directory under `content/research/`, confirm `.gitignore` posture: if `content/research/` is gitignored, the dossier still ships in the PR by adding an exception or by moving to `docs/research/` (precedent set by Strand D's seg 11-13 dossier — match whichever location it landed at).
+
+URL fidelity: every URL cited in the dossier should resolve at write time. Use `curl -sI <url>` for fast spot-checks on suspicious links; not every URL needs a full fetch.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):**
+  - `content/research/tour-history-research.md` (or `docs/research/...` if .gitignore forces it; match Strand D's location convention).
+- **What this strand reads:**
+  - `data/historical-tdf.json` (the starting corpus)
+  - `data/segments.json`, `data/town-coords.json` (for segment-keying verification)
+  - CLAUDE.md "References: Cycling History Along the Route" + "References: Creative Commons Image Sources"
+  - External research sources (Wikipedia, ASO, Tour archives, Wikimedia Commons, etc.)
+- **What this strand must NOT touch:**
+  - `data/historical-tdf.json` — additions go through follow-up issues + later strand work, not inline.
+  - `content/entries/*.md` — published entries are fixed per `feedback_content_change_rule.md`.
+  - `data/segments.json`, `data/attractions.json`, etc. — out of scope.
+  - CLAUDE.md — narrative project context belongs to other strands (deprecation #491 owns the "Known Waypoints" tables, but the "References" sections stay; do not edit them).
+- **Cross-strand collisions:**
+  - **CLAUDE.md deprecation strand (#491)** runs concurrently in v1.4.19 and only edits CLAUDE.md "Known Waypoints and Climbs" subsection — does NOT touch the "References: Cycling History Along the Route" section that this strand reads. No collision.
+  - **#478 segs 14-16 verification strand** will be adding the 1987 Chaumeil men's + women's TdF entries to `data/historical-tdf.json` keyed to seg 15. Coordination: this dossier should reference 1987 Chaumeil as upcoming-data (cite #478's eventual landing), not insert it.
+  - **#503 historical-tdf.json segments-27 fix** is a v1.4.19 sibling — flag the bug in the dossier; do not fix the JSON inline; reference #503's eventual resolution.
+  - **Strand D content research (km 70-92)** completed in v1.4.18; check whether Strand D's dossier surfaces any Tour-history items relevant here — cross-link if so.
+
+## 8. Scope discipline
+
+- **No inline edits to `data/historical-tdf.json`.** Every new entry the research finds → file a follow-up issue; the data-add is a separate strand.
+- **No prose drafting for the eventual `/tour-history` page.** The dossier is research, not draft. Story arcs are recommendations; final narrative is design-phase + draft-phase work.
+- **No retroactive edits to published per-segment HistoricalContext content** (`feedback_content_change_rule.md`). If the research surfaces something that should have been in seg 1 / 2 / 10's HistoricalContext, capture it in the dossier as carryforward; the eventual `/tour-history` page can include it.
+- **AskUserQuestion at material disagreements** — likely candidates:
+  - Story-arc recommendation: which arc would the publisher rather see drafted?
+  - Hero-image candidate: which to feature?
+  - Coverage scope: should the dossier include adjacent-but-not-corridor history (Massif Central terrain, Pyrenees-as-foil, etc.) or stay strict-corridor-only?
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md` — dossier is hand-curated; do not let it become a parallel source-of-truth for the canonical data
+- `feedback_on_route_checks.md` — verify segment keying against polylines, not CLAUDE.md tabular data
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_issues_describe_problems.md` — follow-up issues describe data-gaps as problems, not solutions
+- `feedback_content_change_rule.md` — published entries are fixed
+- `feedback_sources_section.md` — dossier sources section is the seed for the eventual page's Sources surface
+- `feedback_literary_footnotes.md` — if the eventual `/tour-history` page draws on literary references, capture bibliographic context here
+- `reference_european_video_embeds.md` — INA / France Télévisions cookie-banner caveat
+- `reference_wikimedia_thumb_widths.md` — image-URL gotcha
+
+## 10. Stop when
+
+- Dossier file exists at the target path with all sections populated.
+- Sources section is complete (every factual claim in the dossier traces to a URL or named source).
+- Carryforwards-out-of-scope section names every data-add follow-up issue filed.
+- Story-arc recommendations and hero-image candidates documented for the design phase.
+- PR open and tagged on milestone v1.4.20, referencing #502 (does not close it).
+- Follow-up issues filed for each `data/historical-tdf.json` data-add the research uncovered.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-tour-history` once the PR has merged.
+- Final report posted to publisher: PR link, dossier path, story-arc recommendation count, hero-image candidate count, follow-up issues filed (count + numbers), any open questions surfaced for the design-phase planning conversation.


### PR DESCRIPTION
## Summary

Cleanup commit for the strand briefs that lived as untracked files on `main` since the 2026-05-06 + 2026-05-07 planning sessions. Bundles eight briefs and the planning continuation note.

## Already-shipped briefs (retro reference; sweep candidates post-v1.4.18 retro)

- `strand-publish-sh-fail-fast.md` (PR #512)
- `strand-skill-strand-brief.md` (PR #511)
- `strand-claude-md-deprecation.md` (PR #507)
- `strand-i-verify-segs-14-16.md` (PR #514)
- `strand-climb-data.md` (PR #516)

## Runnable briefs (next strand sessions)

- `strand-tour-history-research.md` — Session 1 commits already pushed to `feature/issue-502-tour-history-research`; Session 2 pending
- `strand-publisher-contract.md` — Topic 8a 2026-05-07; not yet spawned
- `strand-seg-11-drafting.md` — Sun 2026-05-10 publish; voice register picked at draft time

## Planning continuation

- `docs/planning/NEXT.md` — singleton; will archive at session close per Topic 15 sweep

## Test plan

- [x] `git status` clean after merge
- [x] All eight briefs accessible from new worktrees branched off `main`