### PR TITLE
chore(docs): commit follow-up strand briefs (#441, #519, #522)

### DIFF
--- a/docs/strands/strand-441-codeql-shell-injection.md
+++ b/docs/strands/strand-441-codeql-shell-injection.md
@@ -1,0 +1,101 @@
+# Strand: CodeQL shell-injection fix (#441)
+
+Security fix strand. Authored at the 2026-05-07 planning session resume (Topic 14 backlog sweep).
+
+## 1. Goal
+
+Clear the three open CodeQL shell-command-injection alerts on admin server APIs by switching from shell-mode `execSync` to argument-array form (`execFileSync` or `execSync` with array args). Closes [#441](https://github.com/gneeek/tdf26/issues/441). Milestone: **v1.4.19**. No deadline; fits as a small strand or single PR.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-441-shell-injection-fix /home/jhs/code/tdf26-441 main
+```
+
+- Run from outside the repo (or via `git -C`); see `feedback_strand_worktree_path.md`.
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: before each `git add` / `git commit`, run `git branch --show-current` and confirm `feature/issue-441-shell-injection-fix` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+- The three CodeQL alert pages are the canonical fix references. Read them first:
+  - [#11 — server/api/images-suggest.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/11)
+  - [#12 — server/api/publish.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/12)
+  - [#13 — server/api/riders.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/13)
+- Read each affected file before editing. Per `feedback_brief_content_is_carryforward.md`: the shapes described in §5 below are this brief's understanding — verify against current code before treating them as bedrock.
+
+## 4. Target issues
+
+- [#441](https://github.com/gneeek/tdf26/issues/441) — admin server APIs build shell commands from environment paths. Closes after the three alerts clear and the PR merges.
+
+## 5. Workflow
+
+The three sites have similar shape but each needs its own treatment. Read all three first, then refactor in any order. The pattern: replace `execSync(<single-string>, { shell: ... })` with `execFileSync(<file>, <args-array>, <options>)` so no shell is invoked.
+
+### 5a. `server/api/publish.post.ts` (line 15)
+
+Currently a `run(label, cmd)` helper that calls `execSync(cmd, { cwd, timeout, encoding, shell: '/bin/bash' })`. Three call sites: rider-stats, weather (env-derived `apiKey` interpolated), and any others present at execution time. Refactor:
+
+- Change `run` signature to `run(label: string, file: string, args: string[])`.
+- Body uses `execFileSync(file, args, { cwd: projectDir, timeout: 60000, encoding: 'utf8' })` — drop the `shell:` option.
+- Update each call site to pass the venv Python path as `file` and the script + args as the array. Example: `run('Rider Stats', venvPython, ['processing/rider_stats.py', '--daily-log', '...', '--rider-config', '...', '--output', '...'])`.
+- The weather case interpolates `apiKey` — make sure it's a separate array element, not concatenated into a flag string.
+
+### 5b. `server/api/images-suggest.post.ts` (line 18)
+
+Currently `execSync(\`${venvPython} ${script} --segments-json ... --segment ${segment}\`, { timeout, encoding })` — segment comes from the request body. Refactor:
+
+- `execFileSync(venvPython, [script, '--segments-json', segmentsJson, '--output-dir', outputDir, '--segment', String(segment)], { timeout: 30000, encoding: 'utf8' })`.
+- `String(segment)` is the right coercion — segment may be `0` or a number, and the array form forwards the literal string to argv. Reject non-numeric values earlier in the handler if not already done.
+
+### 5c. `server/api/riders.post.ts` (line 9)
+
+Currently builds `[venvPython, scriptPath, ...args]` then JSON.stringify-joins them and passes as a single string to `execSync(cmd, { stdio })`. The JSON.stringify dance was a partial mitigation; the array-form fix supersedes it. Refactor:
+
+- Drop the `cmd = [...].map(...).join(' ')` line.
+- `execFileSync(venvPython, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })`.
+
+### 5d. After all three are refactored
+
+- Run `npm test` — 186+ tests pass against the refactor (these endpoints aren't covered by JS unit tests; defensive).
+- Run a manual smoke for each admin endpoint locally (`npm run dev`, hit `/admin/...`, confirm same behavior). Record the smoke evidence in the PR test plan.
+- Open PR against `main`. Title: `fix(security): switch admin execSync calls to arg-array form (closes #441)`. Body: list each file's before/after pattern, link the three CodeQL alerts, state that no behavior change is intended.
+- After merge, watch the CodeQL re-scan — all three alerts should clear automatically. If any remains open, investigate whether a residual shell-mode call slipped through.
+
+## 6. Verification
+
+- `npm test` green (186+ tests).
+- `npx nuxt prepare` (in worktree) to ensure no type errors.
+- Manual smoke per §5d.
+- CodeQL alerts #11, #12, #13 clear after PR merge. (CodeQL runs on PR-open and on push-to-main; results visible at `gh api repos/gneeek/tdf26/code-scanning/alerts`.)
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `server/api/images-suggest.post.ts`, `server/api/publish.post.ts`, `server/api/riders.post.ts`. Possibly a small shared helper if the three refactors collapse cleanly into one — but default is keep the refactors local; do not create a `runPythonScript` utility unless it falls out naturally.
+- **Reads:** the three files above; `processing/.venv/bin/python` path conventions; the CodeQL alert pages.
+- **Must NOT touch:** `scripts/publish.sh` (separate territory; the seg 11 ship Sun 2026-05-10 must not be disturbed); content/entries; data files; the seg-11 / publisher-contract / tour-history strands' file regions.
+- **Cross-strand collisions:** none expected. Admin endpoints are isolated from the parallel work.
+
+## 8. Scope discipline
+
+- Three alerts only. Do not refactor admin endpoints beyond the shell-mode fix.
+- File new issues for any other security findings encountered (e.g., other `execSync` calls or `eval`-shaped patterns) per `feedback_issues_describe_problems.md`.
+- Do not introduce a new helper module just to share the `execFileSync` invocation — that's premature abstraction; three local refactors is fine.
+- If the smoke test surfaces a behavior change (e.g., env-var interpolation broke because of a quoting subtlety), pause and AskUserQuestion before adjusting.
+
+## 9. Memories that apply
+
+- `feedback_brief_content_is_carryforward.md` (verify the shapes described in §5 against current code)
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_assertion_bug_class.md` (consider whether to add a lint or test that catches future shell-mode regressions — out of scope for this strand but worth filing as a follow-up if the publisher endorses it)
+- `feedback_pre_publish_scrutiny.md` (security-adjacent work in publish-day territory; treat carefully)
+
+## 10. Stop when
+
+- Three CodeQL alerts cleared on a fresh scan against `main`.
+- `npm test` green.
+- Manual smoke green for each of the three admin endpoints.
+- PR opened, reviewed, merged.
+- **Cleanup (you run this, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-441` once the PR has merged. The strand owns its own worktree teardown.
+- Final report posted to publisher: PR link, before/after pattern per file, smoke evidence, any follow-up issues filed.

--- a/docs/strands/strand-519-date-based-tags.md
+++ b/docs/strands/strand-519-date-based-tags.md
@@ -1,0 +1,121 @@
+# Strand: Date-based release tag migration (#519)
+
+Infrastructure / process strand. Authored at the 2026-05-07 planning session resume (Topic 9a follow-through).
+
+## 1. Goal
+
+Migrate release tags from semver (`v1.4.x`) to date-based on the next production deploy. Closes [#519](https://github.com/gneeek/tdf26/issues/519). No firm milestone — the strand should land before the seg 11 ship Sun 2026-05-10 if format-decision and implementation are quick, otherwise on the Wed 2026-05-13 / next ship after that. Existing `v1.4.x` tags stay as historical record per the planning decision.
+
+This strand is *publisher-paced single-strand mode* — the format decision is the load-bearing AskUserQuestion checkpoint and shouldn't be pre-decided.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-519-date-based-tags /home/jhs/code/tdf26-519 main
+```
+
+- Run from outside the repo (or via `git -C`); see `feedback_strand_worktree_path.md`.
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: before each `git add` / `git commit`, run `git branch --show-current` and confirm `feature/issue-519-date-based-tags` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+- `project_release_tagging.md` (memory) is the canonical rule for tagging policy. The 2026-05-07 edit captured the date-based decision; this strand is the implementation.
+- `scripts/publish.sh` is the load-bearing code: line ~104 currently validates `^v[0-9]+\.[0-9]+\.[0-9]+$`. The migration changes this regex.
+- Per `feedback_brief_content_is_carryforward.md`: the file-line citations and shapes in §5 below are this brief's understanding — verify against current code at strand start.
+
+## 4. Target issues
+
+- [#519](https://github.com/gneeek/tdf26/issues/519) — switch release tags from semver to date-based. Closes after the new format is decided, `publish.sh` migration lands, the next production deploy uses the new format, and the existing tags are confirmed as preserved.
+
+## 5. Workflow
+
+### 5a. Decide the tag format (AskUserQuestion checkpoint — do not pre-decide)
+
+Three plausible candidates; the publisher chooses. Each has tradeoffs:
+
+| Format | Example | Pros | Cons |
+|---|---|---|---|
+| **ISO week** | `2026-W19` (with `.1`/`.2` if multiple deploys per week) | Aligns with twice-weekly publication cadence; one tag per week is the natural scale; week boundaries match retro windows | Less immediately legible to non-ISO-week audiences; may need leading-zero discipline (`W05` vs `W5`) |
+| **Calendar date** | `2026-05-10` (with `.1`/`.2` if multiple deploys same day) | Most legible; sortable lexically; common convention | Two deploys same day need a counter; format is otherwise correct ISO-8601 but git tag chars are fine |
+| **Date + sequence** | `2026.05.10.1` | Explicit counter from day 1; sorts cleanly | Verbose; `.` chars in tags may interact awkwardly with some tooling |
+
+Read the publisher's existing memory (`project_release_tagging.md`) before asking — they may already have a leaning. The decision is also tied to the planning-notes carryforward "Date-based milestone naming follow-up" (whether existing v1.4.18/v1.4.19/v1.4.20 milestones get renamed); this strand defers the milestone-rename decision (out of scope).
+
+### 5b. Update the `publish.sh` regex and help text
+
+After the format is decided:
+
+- Edit `scripts/publish.sh` line ~104 (`^v[0-9]+\.[0-9]+\.[0-9]+$` regex) to accept the new format. Decision: replace the regex outright (clean break) or accept *both* old and new during a transition window (defensive). Recommended: clean break — existing tags are historical record, new tags use the new format, no in-flight semver tags need accepting.
+- Update the `--help` text (line ~55, line ~63) to show the new format example.
+- Update the usage line at the top of the file (line ~6) similarly.
+- Smoke: invoke `./scripts/publish.sh --release-tag <bad-format>` and confirm the validation rejects with the new error message.
+
+### 5c. Optional helper: `scripts/next-tag.sh`
+
+If the format chosen has a deterministic "next tag" (e.g. ISO-week or date), a tiny helper script can generate the next valid tag automatically so the publisher doesn't have to type it. Decision via AskUserQuestion at the publisher's option. Default: skip the helper this strand; defer to a follow-up issue if needed.
+
+### 5d. Validate against the seg 11 publish (or next deploy)
+
+The next production deploy will be the first under the new scheme. Verify:
+
+- The new format passes `publish.sh` validation.
+- The tag lands on GitHub.
+- A GitHub Release renders with the new tag name.
+- No tooling that consumes tags breaks — `gh release list`, the deploy workflow (currently doesn't trigger on tags per CI inspection, but verify), any external watchers.
+
+### 5e. Update memory and CLAUDE.md narrative references
+
+- `project_release_tagging.md` — confirm the existing edit's wording matches the format decided in 5a (or amend if it doesn't).
+- CLAUDE.md narrative references to versioning are minimal but check; do not edit content/entries (per `feedback_content_change_rule.md`).
+- The planning-notes file's "Date-based milestone naming follow-up" carryforward stays open — this strand only addresses tags, not milestones.
+
+### 5f. Open the PR
+
+- Title: `infra: switch release tags from semver to <date-format> (closes #519)`.
+- Body: format chosen + rationale, regex before/after, help-text before/after, smoke evidence, link to #519, callout that existing v1.4.x tags are preserved.
+
+## 6. Verification
+
+- `bash -n scripts/publish.sh` — syntax OK.
+- `./scripts/publish.sh --help` — help text reflects new format.
+- Smoke: `./scripts/publish.sh --release-tag 2026-W19 --skip-release` (or equivalent for chosen format) validates as expected; bad format rejected.
+- `npm test` — green (no JS test depends on the tag format).
+- The next production deploy uses the new format (this verification spans into the deploy window — schedule the strand merge to leave a buffer before publish.sh runs).
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `scripts/publish.sh`. Possibly `scripts/next-tag.sh` if 5c lands. Possibly small edits to memory/`project_release_tagging.md`. Possibly small CLAUDE.md narrative edits.
+- **Reads:** `project_release_tagging.md`, the existing tag list (`git tag`), `.github/workflows/*.yml` to confirm CI doesn't trigger on tag patterns.
+- **Must NOT touch:** `content/entries/*` (content-change rule); `data/*` files; the seg-11 / publisher-contract / tour-history / Voices / #441 / #522 strand file regions.
+- **Cross-strand collisions with seg-11 drafting (in flight):** seg 11 publishes Sun 2026-05-10. This strand modifies `publish.sh` — the same script that runs the seg 11 publish. Coordination required:
+  - **Option A (preferred):** land this strand *before* the publish.sh fail-fast strand finishes consuming attention; the publish.sh changes are isolated to the regex and help text, low risk.
+  - **Option B:** land this strand *after* seg 11 publishes (seg 12 ship is Wed 2026-05-13; gives a window).
+  - The publisher decides via AskUserQuestion at strand start.
+
+## 8. Scope discipline
+
+- Tag format only. Do not refactor publish.sh structure.
+- Do not rename existing milestones (v1.4.18, v1.4.19, v1.4.20) — that's a separate follow-up flagged in planning-notes carryforwards.
+- Do not back-tag historical releases. v1.4.x tags stay as historical record.
+- Do not update wiki retro pages or other narrative-only references — the new scheme applies forward; old references are part of the project's history.
+- File new issues for any related work surfaced (e.g., a `next-tag.sh` helper if deferred; milestone-naming policy decision).
+
+## 9. Memories that apply
+
+- `project_release_tagging.md` (the canonical rule)
+- `feedback_brief_content_is_carryforward.md` (verify the file-line citations in §5 against current code)
+- `feedback_pre_publish_scrutiny.md` (this strand modifies the publish-day script; the rules apply)
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_no_regex_in_bash.md` (relevant if the format decision involves a tag-validation regex more complex than the current shape)
+
+## 10. Stop when
+
+- Format decided via AskUserQuestion checkpoint.
+- `scripts/publish.sh` regex + help text + usage line updated.
+- Smoke confirms validation works for new format and rejects old format.
+- PR opened, reviewed, merged.
+- The first production deploy under the new scheme lands a date-based tag on GitHub; existing v1.4.x tags confirmed preserved (`git tag` shows both).
+- **Cleanup (you run this, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-519` once the PR has merged.
+- Final report posted to publisher: PR link, format chosen, smoke evidence, the first new-format tag URL, any follow-ups filed.

--- a/docs/strands/strand-522-entrycard-extraction.md
+++ b/docs/strands/strand-522-entrycard-extraction.md
@@ -1,0 +1,112 @@
+# Strand: EntryCard component extraction (#522)
+
+Vue refactor strand. Authored at the 2026-05-07 planning session resume (Topic 13 item 1). Reader-uplift v1.4.19 work.
+
+## 1. Goal
+
+Extract a shared `components/EntryCard.vue` component and consume it from the existing call sites so future card-shaped reader-uplift work doesn't keep duplicating Tailwind class strings. Closes [#522](https://github.com/gneeek/tdf26/issues/522). Milestone: **v1.4.19**. No deadline.
+
+This is a structural refactor, not a feature change. Visual output should be byte-identical (or near-identical) before and after; the diff lives in component organization, not on the rendered page.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-522-entrycard /home/jhs/code/tdf26-522 main
+```
+
+- Run from outside the repo (or via `git -C`); see `feedback_strand_worktree_path.md`.
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: before each `git add` / `git commit`, run `git branch --show-current` and confirm `feature/issue-522-entrycard` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+- Read both call sites before editing. The duplication shape described in §5 is this brief's understanding — verify against current code per `feedback_brief_content_is_carryforward.md`.
+- The Tailwind class string is the canonical visual contract; preserve it exactly when extracting.
+
+## 4. Target issues
+
+- [#522](https://github.com/gneeek/tdf26/issues/522) — extract shared EntryCard. Closes after refactor + visual verification + PR merge.
+
+## 5. Workflow
+
+The card markup currently appears in two places that share a near-identical Tailwind class string but differ in inner content (thumbnail vs no thumbnail).
+
+### 5a. Identify the duplication
+
+- **Homepage** — `pages/index.vue` line 26: `<article>` block under "Latest Entries". Includes thumbnail (`<img v-if="entry.images && entry.images.length">`) before the text block. Link is `<NuxtLink :to="..." class="flex gap-4 items-start">`.
+- **Archive** — `pages/entries/index.vue` line 11: same `<article>` shape, no thumbnail. Link is `<NuxtLink :to="..." class="block">`.
+
+The shared class string on `<article>`:
+```
+group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent
+```
+
+Both render: optional thumbnail, segment+km label, title, optional subtitle, publishDate.
+
+### 5b. Component shape
+
+Create `components/EntryCard.vue` with:
+
+- **Props**: `entry: object` (the Nuxt Content entry doc — at minimum `path`, `_path`, `segment`, `kmStart`, `kmEnd`, `title`, `subtitle?`, `publishDate`, `images?`); `density: 'compact' | 'standard'` defaulting to `'standard'`.
+- **Behavior**:
+  - When `images?.length` is truthy and `density === 'standard'`, render the thumbnail block + `<NuxtLink class="flex gap-4 items-start">`.
+  - When no images or `density === 'compact'`, render the text-only block + `<NuxtLink class="block">`.
+  - Identical class string on the outer `<article>` in both modes.
+- **Date formatting**: import / receive `formatDate` consistently. Both call sites currently define their own — pick one canonical implementation (probably extract to `composables/useDate.ts` if it doesn't already live there) or accept the formatted string as a prop, whichever is cleaner.
+
+### 5c. Replace the two call sites
+
+- `pages/index.vue`: replace the `<article v-for="entry in entries">` block (lines ~26-50) with `<EntryCard v-for="entry in entries" :key="entry.path || entry._path" :entry="entry" />`. Default density='standard' shows thumbnails.
+- `pages/entries/index.vue`: replace the `<article v-for="entry in entries">` block (lines ~11-22) with `<EntryCard v-for="entry in entries" :key="entry.path || entry._path" :entry="entry" />`. Pass `density='compact'` if archive should stay text-only, OR drop the prop and let archive cards gain thumbnails (decide via AskUserQuestion checkpoint — see §8).
+
+### 5d. Visual verification
+
+Per `feedback_production_preview.md`: build production preview before merging visual PRs. Specifically:
+
+- `npm run build` succeeds.
+- `npm run preview` (or production-mode dev server) loads `/` and `/entries` without errors.
+- Pixel-diff or side-by-side compare the homepage Latest Entries section and the /entries archive page against `main`. Differences should be: zero (if archive stays text-only) or thumbnails appearing in archive (if density default chosen).
+- Test responsive breakpoints (sm, md, lg) — the Tailwind classes include responsive modifiers; the extraction should preserve them.
+
+### 5e. Open the PR
+
+- Title: `refactor: extract shared EntryCard component (closes #522)`.
+- Body: list the two call sites' before/after, screenshot of the homepage and archive at `main` vs branch, density-prop decision rationale, link to #522.
+
+## 6. Verification
+
+- `npm test` green (existing tests should continue passing — entry shape isn't changing).
+- `npm run build` succeeds; `npm run preview` renders both call sites.
+- Visual diff captured in PR body.
+- No console warnings on the rendered pages.
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** new `components/EntryCard.vue`, edits to `pages/index.vue` + `pages/entries/index.vue`. Possibly `composables/useDate.ts` or similar if extraction collapses out a shared formatter.
+- **Reads:** both pages above; existing components for naming-convention reference (`components/StageDetails.vue` is a similar reader-facing component).
+- **Must NOT touch:** `pages/entries/[...slug].vue` (separate prev/next nav, different visual element); `content/entries/*.md` (no entry frontmatter changes); the seg-11 / publisher-contract / tour-history strands' file regions.
+- **Cross-strand collisions:** none expected; the seg 11 drafting strand writes new entry markdown, which renders through these pages but doesn't touch their templates.
+
+## 8. Scope discipline
+
+- One AskUserQuestion checkpoint at §5b/5c: should the archive page gain thumbnails (drop density='compact') or stay text-only (keep the asymmetry)? The original Topic 13 framing offered "leave the asymmetry as a deliberate 'archive is denser' choice" — the publisher decides whether to preserve that or unify.
+- Do not add new entry-card features in this strand (e.g., reading time, related entries). Extraction only. Future card-shaped uplift work is the *third caller candidate* the issue references; this strand makes that work cheap, but doesn't include it.
+- File new issues for any drift discovered between the two existing call sites that isn't covered by the density prop.
+- Do not refactor unrelated components even if they appear similar. If a third call site is discovered (e.g., the prev/next nav at `pages/entries/[...slug].vue` lines 47-61, which is currently just text links), evaluate whether it benefits from the same component — but default is leave it; that nav is structurally different.
+
+## 9. Memories that apply
+
+- `feedback_brief_content_is_carryforward.md` (verify the duplication shape against current code)
+- `feedback_production_preview.md` (build production preview before merging)
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_parallel_source_of_truth_detector.md` (the duplication is itself a parallel-source-of-truth instance at the markup level — extracting it removes the drift surface)
+
+## 10. Stop when
+
+- `components/EntryCard.vue` exists; both call sites consume it.
+- Visual diff captured; publisher endorsed the density-prop decision.
+- `npm test` green; `npm run build` succeeds.
+- PR opened, reviewed, merged.
+- **Cleanup (you run this, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-522` once the PR has merged.
+- Final report posted to publisher: PR link, visual diff summary, density-prop decision, any follow-up issues filed.


### PR DESCRIPTION
## Summary

Three additional strand briefs authored at the 2026-05-07 planning resume after the initial briefs cleanup (PR #520). Same pattern: bundle to main so a parallel session can branch from main and inherit each brief.

## Briefs

- **`strand-441-codeql-shell-injection.md`** — security strand for the three CodeQL shell-mode `execSync` alerts in `server/api/{images-suggest,publish,riders}.post.ts`. Closes #441 when the strand runs. Milestone v1.4.19.
- **`strand-519-date-based-tags.md`** — Topic 9a follow-through; migrate release tags from semver to date-based on the next production deploy. Closes #519. No firm milestone.
- **`strand-522-entrycard-extraction.md`** — Topic 13 item 1; extract a shared `components/EntryCard.vue` consumed from `pages/index.vue` and `pages/entries/index.vue`. Closes #522. Milestone v1.4.19.

None spawned yet; this PR makes them branch-from-main reachable.

## Test plan

- [x] `git status` clean after merge
- [x] CI green