### PR TITLE
infra: switch release tags from semver to ISO-week with publication marker (closes #519)

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -4,9 +4,13 @@
 # Usage:
 #   ./scripts/create-release.sh <tag> [--title <title>]
 #
+# Tag format is date-based, year-implicit (this is tdf26):
+#   Publication deploys:     W<NN>-seg<N>   (e.g. W19-seg11)
+#   Non-publication deploys: W<NN>.<N>      (e.g. W19.1)
+#
 # Example:
-#   ./scripts/create-release.sh v1.4.14
-#   ./scripts/create-release.sh v1.4.14 --title "v1.4.14 - Segment 9 publication"
+#   ./scripts/create-release.sh W19-seg11
+#   ./scripts/create-release.sh W19-seg11 --title "W19-seg11 - Segment 11 publication"
 #
 # The release body is auto-generated from the git log between the previous tag
 # and HEAD, plus a retro-link placeholder. The publisher can edit the body and
@@ -51,8 +55,8 @@ if [ -z "$TAG" ]; then
     exit 1
 fi
 
-if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "ERROR: tag must match v<major>.<minor>.<patch> (got: $TAG)" >&2
+if ! [[ "$TAG" =~ ^W[0-9]{2}(-seg[0-9]+|\.[0-9]+)$ ]]; then
+    echo "ERROR: tag must match W<NN>-seg<N> (publication) or W<NN>.<N> (non-publication) (got: $TAG)" >&2
     exit 1
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,7 @@
 # build site, deploy, and commit the frontmatter changes this script produced
 # so main is reconciled with the deployed artifact before the script exits.
 #
-# Usage: ./scripts/publish.sh [--segment N] [--release-tag vX.Y.Z]
+# Usage: ./scripts/publish.sh [--segment N] [--release-tag W<NN>-segN | W<NN>.N]
 #                             [--skip-deploy] [--skip-weather] [--skip-commit] [--skip-release]
 #
 # Environment variables (loaded from .env if present):
@@ -52,9 +52,11 @@ for arg in "$@"; do
             echo ""
             echo "Options:"
             echo "  --segment N            Segment number to publish (auto-detects if omitted)"
-            echo "  --release-tag vX.Y.Z   Tag and GitHub Release to create after a successful"
-            echo "                         deploy (must match v<major>.<minor>.<patch> format and"
-            echo "                         not already exist). Required unless --skip-release."
+            echo "  --release-tag TAG      Tag and GitHub Release to create after a successful"
+            echo "                         deploy. Date-based, year-implicit (this is tdf26):"
+            echo "                           Publication deploys: W<NN>-seg<N>   (e.g. W19-seg11)"
+            echo "                           Non-publication:     W<NN>.<N>      (e.g. W19.1)"
+            echo "                         Tag must not already exist. Required unless --skip-release."
             echo "  --skip-deploy          Skip the deployment step (also skips commit and release)"
             echo "  --skip-weather         Skip weather fetch"
             echo "  --skip-commit          Deploy but do not commit frontmatter to main"
@@ -101,8 +103,8 @@ if [ "$SKIP_RELEASE" = false ] && [ "$SKIP_DEPLOY" = false ]; then
         echo "ERROR: --release-tag is required (or pass --skip-release to suppress)." >&2
         exit 1
     fi
-    if ! [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "ERROR: --release-tag must match v<major>.<minor>.<patch> (got: $RELEASE_TAG)." >&2
+    if ! [[ "$RELEASE_TAG" =~ ^W[0-9]{2}(-seg[0-9]+|\.[0-9]+)$ ]]; then
+        echo "ERROR: --release-tag must match W<NN>-seg<N> (publication) or W<NN>.<N> (non-publication) (got: $RELEASE_TAG)." >&2
         exit 1
     fi
     if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Migrates `--release-tag` validation in `scripts/publish.sh` and `scripts/create-release.sh` from semver (`v<major>.<minor>.<patch>`) to a date-based, year-implicit ISO-week format with a visible publication marker. Closes #519.

The brief lives at `docs/strands/strand-519-date-based-tags.md`. The format-decision checkpoint (§5a) and timing checkpoint were taken with the publisher; the optional helper script (§5c) was deferred.

## Format chosen

| Deploy type | Format | Example |
|---|---|---|
| Publication (new segment content) | `W<NN>-seg<N>` | `W19-seg11` |
| Non-publication production deploy | `W<NN>.<N>` | `W19.1` |

- Year is implicit (this is tdf26 — only 2026).
- Weeks are zero-padded (`W05`, not `W5`).
- `-seg<N>` makes content-publication deploys visually distinguishable from non-publication deploys at `git tag` / `gh release list` glance — the marker the publisher requested during the format checkpoint.

Validation regex (used in both scripts):
```
^W[0-9]{2}(-seg[0-9]+|\.[0-9]+)$
```

## Diff

### `scripts/publish.sh`

- Usage line (top-of-file comment): `--release-tag vX.Y.Z` → `--release-tag W<NN>-segN | W<NN>.N`.
- `--help` text for `--release-tag`: shows the publication and non-publication shapes side by side.
- Validation regex (line ~104): `^v[0-9]+\.[0-9]+\.[0-9]+$` → `^W[0-9]{2}(-seg[0-9]+|\.[0-9]+)$`.
- Error message updated to name both publication and non-publication forms.

### `scripts/create-release.sh` *(not called out in the brief; publish.sh delegates here at line 424 — same regex needed updating)*

- Header docstring example (lines 7–9): old `v1.4.14` examples replaced with `W19-seg11`, plus a 4-line block documenting the publication / non-publication forms.
- Validation regex (line ~54): same migration as publish.sh.
- Error message updated to match.

Clean break per the brief's recommendation: regex is replaced outright, not extended to accept both old and new formats. Existing `v1.4.x` tags are historical record — no in-flight semver tags need to validate.

## Smoke evidence

**Syntax checks:**
```
$ bash -n scripts/publish.sh && bash -n scripts/create-release.sh
publish.sh syntax OK
create-release.sh syntax OK
```

**`./scripts/publish.sh --help`** shows the new format clearly:
```
  --release-tag TAG      Tag and GitHub Release to create after a successful
                         deploy. Date-based, year-implicit (this is tdf26):
                           Publication deploys: W<NN>-seg<N>   (e.g. W19-seg11)
                           Non-publication:     W<NN>.<N>      (e.g. W19.1)
                         Tag must not already exist. Required unless --skip-release.
```

**Regex matrix (direct bash test against the new validator):**

| Tag | Verdict | Why |
|---|---|---|
| `W19-seg11` | ACCEPT | publication, ISO week 19, segment 11 |
| `W14-seg1` | ACCEPT | publication, week 14, segment 1 (project-window start) |
| `W28-seg26` | ACCEPT | publication, week 28, segment 26 (project-window end, race week) |
| `W19.1` | ACCEPT | non-publication, week 19, sequence 1 |
| `W20.10` | ACCEPT | non-publication, multi-digit sequence |
| `v1.4.18` | REJECT | old semver |
| `v1.4.X` | REJECT | malformed semver |
| `2026-W19` | REJECT | year prefix not allowed |
| `W19-seg` | REJECT | missing segment number |
| `W19` | REJECT | no marker |
| `19-seg11` | REJECT | missing `W` |
| `W1-seg1` | REJECT | week not zero-padded |
| `W19-seg11.1` | REJECT | mixed publication / non-publication forms |
| `(empty)` | REJECT | empty input |

**End-to-end rejection paths through the actual scripts:**

```
$ ./scripts/publish.sh --release-tag v1.4.18
ERROR: --release-tag must match W<NN>-seg<N> (publication) or W<NN>.<N> (non-publication) (got: v1.4.18).
exit: 1

$ ./scripts/publish.sh --release-tag W19-seg-bad-format-test
ERROR: --release-tag must match W<NN>-seg<N> (publication) or W<NN>.<N> (non-publication) (got: W19-seg-bad-format-test).
exit: 1

$ ./scripts/create-release.sh v1.4.18
ERROR: tag must match W<NN>-seg<N> (publication) or W<NN>.<N> (non-publication) (got: v1.4.18)
exit: 1
```

The accept-good-format path through publish.sh's validation block is exercised through the regex matrix above; running it via the live script would proceed past validation into deploy, which is destructive on a smoke run.

**No JS test depends on the tag format.** Grep across `tests/` finds only stale narrative comments referring to `v1.4.x` (in `tests/utils/town-positions.test.ts:14` and `tests/data/schemas.test.ts:43`) — neither asserts on tag shape.

**No CI workflow triggers on tag patterns** (`.github/workflows/ci.yml`, `.github/workflows/deploy.yml`).

## Migration semantics

- Existing `v1.4.x` tags stay on GitHub as historical record. No back-tagging. No renames.
- First new-format tag will be created by the next production deploy through `publish.sh`. That is the seg 11 ship on Sun 2026-05-10, which (per the publisher's strand-start checkpoint) will tag as `W19-seg11`.
- Existing milestones (`v1.4.18`, `v1.4.19`, `v1.4.20`) keep their semver names per the planning decision captured in `project_release_tagging.md` — milestone-name policy is a separate, future-only concern, out of scope for this PR.

## Out of scope (deferred)

- `scripts/next-tag.sh` helper to compute the next valid publication tag (deferred via the §5c checkpoint; file a follow-up if typing the tag becomes friction).
- Existing milestone renames (settled in memory: future-only).

## Test plan

- [x] `bash -n` clean on both scripts
- [x] `--help` output reflects new format
- [x] Old semver format rejected by both scripts
- [x] New format accepted by validator (regex matrix)
- [x] No JS test references tag format
- [ ] First production deploy under new scheme creates `W19-seg11` tag (validates after merge, on the seg 11 publish run Sun 2026-05-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)