### PR TITLE
fix(security): switch admin execSync calls to arg-array form (closes #441)

### DIFF
--- a/server/api/images-suggest.post.ts
+++ b/server/api/images-suggest.post.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { resolve } from 'path'
 
 export default defineEventHandler(async (event) => {
@@ -9,14 +9,19 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Missing segment number' })
   }
 
+  if (typeof segment !== 'number' || !Number.isFinite(segment)) {
+    throw createError({ statusCode: 400, message: 'segment must be a number' })
+  }
+
   const venvPython = resolve('processing/.venv/bin/python')
   const script = resolve('processing/suggest_images.py')
   const segmentsJson = resolve('data/segments.json')
   const outputDir = resolve('data/image-suggestions')
 
   try {
-    execSync(
-      `${venvPython} ${script} --segments-json ${segmentsJson} --output-dir ${outputDir} --segment ${segment}`,
+    execFileSync(
+      venvPython,
+      [script, '--segments-json', segmentsJson, '--output-dir', outputDir, '--segment', String(segment)],
       { timeout: 30000, encoding: 'utf8' }
     )
     return { success: true }

--- a/server/api/publish.post.ts
+++ b/server/api/publish.post.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { resolve } from 'path'
 
 export default defineEventHandler(async (event) => {
@@ -9,14 +9,13 @@ export default defineEventHandler(async (event) => {
   const venvPython = resolve('processing/.venv/bin/python')
   const logs: string[] = []
 
-  function run(label: string, cmd: string) {
+  function run(label: string, file: string, args: string[]) {
     logs.push(`--- ${label} ---`)
     try {
-      const output = execSync(cmd, {
+      const output = execFileSync(file, args, {
         cwd: projectDir,
         timeout: 60000,
-        encoding: 'utf8',
-        shell: '/bin/bash'
+        encoding: 'utf8'
       })
       if (output.trim()) logs.push(output.trim())
       logs.push(`✓ ${label} complete`)
@@ -29,13 +28,24 @@ export default defineEventHandler(async (event) => {
   }
 
   if (steps.includes('stats')) {
-    run('Rider Stats', `${venvPython} processing/rider_stats.py --daily-log data/riders/daily-log.json --rider-config data/riders/rider-config.json --output data/riders/stats.json`)
+    run('Rider Stats', venvPython, [
+      'processing/rider_stats.py',
+      '--daily-log', 'data/riders/daily-log.json',
+      '--rider-config', 'data/riders/rider-config.json',
+      '--output', 'data/riders/stats.json'
+    ])
   }
 
   if (steps.includes('weather')) {
     const apiKey = process.env.OPENWEATHERMAP_API_KEY
     if (apiKey) {
-      run('Weather', `${venvPython} processing/weather.py --entry current --api-key ${apiKey} --segments-json data/segments.json --entries-dir content/entries`)
+      run('Weather', venvPython, [
+        'processing/weather.py',
+        '--entry', 'current',
+        '--api-key', apiKey,
+        '--segments-json', 'data/segments.json',
+        '--entries-dir', 'content/entries'
+      ])
     } else {
       logs.push('--- Weather ---')
       logs.push('No OPENWEATHERMAP_API_KEY set, skipped')

--- a/server/api/riders.post.ts
+++ b/server/api/riders.post.ts
@@ -1,12 +1,11 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 
 function runPython(scriptPath: string, args: string[]) {
   const venvPython = resolve('processing/.venv/bin/python')
-  const cmd = [venvPython, scriptPath, ...args].map(s => JSON.stringify(s)).join(' ')
   try {
-    execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync(venvPython, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
   } catch (err: unknown) {
     const e = err as { stderr?: Buffer | string; message?: string }
     const stderr = e.stderr ? e.stderr.toString().trim() : ''

--- a/tests/api/riders.test.ts
+++ b/tests/api/riders.test.ts
@@ -17,8 +17,8 @@ vi.mock('fs', () => ({
 }))
 
 vi.mock('child_process', () => ({
-  execSync: mockedExec,
-  default: { execSync: mockedExec },
+  execFileSync: mockedExec,
+  default: { execFileSync: mockedExec },
 }))
 
 const sampleConfig = JSON.stringify({


### PR DESCRIPTION
## Summary

Clears the three open CodeQL shell-command-injection alerts on admin server APIs by switching shell-mode `execSync` to `execFileSync` arg-array form. No shell is invoked, so user-controlled or env-derived strings cannot break out of the argv slot.

Closes #441. Strand brief: `docs/strands/strand-441-codeql-shell-injection.md`.

CodeQL alerts addressed:
- [#11 — server/api/images-suggest.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/11)
- [#12 — server/api/publish.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/12)
- [#13 — server/api/riders.post.ts](https://github.com/gneeek/tdf26/security/code-scanning/13)

## Per-file before/after

### `server/api/publish.post.ts`

**Before:** `run(label, cmd: string)` interpolated `${venvPython}` and `${apiKey}` into a single string and called `execSync(cmd, { shell: '/bin/bash', ... })`.

**After:** `run(label, file: string, args: string[])` calls `execFileSync(file, args, { ... })` with `shell` dropped. Each call site passes the venv Python as the file and the script + flags as discrete array elements; the weather case keeps `apiKey` as its own array element rather than a flag-string.

### `server/api/images-suggest.post.ts`

**Before:** `execSync(\`${venvPython} ${script} --segments-json ${segmentsJson} --output-dir ${outputDir} --segment ${segment}\`, { ... })` — `segment` came straight from the request body.

**After:** `execFileSync(venvPython, [script, '--segments-json', segmentsJson, '--output-dir', outputDir, '--segment', String(segment)], { ... })`. Added an explicit `typeof segment === 'number' && Number.isFinite(segment)` guard so non-numeric input is rejected with 400 before the spawn.

### `server/api/riders.post.ts`

**Before:** `runPython` built `[venvPython, scriptPath, ...args].map(s => JSON.stringify(s)).join(' ')` and passed the joined string to `execSync(cmd, { stdio })`. The JSON.stringify dance was a partial mitigation; the array-form fix supersedes it.

**After:** `execFileSync(venvPython, [scriptPath, ...args], { stdio })` — argv is forwarded literally, no shell parsing.

### `tests/api/riders.test.ts`

Updated the `vi.mock('child_process', ...)` factory to expose `execFileSync` instead of `execSync`. Mechanical follow-on; assertions on call shape (`mock.calls[N]` containing the script name) keep working because the script path remains a string element.

## Test plan

- [x] `npm test` — 186/186 pass (was 180/186 before mock update; failures were the four `execSync` mock sites).
- [x] `npx nuxt prepare` — types regenerate without errors.
- [x] Manual smoke against `npm run dev` (port 3001) with seeded rider data and venv symlink:
  - `POST /api/publish {"steps":["stats"]}` → `success:true`, rider_stats.py output captured in logs.
  - `POST /api/riders {"date":"2026-04-08","distances":{...}}` → `success:true`, full stats payload with all four riders, both rider_stats.py and calculate_points.py invoked.
  - `POST /api/images-suggest {"segment":1}` → `success:true`; suggestions written to `data/image-suggestions/`.
  - `POST /api/images-suggest {"segment":"1; rm -rf /tmp/foo"}` → 400 `segment must be a number` (validates the new type guard short-circuits before any spawn).
- [ ] Post-merge: CodeQL re-scan should clear alerts #11, #12, #13.

## Scope notes

- No behavior change is intended for the happy paths; argv reaches each Python script identically.
- `scripts/publish.sh` was deliberately not touched (separate territory; seg 11 ship Sun 2026-05-10).
- No new helper module — three local refactors collapse cleanly without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)