### PR TITLE
fix(entry-card): honour images[0].objectPosition on thumbnail

### DIFF
--- a/components/EntryCard.vue
+++ b/components/EntryCard.vue
@@ -7,6 +7,7 @@
           :alt="entry.images[0].alt || ''"
           loading="lazy"
           class="w-20 h-20 sm:w-28 sm:h-28 rounded object-cover flex-shrink-0"
+          :style="entry.images[0].objectPosition ? { objectPosition: entry.images[0].objectPosition } : null"
         >
         <div class="min-w-0 flex-1">
           <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">


### PR DESCRIPTION
## Summary

Hotfix surfaced immediately post-seg-11 publish. The homepage `EntryCard` thumbnail centre-crops the seg 11 carnyx image (showing the long shaft) instead of the boar-headed bell at the top of the portrait.

`ImageGallery` already honours an optional `images[*].objectPosition` field (PR #538 added it for the in-entry gallery). `EntryCard` did not, so the homepage card disagreed with the entry's own gallery thumbnail.

## Change

One-line addition to `components/EntryCard.vue`: when `entry.images[0].objectPosition` is set, apply it as an inline style on the thumbnail. Otherwise the browser default (centre) applies. Backwards-compatible — every other entry's first-image renders unchanged.

## Bundled hotfix deploy

Will be deployed alongside a local-only correction to `data/riders/snapshots/snapshot-11.json` (Nan and Wally `estimatedFinishDate` 2026-07-04 → 2026-07-03, `estimatedDaysToFinish` 54 → 53) which surfaced the time-of-day-dependent finish-date bug noted at publish time. The snapshot file is gitignored and is fixed via local edit + rebuild + rsync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)