### PR TITLE
chore(docs): commit remaining strand briefs (seg 12/13 draft + verify 17-26)

### DIFF
--- a/docs/strands/strand-498-verify-segs-17-19.md
+++ b/docs/strands/strand-498-verify-segs-17-19.md
@@ -1,0 +1,87 @@
+# Strand: Verify segs 17-19 (#498)
+
+Data-verification strand. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Audit `data/*.json` against `data/segments/segment-{17,18,19}.gpx` and authoritative external sources for the segs 17–19 block (km ~112–128: Treignac, Côte de la Croix de Pey, the Plateau de Millevaches gateway). Closes [#498](https://github.com/gneeek/tdf26/issues/498). Milestone: [v1.4.20](https://github.com/gneeek/tdf26/milestone/20) (subject to renumbering per Topic 9a). Spawn timing: ~3 weeks from 2026-05-07 (publisher discretion). Mirrors PR #470 (segs 9-10), #489 (segs 11-13), #514 (segs 14-16).
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-498-segs-17-19-verify /home/jhs/code/tdf26-498 main
+```
+
+- Run from outside the repo, or use `git -C`. Do not run `git worktree add ...` from inside the repo (per `feedback_strand_worktree_path.md`).
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: run `git branch --show-current` immediately before each `git add` / `git commit` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-{17,18,19}.gpx` directly. Use the GPX polyline (not segment endpoints) for proximity checks (per `feedback_on_route_checks.md`). External sources: OSM, Wikipédia (FR/EN), Mérimée database, Tourisme Corrèze, regional press archives. Per `feedback_brief_content_is_carryforward.md`: facts cited in this brief are scaffolding; verify against authoritative sources before using.
+
+## 4. Target issues
+
+- [#498](https://github.com/gneeek/tdf26/issues/498) — data verification segs 17-19. Closes when the audit ships and any data corrections land.
+
+## 5. Workflow per issue
+
+Per-claim audit pass (pattern established by PRs #470, #489, #514):
+
+1. **GPX polyline integrity** for segs 17, 18, 19 — `data/segments/segment-NN.gpx` reads cleanly; km markers in `data/segments.json` match GPX cumulative distance.
+2. **Town keying** — `Treignac` (currently keyed to seg 18 per existing data; verify against polyline; the medieval bridge / granite town is the seg 18 anchor). Confirm any other towns the route transits or passes near in segs 17-19.
+3. **Climb keying** — Côte de la Croix de Pey (7.0 km @ 4.4% per current points-config; verify summit km against GPX local maximum and gradient against per-source detector pattern at `tests/utils/climb-gradient.test.ts`). Any other climbs in segs 17-19 currently in points-config.
+4. **`data/attractions.json`** — proximity (≤5 km from polyline), category, source URL, infoUrl. Treignac's medieval bridge is the obvious candidate; the Plateau de Millevaches gateway has fewer landmarks and may surface the "verified empty" finding pattern (per `feedback_pre_publish_scrutiny.md` audit-table format).
+5. **`data/historical-tdf.json`** — verify any events keyed to segs 17-19 are correct; surface any corridor-relevant events not yet keyed.
+6. **AskUserQuestion at material disagreements** — expect 1-2 such checkpoints (per `feedback_multi_strand_session_checkpoints.md`).
+7. **Audit summary** — per-claim table in PR body listing source, current value, audit finding, action.
+8. **PR open against `main`** — title `data: seg 17-19 verification (closes #498)`; closes #498.
+
+## 6. Verification commands
+
+```bash
+npm test                                                                       # all tests pass
+python3 processing/validate_points.py                                          # OK
+python3 processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
+python3 processing/audit_segment_data.py --segment 17                          # clean
+python3 processing/audit_segment_data.py --segment 18                          # clean
+python3 processing/audit_segment_data.py --segment 19                          # clean
+npm run build                                                                  # complete
+```
+
+Where applicable, demonstrate red-green: show that the test fires red against the broken state and green against the fix.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):** `data/attractions.json` (additions / corrections for segs 17-19), `data/segments.json` (towns / notable_points for segs 17-19), `data/town-coords.json` (any new towns added), `data/historical-tdf.json` (additions / re-keyings keyed to segs 17-19), `data/town-positions.ts` (mirror of any town additions). PR-body audit summary.
+- **What this strand reads:** `data/competition/points-config.json` (read-only; climb metadata is canonical there per #516); `data/segments/segment-{17,18,19}.gpx`; `data/elevation/segment-{17,18,19}.json`; CLAUDE.md narrative project context (not deprecated tabular data).
+- **What this strand must NOT touch:** `content/entries/*.md` (separate drafting strands); `data/competition/points-config.json` (only climb-data strands write here); STRAND-BRIEF-TEMPLATE.md.
+- **Cross-strand collisions:** none expected. Drafting strands for segs 12-13 work on different file regions; the seg 17 drafting strand (when it spawns) reads this strand's outputs.
+
+## 8. Scope discipline
+
+- Default: file new issues for findings outside the strand's owned write-set (e.g., a points-config drift discovered while reading; a CLAUDE.md narrative inaccuracy).
+- AskUserQuestion at material-disagreement points only.
+- Document publisher-approved scope overrides in the PR body.
+- Use the audit-table distinction between "verified empty" and "unaudited absence" (per the seg 14-16 strand's pattern observation about Plateau de Millevaches sparseness).
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_on_route_checks.md`
+- `feedback_multi_strand_session_checkpoints.md`
+- `feedback_pre_publish_scrutiny.md` (segs 17-19 publish ~late May / early June 2026)
+- `feedback_brief_content_is_carryforward.md`
+- `feedback_parallel_source_of_truth_detector.md` (cross-source assertions are the bug-class-fix pattern; flag drift discovered in audit)
+- `feedback_assertion_bug_class.md` (any new assertion needs hand-computed diagnostic)
+
+## 10. Stop when
+
+- Per-claim audit table complete in PR body for segs 17, 18, 19.
+- Any data corrections landed; any cross-strand follow-ups filed (e.g., points-config drift → file separate issue).
+- `npm test` + validators + audit script all clean for segs 17-19.
+- PR opened, reviewed, merged.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-498` once the work has merged.
+- Final report posted to publisher: PR link, audit table summary, any open questions surfaced for downstream drafting strands (segs 17, 18, 19 drafters will consume).

--- a/docs/strands/strand-499-verify-segs-20-22.md
+++ b/docs/strands/strand-499-verify-segs-20-22.md
@@ -1,0 +1,90 @@
+# Strand: Verify segs 20-22 (#499)
+
+Data-verification strand. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Audit `data/*.json` against `data/segments/segment-{20,21,22}.gpx` and authoritative external sources for the segs 20–22 block (km ~128–150: Bugeat, the Plateau de Millevaches heart, Mont Bessou — the highest point in Corrèze at 977m). Closes [#499](https://github.com/gneeek/tdf26/issues/499). Milestone: [v1.4.20](https://github.com/gneeek/tdf26/milestone/20) (subject to renumbering per Topic 9a). Spawn timing: ~5 weeks from 2026-05-07 (publisher discretion). Mirrors PR #470, #489, #514.
+
+Special note: per PR #514, the 2024 Tour de France Stage 11 reference was re-keyed from segs 14-16 to **seg 22** (Mont Bessou as the highest-altitude parallel for that stage's Puy Mary climb). This strand should verify the keying held and the description still reads cleanly post-correction.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-499-segs-20-22-verify /home/jhs/code/tdf26-499 main
+```
+
+- Run from outside the repo, or use `git -C`. Do not run `git worktree add ...` from inside the repo (per `feedback_strand_worktree_path.md`).
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: run `git branch --show-current` immediately before each `git add` / `git commit` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-{20,21,22}.gpx` directly. Use the GPX polyline (not segment endpoints) for proximity checks (per `feedback_on_route_checks.md`). External sources: OSM, Wikipédia, Mérimée, Tourisme Corrèze, Parc naturel régional de Millevaches website, regional press. Per `feedback_brief_content_is_carryforward.md`: facts cited in this brief are scaffolding; verify against authoritative sources.
+
+## 4. Target issues
+
+- [#499](https://github.com/gneeek/tdf26/issues/499) — data verification segs 20-22. Closes when the audit ships and any data corrections land.
+
+## 5. Workflow per issue
+
+Per-claim audit pass:
+
+1. **GPX polyline integrity** for segs 20, 21, 22 — files read cleanly; km markers in `data/segments.json` match GPX cumulative distance.
+2. **Town keying** — `Bugeat` (currently keyed to seg 21 per existing data; verify against polyline). Confirm other towns transited.
+3. **Climb keying** — Mont Bessou (5.0 km @ 2.7% per current points-config post-#516; summit at 977m, the highest point in Corrèze; ASO-categorised per #492 outcome). Verify summit km against GPX local maximum; verify the per-source-of-truth gradient assertion at `tests/utils/climb-gradient.test.ts` still passes.
+4. **`data/attractions.json`** — proximity, category, sources. Plateau de Millevaches has sparse classical-attraction density (the Parc itself is the attraction); use the "verified empty" finding pattern where appropriate.
+5. **`data/historical-tdf.json`** — verify the 2024 Stage 11 entry (re-keyed to seg 22 by PR #514) still reads cleanly; surface any other corridor-relevant events.
+6. **2024 Stage 11 keying check** — the Mont Bessou / Puy Mary parallel is the rationale; confirm the description in `data/historical-tdf.json` still fits and no detail belongs back at segs 14-16.
+7. **AskUserQuestion at material disagreements**.
+8. **Audit summary** — per-claim table in PR body.
+9. **PR open against `main`** — title `data: seg 20-22 verification (closes #499)`; closes #499.
+
+## 6. Verification commands
+
+```bash
+npm test                                                                       # all tests pass
+python3 processing/validate_points.py                                          # OK
+python3 processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
+python3 processing/audit_segment_data.py --segment 20                          # clean
+python3 processing/audit_segment_data.py --segment 21                          # clean
+python3 processing/audit_segment_data.py --segment 22                          # clean
+npm run build                                                                  # complete
+```
+
+Where applicable, demonstrate red-green: show that the test fires red against the broken state and green against the fix.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):** `data/attractions.json` (segs 20-22), `data/segments.json` (towns / notable_points segs 20-22), `data/town-coords.json` (any new towns), `data/historical-tdf.json` (events keyed to segs 20-22), `data/town-positions.ts`. PR-body audit summary.
+- **What this strand reads:** `data/competition/points-config.json` (read-only); `data/segments/segment-{20,21,22}.gpx`; `data/elevation/segment-{20,21,22}.json`; CLAUDE.md narrative.
+- **What this strand must NOT touch:** `content/entries/*.md`; `data/competition/points-config.json` (only climb-data strands write here); STRAND-BRIEF-TEMPLATE.md; segs 17-19 / 23-26 verification work (separate strands).
+- **Cross-strand collisions:** if #498 (segs 17-19) is merged before this spawns, no overlap. If #500 (segs 23-26) is in flight concurrently, neither writes overlapping km ranges; flag in PR body for awareness.
+
+## 8. Scope discipline
+
+- Default: file new issues for findings outside owned write-set.
+- AskUserQuestion at material-disagreement points only.
+- Document publisher-approved scope overrides in PR body.
+- Use the "verified empty" vs "unaudited absence" distinction in audit tables.
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_on_route_checks.md`
+- `feedback_multi_strand_session_checkpoints.md`
+- `feedback_pre_publish_scrutiny.md` (segs 20-22 publish ~mid-June 2026)
+- `feedback_brief_content_is_carryforward.md`
+- `feedback_parallel_source_of_truth_detector.md`
+- `feedback_assertion_bug_class.md`
+
+## 10. Stop when
+
+- Per-claim audit table complete for segs 20, 21, 22.
+- Any data corrections landed; cross-strand follow-ups filed.
+- `npm test` + validators + audit script all clean for segs 20-22.
+- PR opened, reviewed, merged.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-499` once the work has merged.
+- Final report posted to publisher: PR link, audit table summary, any open questions surfaced for downstream drafting strands.

--- a/docs/strands/strand-500-verify-segs-23-26.md
+++ b/docs/strands/strand-500-verify-segs-23-26.md
@@ -1,0 +1,103 @@
+# Strand: Verify segs 23-26 (#500)
+
+Data-verification strand. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Audit `data/*.json` against `data/segments/segment-{23,24,25,26}.gpx` and authoritative external sources for the segs 23–26 block (km ~150–185: Meymac, Côte des Gardes, Ussel — the stage-9 finish at Place Voltaire). Closes [#500](https://github.com/gneeek/tdf26/issues/500). Milestone: [v1.4.20](https://github.com/gneeek/tdf26/milestone/20) (subject to renumbering per Topic 9a). Spawn timing: ~6 weeks from 2026-05-07 (publisher discretion). Mirrors PR #470, #489, #514.
+
+**Special checks for this strand:**
+
+- **Mascaron / Saintsbury voice scheduling.** Per `project_meymac_voice.md` and the planning-notes carryforward, Meymac's saintsbury voice may need to shift from seg 24 to seg 25 depending on which segment actually anchors the abbey (Abbaye Saint-André, founded 1085). This audit decides. Update `project_meymac_voice.md` accordingly when the answer lands.
+- **`historical-tdf.json` segments [25, 26, 27] grouping.** The route only has 26 segments per `data/segments.json`; the [25, 26, 27] keying in `data/historical-tdf.json` references a non-existent seg 27. Pre-existing finding flagged in PR #514's "out of scope" notes (#503 tracks). This strand should fix or surface as needed.
+- **Paris-Corrèze keying.** Per the #502 tour-history strand Session 1 dossier, the existing Paris-Corrèze entry is mis-keyed to segs [25, 26, 27] but every documented year (2005–2012) finished at **Chaumeil (seg 15)** and 2009 specifically went **Tulle (seg 10) → Chaumeil (seg 15)**. The keying needs correction; do this strand or close as fixed elsewhere if the tour-history strand handled it first.
+- **Ussel finish geometry.** Place Voltaire is the sprint judge; Avenue Thiers is the run-in. Verify that the polyline passes through both and that town-coords / segments.json reflect the finish accurately.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/issue-500-segs-23-26-verify /home/jhs/code/tdf26-500 main
+```
+
+- Run from outside the repo, or use `git -C`. Do not run `git worktree add ...` from inside the repo (per `feedback_strand_worktree_path.md`).
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: run `git branch --show-current` immediately before each `git add` / `git commit` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-{23,24,25,26}.gpx` directly. Use the GPX polyline (not segment endpoints) for proximity checks (per `feedback_on_route_checks.md`). External sources: OSM, Wikipédia, Mérimée, Tourisme Corrèze, Tourisme Egletons, Meymac abbey site, Ussel municipal site, regional press. Per `feedback_brief_content_is_carryforward.md`: facts cited in this brief are scaffolding; verify against authoritative sources.
+
+This strand sits at the end of the route — sources for Ussel and Meymac are richer than for the Plateau de Millevaches block, so the audit table should be denser on attractions, sparser on the "verified empty" pattern.
+
+## 4. Target issues
+
+- [#500](https://github.com/gneeek/tdf26/issues/500) — data verification segs 23-26. Closes when the audit ships and corrections land.
+- [#503](https://github.com/gneeek/tdf26/issues/503) — `historical-tdf.json` segment-27 drift. Likely closes alongside this strand if the segments [25, 26, 27] keying gets fixed here.
+
+## 5. Workflow per issue
+
+Per-claim audit pass:
+
+1. **GPX polyline integrity** for segs 23, 24, 25, 26 — files read cleanly; km markers match GPX cumulative.
+2. **Town keying** — `Meymac` (currently seg 24 per existing data; verify polyline; the abbey is the anchor), `Ussel` (segs 25-26; verify finish-line km against the actual stage-9 finish coords; `data/town-coords.json` already has a `note` field for towns whose centre sits off the polyline). Confirm any other transited towns.
+3. **Climb keying** — Côte des Gardes (currently seg 24 in points-config: 2.2 km @ 4.3%; verify summit km against GPX). Per `feedback_assertion_bug_class.md`, also sanity-check the gradient assertion at `tests/utils/climb-gradient.test.ts` still passes for this climb.
+4. **Meymac abbey segment keying** — does the Abbaye Saint-André sit in seg 23 or seg 24? The medieval town centre vs the route polyline determines voice scheduling per `project_meymac_voice.md`. Decide and update the memory.
+5. **`data/attractions.json`** — Meymac abbey, the Centre d'Art Contemporain, Ussel medieval town, Place Voltaire. Verify proximity, category, source URLs.
+6. **`data/historical-tdf.json` cleanup** — fix the [25, 26, 27] grouping to reference only existing segments. Re-key or remove the Paris-Corrèze entry per the #502 dossier finding (was finishing at Chaumeil seg 15, not Ussel). Surface any other corridor-relevant events.
+7. **AskUserQuestion at material disagreements** — expect 2-3 such checkpoints (this strand has more contested facts than mid-route blocks).
+8. **Audit summary** — per-claim table in PR body.
+9. **PR open against `main`** — title `data: seg 23-26 verification (closes #500)`; closes #500 (and #503 if folded in).
+
+## 6. Verification commands
+
+```bash
+npm test                                                                       # all tests pass
+python3 processing/validate_points.py                                          # OK
+python3 processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
+python3 processing/audit_segment_data.py --segment 23                          # clean
+python3 processing/audit_segment_data.py --segment 24                          # clean
+python3 processing/audit_segment_data.py --segment 25                          # clean
+python3 processing/audit_segment_data.py --segment 26                          # clean
+npm run build                                                                  # complete
+```
+
+Where applicable, demonstrate red-green: show that the test fires red against the broken state and green against the fix.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):** `data/attractions.json` (segs 23-26), `data/segments.json` (towns / notable_points), `data/town-coords.json` (any new towns added), `data/historical-tdf.json` (segs 23-26 events; segments [25, 26, 27] cleanup; Paris-Corrèze re-keying), `data/town-positions.ts`. Possibly `project_meymac_voice.md` (memory edit, depends on seg 24 vs 25 finding). PR-body audit summary.
+- **What this strand reads:** `data/competition/points-config.json` (read-only); `data/segments/segment-{23,24,25,26}.gpx`; `data/elevation/segment-{23,24,25,26}.json`; CLAUDE.md narrative; `content/research/tour-history-research.md` (committed via the #502 tour-history strand) for the Paris-Corrèze re-keying context.
+- **What this strand must NOT touch:** `content/entries/*.md`; `data/competition/points-config.json` (only climb-data strands write); STRAND-BRIEF-TEMPLATE.md; segs 17-19 / 20-22 verification work.
+- **Cross-strand collisions:** if the #502 tour-history strand has already corrected the Paris-Corrèze entry, this strand reads but doesn't re-touch it. Coordinate via PR body / issue comments if both strands are in flight.
+
+## 8. Scope discipline
+
+- Default: file new issues for findings outside owned write-set.
+- AskUserQuestion at material-disagreement points only.
+- Document publisher-approved scope overrides in PR body.
+- The Mascaron / Saintsbury voice question is a memory edit, not a code edit — do not touch any voice-skill files in this strand.
+- Use the audit-table distinction between "verified empty" and "unaudited absence."
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_on_route_checks.md`
+- `feedback_multi_strand_session_checkpoints.md`
+- `feedback_pre_publish_scrutiny.md` (segs 23-26 publish ~late June / early July 2026 — close to the actual stage 9 day)
+- `feedback_brief_content_is_carryforward.md`
+- `feedback_parallel_source_of_truth_detector.md`
+- `feedback_assertion_bug_class.md`
+- `project_meymac_voice.md` (this strand decides seg 24 vs seg 25 and updates the memory)
+
+## 10. Stop when
+
+- Per-claim audit table complete for segs 23, 24, 25, 26.
+- Mascaron / Saintsbury voice scheduling decided; `project_meymac_voice.md` updated.
+- `historical-tdf.json` [25, 26, 27] keying fixed; Paris-Corrèze entry corrected or confirmed correct.
+- Any other data corrections landed; cross-strand follow-ups filed.
+- `npm test` + validators + audit script all clean for segs 23-26.
+- PR opened, reviewed, merged. #500 closes; #503 closes if folded in.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-500` once the work has merged.
+- Final report posted to publisher: PR link, audit table summary, voice scheduling outcome, Paris-Corrèze re-keying outcome, any open questions surfaced for downstream drafting strands (Meymac and Ussel drafters will consume).

--- a/docs/strands/strand-seg-12-drafting.md
+++ b/docs/strands/strand-seg-12-drafting.md
@@ -1,0 +1,92 @@
+# Strand: Seg 12 drafting
+
+Drafting strand for segment 12 of the tdf26 travelogue. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Land a draft of `content/entries/12-*.md` ready for the publisher's pre-publish review window before the seg 12 publish (Wed 2026-05-13 if the cadence holds). Segment 12 covers km 77–84 (Naves into the Puy de Lachaud approach). Milestone: [v1.4.19](https://github.com/gneeek/tdf26/milestone/19) (subject to renumbering per Topic 9a). Hard deadline: roughly Tue 2026-05-12 evening.
+
+This strand runs in **publisher-paced single-strand mode** (per `feedback_multi_strand_session_checkpoints.md` 2026-05-07 sharpening) — checkpoint at editorial micro-decisions. Spawn only after seg 11 has shipped: voice-register choice and any seg-11-publication learnings should inform seg 12.
+
+This is the **Barthes-arc "tightens" beat** per `project_barthes_callback.md` (seg 6 plants — absence; seg 12 tightens — argument becoming visible; seg 15 develops — argument earned at Suc au May). The forward-looking literary thread opens here, not earlier.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/seg-12-draft /home/jhs/code/tdf26-seg-12 main
+```
+
+- Run from outside the repo, or use `git -C`. Do not run `git worktree add ...` from inside the repo (per `feedback_strand_worktree_path.md`).
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: run `git branch --show-current` immediately before each `git add` / `git commit` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-12.gpx` directly for any factual claim about route geometry, town/attraction position, or climb metadata. Do not transcribe CLAUDE.md tabular data (deprecated per #491 / PR #507). Use the GPX polyline (not segment endpoints) for proximity checks (per `feedback_on_route_checks.md`, `feedback_source_of_truth_framing.md`).
+
+`content/research/segs-11-13-block-research.md` (committed via PR #501 with Bol d'Or correction) is the primary content input. Treat as research, not authoritative for facts you'll publish — verify cited sources against URLs given. Per `feedback_brief_content_is_carryforward.md`: dossier facts are scaffolding, not bedrock.
+
+## 4. Target issues
+
+No tracking issue at brief time. If the strand opens its own (e.g., to capture a follow-up surfaced during draft), file at strand start: `Seg 12 drafting strand`, milestone v1.4.19. PR closes whatever issue is opened.
+
+## 5. Workflow per issue
+
+Cadence is publisher-paced via AskUserQuestion checkpoints. List of checkpoints (not prose-writing steps):
+
+1. **Read seg 12 section of dossier** + factor in seg 11 publication learnings (post-mortem of seg 11 ship, anything that surfaced at publish time).
+2. **Voice register checkpoint** (AskUserQuestion). Voice picked at draft time; the `tdf26-voice` skill provides options. Do not start drafting until voice is fixed.
+3. **Arc agreement checkpoint** — confirm the Barthes seg-12 "tightens" beat stays in scope; confirm the Naves cultural anchors (Tintignac echo if not already spent in seg 11; Koscielny home; Retable de Naves; A89 viaduct framing) the publisher wants foregrounded.
+4. **First draft** — write to chosen voice. Keep Naves-as-village-someone-comes-home-to as primary; layer the climb of Côte des Naves (canonical name post-#516; no "s") and the start of the Puy de Lachaud approach. Verify factual claims against the dossier's source URLs.
+5. **First draft review** — publisher reads; AskUserQuestion checkpoints fire on factual calls and on any forward-looking thread placement. Note the "between-places" texture of the seg 12-13 transition that the dossier flagged for seg 13 — do not poach.
+6. **Revisions** — apply publisher edits.
+7. **Sources section + disclosure footer** — `## Sources` per `feedback_sources_section.md`; pair-writing + voice-register footer per `project_disclosure_practice.md`.
+8. **PR open against `main`** — title `seg 12 draft: <subtitle>`; body lists voice picked, AskUserQuestion checkpoints fired, any new issues filed.
+
+## 6. Verification commands
+
+- `npm test` — entry-shape assertions pass.
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — entry passes shape checks.
+- `python3 processing/validate_points.py` — no regression.
+- `npm run build` and dev preview at `/entries/seg-12-*`: render renders, ElevationChart shows the climb metadata, image gallery placeholder renders.
+- **Pre-publish scrutiny** per `feedback_pre_publish_scrutiny.md`: verify geography, attribution, image rights before publish.sh runs.
+- Where applicable, demonstrate red-green: show that the test fires red against the broken state and green against the fix.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):** `content/entries/12-*.md`. Possibly small additions to `data/historical-tdf.json` if the dossier surfaces a missing event keyed to seg 12, but default is to file an issue per `feedback_issues_describe_problems.md`.
+- **What this strand reads:** `content/research/segs-11-13-block-research.md`, `data/segments.json`, `data/historical-tdf.json`, `data/town-coords.json`, `data/competition/points-config.json`, `data/segments/segment-12.gpx`, `data/elevation/segment-12.json`.
+- **What this strand must NOT touch:** `content/entries/11-*.md` (seg 11 published before this strand spawns; per `feedback_content_change_rule.md` no retroactive edits). `content/entries/13-*.md` (separate drafting strand). Sainte-Fortunade / Monédières / Léon Dautrement / Bourrée des Monédières — reserved for seg 14+. Suc au May / Mont Bessou / Meymac voices / Saintsbury — out of scope. STRAND-BRIEF-TEMPLATE.md untouched.
+- **Cross-strand collisions:** none expected. The seg 13 drafting strand (if running concurrently) writes a different entry file; the dossier sections for segs 12 and 13 are distinct.
+
+## 8. Scope discipline
+
+- Default: file new issues for findings outside the strand's owned write-set (e.g., a dossier claim that fails source verification at draft time, an image needing licensing chase).
+- AskUserQuestion at material-disagreement points only; do not rubber-stamp.
+- Do not retroactively edit prior entries (per `feedback_content_change_rule.md`).
+- Document any publisher-approved scope overrides in the PR body.
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_on_route_checks.md`
+- `feedback_multi_strand_session_checkpoints.md` (publisher-paced this strand)
+- `feedback_content_change_rule.md`
+- `feedback_pre_publish_scrutiny.md`
+- `feedback_brief_content_is_carryforward.md` (dossier facts are scaffolding)
+- `feedback_literary_footnotes.md` (post-seg-6, applies)
+- `feedback_sources_section.md` (post-seg-6, applies)
+- `project_disclosure_practice.md` (post-seg-7, applies; prose footer per 2026-05-07 decision)
+- `project_barthes_callback.md` (this strand owns the "tightens" beat)
+- `feedback_content_workflow.md` (research → discuss → draft)
+
+## 10. Stop when
+
+- Draft committed to `feature/seg-12-draft`; PR opened against `main`.
+- All AskUserQuestion checkpoints fired and answered; publisher reviewed prose at least once.
+- `npm test` + entry validators green.
+- Dev preview rendered without error.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-seg-12` once the PR has merged.
+- Final report posted to publisher: PR link, voice picked, AskUserQuestion checkpoints fired, any open questions surfaced for downstream strands (seg 13 drafting in particular).

--- a/docs/strands/strand-seg-13-drafting.md
+++ b/docs/strands/strand-seg-13-drafting.md
@@ -1,0 +1,95 @@
+# Strand: Seg 13 drafting
+
+Drafting strand for segment 13 of the tdf26 travelogue. Authored at the 2026-05-07 planning session resume.
+
+## 1. Goal
+
+Land a draft of `content/entries/13-*.md` ready for the publisher's pre-publish review window before the seg 13 publish (Sun 2026-05-17 if the cadence holds). Segment 13 covers km 84–92 (Puy de Lachaud crest into the Chaumeil-approach plateau). Milestone: [v1.4.19](https://github.com/gneeek/tdf26/milestone/19) (subject to renumbering per Topic 9a). Hard deadline: roughly Sat 2026-05-16 evening.
+
+This strand runs in **publisher-paced single-strand mode** (per `feedback_multi_strand_session_checkpoints.md` 2026-05-07 sharpening) — checkpoint at editorial micro-decisions. Spawn after seg 12 has shipped (or has at least been drafted to publisher-review state); voice and beat choices for seg 13 should compose with seg 12.
+
+The dossier flagged seg 13 as the **"between-places" texture beat** — the route is leaving Naves and approaching Chaumeil but neither is the anchor; the prose must work with the absence of a destination. Reserve Monédières framing entirely (seg 14+ territory).
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/seg-13-draft /home/jhs/code/tdf26-seg-13 main
+```
+
+- Run from outside the repo, or use `git -C`. Do not run `git worktree add ...` from inside the repo (per `feedback_strand_worktree_path.md`).
+- Do **not** add `ln -s ../tdf26/.claude .claude` — `.claude/` is tracked.
+- Branch verification: run `git branch --show-current` immediately before each `git add` / `git commit` (per `feedback_shared_tree_branch_verification.md`).
+
+## 3. Source-of-truth posture
+
+Read `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-13.gpx` directly. Per #491 / PR #507, do not transcribe CLAUDE.md tabular data. Use the GPX polyline (not segment endpoints) for proximity checks (per `feedback_on_route_checks.md`, `feedback_source_of_truth_framing.md`).
+
+`content/research/segs-11-13-block-research.md` (committed via PR #501) is the primary content input. Seg 13's section in the dossier flags the "between-places" texture, granitic plateau geology, and the carryforward-gating that keeps Monédières framing reserved. Per `feedback_brief_content_is_carryforward.md`: dossier facts are scaffolding — verify cited sources before writing them into prose.
+
+Note the seg-13/14 boundary: per the seg 14-16 verification (PR #514), Chaumeil sits in seg 15 (km 100.30) and the seg 14/15 line is at km 99.4. Seg 13 ends roughly at km 92, so Chaumeil is not even in seg 14 — it's two segments away. Drafters who reach for a Chaumeil callback in seg 13 should resist; the texture beat works precisely because the destination is still distant.
+
+## 4. Target issues
+
+No tracking issue at brief time. If the strand opens its own, file at strand start: `Seg 13 drafting strand`, milestone v1.4.19. PR closes whatever issue is opened.
+
+## 5. Workflow per issue
+
+Cadence is publisher-paced via AskUserQuestion checkpoints. List of checkpoints (not prose-writing steps):
+
+1. **Read seg 13 section of dossier** + factor in seg 11 + seg 12 publication learnings.
+2. **Voice register checkpoint** (AskUserQuestion). Voice picked at draft time. The "between-places" texture may pull voice toward something more reflective / less landmark-driven; the publisher decides.
+3. **Arc agreement checkpoint** — confirm the texture-beat framing; confirm whether to plant any Monédières-as-visible-feature foreshadow (the mountains come into view from the upper Puy de Lachaud plateau, but framing is reserved per the dossier's carryforward).
+4. **First draft** — write to chosen voice. Keep "between-places" primary; granitic plateau geology as cultural anchor; the climb of Puy de Lachaud (non-categorised, regional, per #492 outcome) as the climbing beat. Verify factual claims against the dossier's source URLs.
+5. **First draft review** — publisher reads; AskUserQuestion at factual calls and any cross-segment thread.
+6. **Revisions** — apply publisher edits.
+7. **Sources section + disclosure footer** — `## Sources` per `feedback_sources_section.md`; pair-writing + voice-register footer per `project_disclosure_practice.md`.
+8. **PR open against `main`** — title `seg 13 draft: <subtitle>`; body lists voice picked, checkpoints fired, any new issues filed.
+
+## 6. Verification commands
+
+- `npm test` — entry-shape assertions pass.
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — entry passes shape checks.
+- `python3 processing/validate_points.py` — no regression.
+- `npm run build` and dev preview at `/entries/seg-13-*`: render renders, ElevationChart shows the Puy de Lachaud climb, image gallery placeholder renders.
+- **Pre-publish scrutiny** per `feedback_pre_publish_scrutiny.md`.
+- Where applicable, demonstrate red-green: show that the test fires red against the broken state and green against the fix.
+
+## 7. Cross-strand sharing notes
+
+- **What this strand owns (write):** `content/entries/13-*.md`. Possibly small additions to `data/historical-tdf.json` if the dossier surfaces a missing event keyed to seg 13, but default is to file an issue.
+- **What this strand reads:** `content/research/segs-11-13-block-research.md`, `data/segments.json`, `data/historical-tdf.json`, `data/town-coords.json`, `data/competition/points-config.json`, `data/segments/segment-13.gpx`, `data/elevation/segment-13.json`.
+- **What this strand must NOT touch:** `content/entries/11-*.md` and `content/entries/12-*.md` (already published or drafted; per `feedback_content_change_rule.md`). Monédières framing in any form (Sainte-Fortunade, Léon Dautrement quote, Bourrée des Monédières, Suc au May) — reserved for seg 14+. Mont Bessou, Meymac, Saintsbury — out of scope. STRAND-BRIEF-TEMPLATE.md untouched.
+- **Cross-strand collisions:** none expected with peer drafting strands; the verification strands (#498/#499/#500) operate later in the timeline.
+
+## 8. Scope discipline
+
+- Default: file new issues for findings outside the strand's owned write-set.
+- AskUserQuestion at material-disagreement points only; do not rubber-stamp.
+- Do not retroactively edit prior entries.
+- Document any publisher-approved scope overrides in the PR body.
+- Resist the pull toward the destination. Seg 13 is structurally about absence; let the prose work without anchoring on Chaumeil or the Monédières peaks.
+
+## 9. Memories that apply
+
+- `feedback_source_of_truth_framing.md`
+- `feedback_strand_worktree_path.md`
+- `feedback_shared_tree_branch_verification.md`
+- `feedback_on_route_checks.md`
+- `feedback_multi_strand_session_checkpoints.md` (publisher-paced this strand)
+- `feedback_content_change_rule.md`
+- `feedback_pre_publish_scrutiny.md`
+- `feedback_brief_content_is_carryforward.md`
+- `feedback_literary_footnotes.md` (post-seg-6)
+- `feedback_sources_section.md` (post-seg-6)
+- `project_disclosure_practice.md` (post-seg-7)
+- `project_barthes_callback.md` (seg 13 not in arc; awareness only — do not plant)
+- `feedback_content_workflow.md`
+
+## 10. Stop when
+
+- Draft committed to `feature/seg-13-draft`; PR opened against `main`.
+- All AskUserQuestion checkpoints fired and answered; publisher reviewed prose at least once.
+- `npm test` + entry validators green.
+- Dev preview rendered without error.
+- **Cleanup (you run these, do not hand off):** `git -C /home/jhs/code/tdf26 worktree remove tdf26-seg-13` once the PR has merged.
+- Final report posted to publisher: PR link, voice picked, AskUserQuestion checkpoints fired, any open questions surfaced for downstream strands (the Monédières opens at seg 14 — note any framing the publisher pre-decided here that's relevant for the seg 14 drafting brief later).


### PR DESCRIPTION
## Summary

Five strand briefs authored at the 2026-05-07 planning resume via the `/strand-brief` skill. Same lifecycle pattern as PRs #520 and #525: bundle to main so a parallel session can branch from main and inherit each brief. None spawned yet.

## Briefs

**Drafting (publisher-paced single-strand mode):**

- **`strand-seg-12-drafting.md`** — v1.4.19; Naves into Puy de Lachaud approach; Barthes-arc "tightens" beat per `project_barthes_callback.md`; spawn after seg 11 ships.
- **`strand-seg-13-drafting.md`** — v1.4.19; "between-places" texture beat; Monédières framing reserved for seg 14+; spawn after seg 12.

**Data-verification (mirror PR #470, #489, #514):**

- **`strand-498-verify-segs-17-19.md`** — Treignac, Côte de la Croix de Pey, Plateau de Millevaches gateway; v1.4.20; spawn ~3 weeks. Closes #498.
- **`strand-499-verify-segs-20-22.md`** — Bugeat, Mont Bessou (highest point in Corrèze); 2024 Stage 11 keying check (re-keyed to seg 22 by PR #514); v1.4.20; spawn ~5 weeks. Closes #499.
- **`strand-500-verify-segs-23-26.md`** — Meymac, Côte des Gardes, Ussel finish; Mascaron/Saintsbury seg 24-vs-25 question (updates `project_meymac_voice.md`); `historical-tdf.json` segments [25,26,27] cleanup + Paris-Corrèze re-keying; v1.4.20; spawn ~6 weeks. Closes #500 and likely #503.

## Test plan

- [x] `git status` clean after merge
- [x] CI green
- [x] All 10 sections of STRAND-BRIEF-TEMPLATE.md present in each brief