### PR TITLE
refactor: extract shared EntryCard component (closes #522)

### DIFF
--- a/components/EntryCard.vue
+++ b/components/EntryCard.vue
@@ -1,0 +1,46 @@
+<template>
+  <article class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
+    <NuxtLink :to="entry.path || entry._path" :class="showThumbnail ? 'flex gap-4 items-start' : 'block'">
+      <template v-if="showThumbnail">
+        <img
+          :src="entry.images[0].src"
+          :alt="entry.images[0].alt || ''"
+          loading="lazy"
+          class="w-20 h-20 sm:w-28 sm:h-28 rounded object-cover flex-shrink-0"
+        >
+        <div class="min-w-0 flex-1">
+          <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+            Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+          </span>
+          <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+          <component :is="`h${headingLevel}`" class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</component>
+          <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+          <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+        </div>
+      </template>
+      <template v-else>
+        <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
+          Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
+        </span>
+        <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
+        <component :is="`h${headingLevel}`" class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</component>
+        <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
+        <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
+      </template>
+    </NuxtLink>
+  </article>
+</template>
+
+<script setup>
+const props = defineProps({
+  entry: { type: Object, required: true },
+  density: { type: String, default: 'standard', validator: v => ['standard', 'compact'].includes(v) },
+  headingLevel: { type: Number, default: 3, validator: v => [2, 3].includes(v) },
+})
+
+const { formatDate } = useFormatDate()
+
+const showThumbnail = computed(() =>
+  props.density === 'standard' && props.entry.images && props.entry.images.length > 0,
+)
+</script>

--- a/composables/useFormatDate.ts
+++ b/composables/useFormatDate.ts
@@ -1,0 +1,13 @@
+export function useFormatDate() {
+  function formatDate(dateStr: string | null | undefined): string {
+    if (!dateStr) return ''
+    return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  return { formatDate }
+}

--- a/pages/entries/index.vue
+++ b/pages/entries/index.vue
@@ -8,17 +8,13 @@
     </header>
 
     <section v-if="entries && entries.length" class="space-y-3">
-      <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
-        <NuxtLink :to="entry.path || entry._path" class="block">
-          <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
-            Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
-          </span>
-          <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
-          <h2 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h2>
-          <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
-          <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
-        </NuxtLink>
-      </article>
+      <EntryCard
+        v-for="entry in entries"
+        :key="entry.path || entry._path"
+        :entry="entry"
+        density="compact"
+        :heading-level="2"
+      />
     </section>
     <p v-else class="text-stone-500 italic">No entries published yet.</p>
 
@@ -40,14 +36,4 @@ const { data: entries } = await useAsyncData('all-entries', () =>
 )
 
 useHead({ title: 'All entries - Corrèze Travelogue' })
-
-function formatDate(dateStr) {
-  if (!dateStr) return ''
-  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  })
-}
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,26 +23,12 @@
         <section>
           <h2 class="text-2xl font-serif font-bold text-stone-800 mb-3">Latest Entries</h2>
           <div v-if="entries && entries.length" class="space-y-3">
-            <article v-for="entry in entries" :key="entry.path || entry._path" class="group bg-white rounded-lg shadow-sm p-4 hover:shadow-md hover:bg-stone-50 hover:border-l-4 hover:border-correze-red cursor-pointer transition-all border-l-4 border-transparent">
-              <NuxtLink :to="entry.path || entry._path" class="flex gap-4 items-start">
-                <img
-                  v-if="entry.images && entry.images.length"
-                  :src="entry.images[0].src"
-                  :alt="entry.images[0].alt || ''"
-                  loading="lazy"
-                  class="w-20 h-20 sm:w-28 sm:h-28 rounded object-cover flex-shrink-0"
-                >
-                <div class="min-w-0 flex-1">
-                  <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
-                    Segment {{ entry.segment }} - Km {{ entry.kmStart }}-{{ entry.kmEnd }}
-                  </span>
-                  <span v-else class="text-sm text-correze-red font-semibold">Preview</span>
-                  <h3 class="text-xl font-serif font-bold text-stone-900 group-hover:text-correze-red transition-colors mt-1">{{ entry.title }}</h3>
-                  <p v-if="entry.subtitle" class="text-stone-600 mt-1">{{ entry.subtitle }}</p>
-                  <time class="text-sm text-stone-400 mt-2 block">{{ formatDate(entry.publishDate) }}</time>
-                </div>
-              </NuxtLink>
-            </article>
+            <EntryCard
+              v-for="entry in entries"
+              :key="entry.path || entry._path"
+              :entry="entry"
+              :heading-level="3"
+            />
           </div>
           <p v-else class="text-stone-500 italic">No entries published yet.</p>
           <p v-if="entries && entries.length" class="mt-3 text-right">
@@ -138,14 +124,4 @@ const { data: entries } = await useAsyncData('entries', () =>
 const latestEntry = computed(() => entries.value?.[0])
 const latestKmEnd = computed(() => latestEntry.value?.kmEnd || 0)
 const latestSegment = computed(() => latestEntry.value?.segment || 0)
-
-function formatDate(dateStr) {
-  if (!dateStr) return ''
-  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  })
-}
 </script>


### PR DESCRIPTION
## Summary

- Extracted `components/EntryCard.vue` from the duplicated card markup in `pages/index.vue` (Latest Entries) and `pages/entries/index.vue` (archive). Props: `entry`, `density: 'standard' | 'compact'` (default `'standard'`), `headingLevel: 2 | 3` (default `3`).
- Pulled `formatDate` into a shared `composables/useFormatDate.ts` so both pages and the new component stop redefining it.
- Closes #522.

## Density-prop decision

The brief asked the publisher to choose between unifying the archive's card style with the homepage (drop `density='compact'`) or preserving the existing text-only archive (keep `density='compact'`).

Decision: **keep the asymmetry for now**. The publisher flagged that the underlying mechanism for selecting which frontmatter image becomes a card thumbnail is itself the load-bearing problem, and unifying card styles before fixing that mechanism would expose entries with weak first-image thumbnails on the archive page. Filed as #535. Once #535 lands, dropping `density='compact'` becomes a cheap one-line change.

So:
- `pages/index.vue` calls `<EntryCard ... :heading-level="3" />` (standard density default, h3 to fit under the "Latest Entries" h2).
- `pages/entries/index.vue` calls `<EntryCard ... density="compact" :heading-level="2" />` (text-only, h2 to fit under the page-level h1).

## Visual verification

Per `feedback_production_preview.md`. Generated `nuxt generate` output for both `main` and the branch with identical `data/riders/{daily-log,points,stats}.json` (the worktree was seeded from the main repo's working copy, since those files are gitignored). Served each on a separate port and pixel-diffed via headless Chromium + PIL `ImageChops`.

| Page | Width | Result |
|---|---|---|
| `/entries` archive | 375 | PIXEL-IDENTICAL |
| `/entries` archive | 768 | PIXEL-IDENTICAL |
| `/entries` archive | 1280 | PIXEL-IDENTICAL |
| `/` homepage Latest Entries region (cropped above Leaflet map) | 375 | PIXEL-IDENTICAL |
| `/` homepage Latest Entries region (cropped above Leaflet map) | 768 | PIXEL-IDENTICAL |
| `/` homepage Latest Entries region (cropped above Leaflet map) | 1280 | PIXEL-IDENTICAL |

Below-the-fold homepage pixel differences exist (1.6%, 8.3%, 4.0% of the full 2400px-tall page at 375/768/1280) but their bounding boxes start at y=1302+ on the 1280 layout and y=1454+ on the 768 layout, which place them inside the Leaflet map / ElevationChart region. Those components are out of scope for this refactor and their non-determinism is unrelated.

The HTML structural diff (post-canonicalization that strips per-build hashes / UUIDs) is reduced to:
- One additional `<link rel="modulepreload">` for the new `EntryCard` chunk.
- Vue 3 SSR fragment markers (`<!--[-->`, `<!--]-->`) around the inner `<template>` blocks. These are HTML comments and visually invisible.

Article counts match: 5 on homepage, 11 on archive on both `main` and branch. NuxtLink class strings, segment label, heading levels (h3 on homepage, h2 on archive), date formatting all preserved.

## Test plan

- [x] `npm test` green (186 tests, 27 files).
- [x] `npm run build` succeeds.
- [x] `npm run generate` succeeds; `/` and `/entries/` serve 200 from `.output/public`.
- [x] No console warnings on the rendered pages.
- [x] Visual diff captured at sm/md/lg breakpoints (see table above).
- [x] Branch confirmed `feature/issue-522-entrycard` immediately before each `git add` / `git commit` per `feedback_shared_tree_branch_verification.md`.
- [x] Worktree fresh-seeded from `data/riders/*.example.json` per the updated `feedback_ci_seed_ordering.md` before the build.

## Out of scope

- `pages/entries/[...slug].vue` prev/next nav. Structurally different (pure text links), per the brief's §7 "must not touch."
- Other `formatDate` duplications in `layouts/default.vue`, `pages/entries/[...slug].vue`, `components/WeatherWidget.vue`, `components/PublishSchedule.vue`. They could migrate to `useFormatDate` later but the brief was explicit about extraction-only scope.
- Thumbnail-mechanism overhaul, tracked separately in #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)