### PR TITLE
chore: track per-segment rider snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ Thumbs.db
 data/riders/daily-log.json
 data/riders/stats.json
 data/riders/points.json
-data/riders/snapshots/
+# Per-segment snapshots are write-once at publish time and tracked
+# so the canonical values for published segments survive a rebuild
+# on another machine.
 
 # Test coverage
 coverage/

--- a/data/riders/snapshots/snapshot-00.json
+++ b/data/riders/snapshots/snapshot-00.json
@@ -1,0 +1,320 @@
+{
+  "segment": 0,
+  "stats": {
+    "asOf": "2026-04-05",
+    "entryNumber": 4,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 4.62,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 7.5,
+        "shortestDay": 2.9,
+        "daysBelowThreeKm": 1,
+        "consistencyStdev": 2.04,
+        "bestThreeDayCombo": 15.6,
+        "recentFiveDayAverage": 4.62,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-02",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 2.0,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 2.7,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 0.77,
+        "bestThreeDayCombo": 7.0,
+        "recentFiveDayAverage": 2.0,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-02",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 3.25,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.7,
+        "shortestDay": 1.9,
+        "daysBelowThreeKm": 1,
+        "consistencyStdev": 1.16,
+        "bestThreeDayCombo": 11.1,
+        "recentFiveDayAverage": 3.25,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-02",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 5.1,
+        "dailyAverageActual": 1.28,
+        "dailyAverageCapped": 1.28,
+        "longestDay": 2.5,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 1.2,
+        "bestThreeDayCombo": 5.0,
+        "recentFiveDayAverage": 1.28,
+        "distanceRemaining": 179.9,
+        "estimatedDaysToFinish": 141,
+        "estimatedFinishDate": "2026-08-24",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 3,
+        "climbPoints": 2,
+        "totalPoints": 5
+      },
+      "marian": {
+        "sprintPoints": 2,
+        "climbPoints": 0,
+        "totalPoints": 2
+      },
+      "nan": {
+        "sprintPoints": 5,
+        "climbPoints": 1,
+        "totalPoints": 6
+      },
+      "wally": {
+        "sprintPoints": 1,
+        "climbPoints": 0,
+        "totalPoints": 1
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 32.8,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.89,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.1
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-01.json
+++ b/data/riders/snapshots/snapshot-01.json
@@ -1,0 +1,320 @@
+{
+  "segment": 1,
+  "stats": {
+    "asOf": "2026-04-04",
+    "entryNumber": 4,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 4.62,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 7.5,
+        "shortestDay": 2.9,
+        "daysBelowThreeKm": 1,
+        "consistencyStdev": 2.03,
+        "bestThreeDayCombo": 15.6,
+        "recentFiveDayAverage": 4.62,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-06",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 2.0,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 2.7,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 0.77,
+        "bestThreeDayCombo": 7.0,
+        "recentFiveDayAverage": 2.0,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-06",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 8.0,
+        "dailyAverageActual": 3.25,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.7,
+        "shortestDay": 1.9,
+        "daysBelowThreeKm": 1,
+        "consistencyStdev": 1.16,
+        "bestThreeDayCombo": 11.1,
+        "recentFiveDayAverage": 3.25,
+        "distanceRemaining": 177.0,
+        "estimatedDaysToFinish": 88,
+        "estimatedFinishDate": "2026-07-06",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 5.2,
+        "dailyAverageActual": 1.3,
+        "dailyAverageCapped": 1.3,
+        "longestDay": 2.5,
+        "shortestDay": 0.2,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 1.17,
+        "bestThreeDayCombo": 5.0,
+        "recentFiveDayAverage": 1.3,
+        "distanceRemaining": 179.8,
+        "estimatedDaysToFinish": 138,
+        "estimatedFinishDate": "2026-08-25",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 3,
+        "climbPoints": 2,
+        "totalPoints": 5
+      },
+      "marian": {
+        "sprintPoints": 2,
+        "climbPoints": 0,
+        "totalPoints": 2
+      },
+      "nan": {
+        "sprintPoints": 5,
+        "climbPoints": 1,
+        "totalPoints": 6
+      },
+      "wally": {
+        "sprintPoints": 1,
+        "climbPoints": 0,
+        "totalPoints": 1
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 32.8,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-02.json
+++ b/data/riders/snapshots/snapshot-02.json
@@ -1,0 +1,347 @@
+{
+  "segment": 2,
+  "stats": {
+    "asOf": "2026-04-07",
+    "entryNumber": 7,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 14.0,
+        "dailyAverageActual": 4.57,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 7.9,
+        "shortestDay": 2.7,
+        "daysBelowThreeKm": 3,
+        "consistencyStdev": 2.23,
+        "bestThreeDayCombo": 15.6,
+        "recentFiveDayAverage": 3.97,
+        "distanceRemaining": 171.0,
+        "estimatedDaysToFinish": 86,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 14.0,
+        "dailyAverageActual": 2.07,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 3,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 6,
+        "consistencyStdev": 0.71,
+        "bestThreeDayCombo": 7.0,
+        "recentFiveDayAverage": 2.2,
+        "distanceRemaining": 171.0,
+        "estimatedDaysToFinish": 86,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 14.0,
+        "dailyAverageActual": 3.53,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 5,
+        "shortestDay": 1.9,
+        "daysBelowThreeKm": 2,
+        "consistencyStdev": 1.15,
+        "bestThreeDayCombo": 11.9,
+        "recentFiveDayAverage": 3.88,
+        "distanceRemaining": 171.0,
+        "estimatedDaysToFinish": 86,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 9.3,
+        "dailyAverageActual": 1.33,
+        "dailyAverageCapped": 1.33,
+        "longestDay": 2.5,
+        "shortestDay": 0.2,
+        "daysBelowThreeKm": 7,
+        "consistencyStdev": 0.9,
+        "bestThreeDayCombo": 5.0,
+        "recentFiveDayAverage": 1.28,
+        "distanceRemaining": 175.7,
+        "estimatedDaysToFinish": 132,
+        "estimatedFinishDate": "2026-08-19",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 3,
+        "climbPoints": 2,
+        "totalPoints": 5
+      },
+      "marian": {
+        "sprintPoints": 2,
+        "climbPoints": 0,
+        "totalPoints": 2
+      },
+      "nan": {
+        "sprintPoints": 5,
+        "climbPoints": 1,
+        "totalPoints": 6
+      },
+      "wally": {
+        "sprintPoints": 1,
+        "climbPoints": 0,
+        "totalPoints": 1
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 32.8,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-03.json
+++ b/data/riders/snapshots/snapshot-03.json
@@ -1,0 +1,402 @@
+{
+  "segment": 3,
+  "stats": {
+    "asOf": "2026-04-11",
+    "entryNumber": 11,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 22.0,
+        "dailyAverageActual": 4.42,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 7.9,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 2.16,
+        "bestThreeDayCombo": 16.6,
+        "recentFiveDayAverage": 4.9,
+        "distanceRemaining": 163.0,
+        "estimatedDaysToFinish": 82,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 22.0,
+        "dailyAverageActual": 2.17,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 3.5,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 9,
+        "consistencyStdev": 0.82,
+        "bestThreeDayCombo": 8.5,
+        "recentFiveDayAverage": 2.48,
+        "distanceRemaining": 163.0,
+        "estimatedDaysToFinish": 82,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 22.0,
+        "dailyAverageActual": 3.29,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 5,
+        "shortestDay": 1.9,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 1.0,
+        "bestThreeDayCombo": 11.9,
+        "recentFiveDayAverage": 3.3,
+        "distanceRemaining": 163.0,
+        "estimatedDaysToFinish": 82,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 15.6,
+        "dailyAverageActual": 1.42,
+        "dailyAverageCapped": 1.42,
+        "longestDay": 2.5,
+        "shortestDay": 0.2,
+        "daysBelowThreeKm": 11,
+        "consistencyStdev": 0.89,
+        "bestThreeDayCombo": 5.3,
+        "recentFiveDayAverage": 1.42,
+        "distanceRemaining": 169.4,
+        "estimatedDaysToFinish": 119,
+        "estimatedFinishDate": "2026-08-10",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 1,
+        "totalPoints": 19
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 0,
+        "totalPoints": 19
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 2,
+        "totalPoints": 27
+      },
+      "wally": {
+        "sprintPoints": 1,
+        "climbPoints": 0,
+        "totalPoints": 1
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 32.8,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-04.json
+++ b/data/riders/snapshots/snapshot-04.json
@@ -1,0 +1,435 @@
+{
+  "segment": 4,
+  "stats": {
+    "asOf": "2026-04-14",
+    "entryNumber": 14,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 28.0,
+        "dailyAverageActual": 4.93,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 2.23,
+        "bestThreeDayCombo": 20.5,
+        "recentFiveDayAverage": 6.04,
+        "distanceRemaining": 157.0,
+        "estimatedDaysToFinish": 78,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 28.0,
+        "dailyAverageActual": 2.76,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 10,
+        "consistencyStdev": 2.01,
+        "bestThreeDayCombo": 14.8,
+        "recentFiveDayAverage": 4.12,
+        "distanceRemaining": 157.0,
+        "estimatedDaysToFinish": 78,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 28.0,
+        "dailyAverageActual": 3.06,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 5,
+        "shortestDay": 1.2,
+        "daysBelowThreeKm": 7,
+        "consistencyStdev": 1.05,
+        "bestThreeDayCombo": 11.9,
+        "recentFiveDayAverage": 2.66,
+        "distanceRemaining": 157.0,
+        "estimatedDaysToFinish": 78,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 19.6,
+        "dailyAverageActual": 1.4,
+        "dailyAverageCapped": 1.4,
+        "longestDay": 2.5,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 14,
+        "consistencyStdev": 0.89,
+        "bestThreeDayCombo": 5.3,
+        "recentFiveDayAverage": 1.16,
+        "distanceRemaining": 165.4,
+        "estimatedDaysToFinish": 118,
+        "estimatedFinishDate": "2026-08-12",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 1,
+        "totalPoints": 19
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 0,
+        "totalPoints": 19
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 2,
+        "totalPoints": 27
+      },
+      "wally": {
+        "sprintPoints": 14,
+        "climbPoints": 0,
+        "totalPoints": 14
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 32.8,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Cote des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-05.json
+++ b/data/riders/snapshots/snapshot-05.json
@@ -1,0 +1,490 @@
+{
+  "segment": 5,
+  "stats": {
+    "asOf": "2026-04-18",
+    "entryNumber": 18,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 36.0,
+        "dailyAverageActual": 5.24,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 4,
+        "consistencyStdev": 2.18,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 6.76,
+        "distanceRemaining": 149.0,
+        "estimatedDaysToFinish": 74,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 36.0,
+        "dailyAverageActual": 3.22,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 11,
+        "consistencyStdev": 2.26,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 5.67,
+        "distanceRemaining": 149.0,
+        "estimatedDaysToFinish": 74,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 35.2,
+        "dailyAverageActual": 3.06,
+        "dailyAverageCapped": 1.96,
+        "longestDay": 5,
+        "shortestDay": 1.2,
+        "daysBelowThreeKm": 9,
+        "consistencyStdev": 1.13,
+        "bestThreeDayCombo": 11.9,
+        "recentFiveDayAverage": 3.0,
+        "distanceRemaining": 149.8,
+        "estimatedDaysToFinish": 77,
+        "estimatedFinishDate": "2026-07-06",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 27.8,
+        "dailyAverageActual": 1.54,
+        "dailyAverageCapped": 1.54,
+        "longestDay": 2.7,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 18,
+        "consistencyStdev": 0.88,
+        "bestThreeDayCombo": 6.9,
+        "recentFiveDayAverage": 1.98,
+        "distanceRemaining": 157.2,
+        "estimatedDaysToFinish": 102,
+        "estimatedFinishDate": "2026-07-31",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 4,
+        "totalPoints": 22
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 4,
+        "totalPoints": 23
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 4,
+        "totalPoints": 29
+      },
+      "wally": {
+        "sprintPoints": 14,
+        "climbPoints": 0,
+        "totalPoints": 14
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-06.json
+++ b/data/riders/snapshots/snapshot-06.json
@@ -1,0 +1,523 @@
+{
+  "segment": 6,
+  "stats": {
+    "asOf": "2026-04-21",
+    "entryNumber": 21,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 42.0,
+        "dailyAverageActual": 4.85,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 6,
+        "consistencyStdev": 2.26,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 4.05,
+        "distanceRemaining": 143.0,
+        "estimatedDaysToFinish": 72,
+        "estimatedFinishDate": "2026-07-05",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 42.0,
+        "dailyAverageActual": 3.35,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 12,
+        "consistencyStdev": 2.15,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 4.32,
+        "distanceRemaining": 143.0,
+        "estimatedDaysToFinish": 72,
+        "estimatedFinishDate": "2026-07-05",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 42.0,
+        "dailyAverageActual": 3.14,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 5,
+        "shortestDay": 1.2,
+        "daysBelowThreeKm": 10,
+        "consistencyStdev": 1.08,
+        "bestThreeDayCombo": 11.9,
+        "recentFiveDayAverage": 3.34,
+        "distanceRemaining": 143.0,
+        "estimatedDaysToFinish": 72,
+        "estimatedFinishDate": "2026-07-05",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 36.8,
+        "dailyAverageActual": 1.75,
+        "dailyAverageCapped": 1.75,
+        "longestDay": 4.1,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 19,
+        "consistencyStdev": 1.03,
+        "bestThreeDayCombo": 9.0,
+        "recentFiveDayAverage": 2.86,
+        "distanceRemaining": 148.2,
+        "estimatedDaysToFinish": 85,
+        "estimatedFinishDate": "2026-07-18",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 4,
+        "totalPoints": 22
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 4,
+        "totalPoints": 23
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 4,
+        "totalPoints": 29
+      },
+      "wally": {
+        "sprintPoints": 14,
+        "climbPoints": 1,
+        "totalPoints": 15
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 43.2,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.6,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 74.8,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 85.6,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 104.8,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 127,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 153,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 24,
+        "km": 167.2,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-07.json
+++ b/data/riders/snapshots/snapshot-07.json
@@ -1,0 +1,584 @@
+{
+  "segment": 7,
+  "stats": {
+    "asOf": "2026-04-25",
+    "entryNumber": 25,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 50.0,
+        "dailyAverageActual": 4.71,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 7,
+        "consistencyStdev": 2.26,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 3.88,
+        "distanceRemaining": 135.0,
+        "estimatedDaysToFinish": 68,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 50.0,
+        "dailyAverageActual": 3.51,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 12,
+        "consistencyStdev": 2.03,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 4.45,
+        "distanceRemaining": 135.0,
+        "estimatedDaysToFinish": 68,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 50.0,
+        "dailyAverageActual": 3.22,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 5,
+        "shortestDay": 1.2,
+        "daysBelowThreeKm": 11,
+        "consistencyStdev": 1.07,
+        "bestThreeDayCombo": 12.7,
+        "recentFiveDayAverage": 3.68,
+        "distanceRemaining": 135.0,
+        "estimatedDaysToFinish": 68,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 50.0,
+        "dailyAverageActual": 2.07,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 20,
+        "consistencyStdev": 1.23,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 3.8,
+        "distanceRemaining": 135.0,
+        "estimatedDaysToFinish": 67,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 4,
+        "totalPoints": 22
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 6,
+        "totalPoints": 25
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 5,
+        "totalPoints": 30
+      },
+      "wally": {
+        "sprintPoints": 14,
+        "climbPoints": 1,
+        "totalPoints": 15
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 76.59,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 128.99,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.98,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-08.json
+++ b/data/riders/snapshots/snapshot-08.json
@@ -1,0 +1,611 @@
+{
+  "segment": 8,
+  "stats": {
+    "asOf": "2026-04-28",
+    "entryNumber": 28,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 56.0,
+        "dailyAverageActual": 4.75,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 8,
+        "consistencyStdev": 2.22,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 5.27,
+        "distanceRemaining": 129.0,
+        "estimatedDaysToFinish": 64,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 56.0,
+        "dailyAverageActual": 3.57,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 13,
+        "consistencyStdev": 1.98,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 4.22,
+        "distanceRemaining": 129.0,
+        "estimatedDaysToFinish": 64,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 56.0,
+        "dailyAverageActual": 3.45,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 6.1,
+        "shortestDay": 1.2,
+        "daysBelowThreeKm": 11,
+        "consistencyStdev": 1.24,
+        "bestThreeDayCombo": 16.3,
+        "recentFiveDayAverage": 4.4,
+        "distanceRemaining": 129.0,
+        "estimatedDaysToFinish": 64,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 56.0,
+        "dailyAverageActual": 2.12,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 23,
+        "consistencyStdev": 1.17,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 3.26,
+        "distanceRemaining": 129.0,
+        "estimatedDaysToFinish": 64,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 18,
+        "climbPoints": 4,
+        "totalPoints": 22
+      },
+      "marian": {
+        "sprintPoints": 19,
+        "climbPoints": 6,
+        "totalPoints": 25
+      },
+      "nan": {
+        "sprintPoints": 25,
+        "climbPoints": 5,
+        "totalPoints": 30
+      },
+      "wally": {
+        "sprintPoints": 14,
+        "climbPoints": 1,
+        "totalPoints": 15
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 76.59,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 128.99,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.98,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-04-26",
+        "distances": {
+          "justin": 4.95,
+          "marian": 3.3,
+          "nan": 5.1,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2.85,
+          "nan": 6.1,
+          "wally": 2.3
+        }
+      },
+      {
+        "date": "2026-04-28",
+        "distances": {
+          "justin": 7.5,
+          "marian": 6,
+          "nan": 5.1,
+          "wally": 2.6
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-09.json
+++ b/data/riders/snapshots/snapshot-09.json
@@ -1,0 +1,697 @@
+{
+  "segment": 9,
+  "stats": {
+    "asOf": "2026-05-02",
+    "entryNumber": 32,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 64.0,
+        "dailyAverageActual": 4.47,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 11,
+        "consistencyStdev": 2.24,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 3.52,
+        "distanceRemaining": 121.0,
+        "estimatedDaysToFinish": 60,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 64.0,
+        "dailyAverageActual": 3.47,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 16,
+        "consistencyStdev": 1.89,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 3.44,
+        "distanceRemaining": 121.0,
+        "estimatedDaysToFinish": 60,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 63.2,
+        "dailyAverageActual": 3.32,
+        "dailyAverageCapped": 1.98,
+        "longestDay": 6.1,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 13,
+        "consistencyStdev": 1.25,
+        "bestThreeDayCombo": 16.3,
+        "recentFiveDayAverage": 2.9,
+        "distanceRemaining": 121.8,
+        "estimatedDaysToFinish": 62,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 4
+      },
+      "wally": {
+        "totalDistanceCapped": 64.0,
+        "dailyAverageActual": 2.2,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 26,
+        "consistencyStdev": 1.18,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 2.74,
+        "distanceRemaining": 121.0,
+        "estimatedDaysToFinish": 60,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 31,
+        "climbPoints": 5,
+        "totalPoints": 36
+      },
+      "marian": {
+        "sprintPoints": 36,
+        "climbPoints": 6,
+        "totalPoints": 42
+      },
+      "nan": {
+        "sprintPoints": 40,
+        "climbPoints": 7,
+        "totalPoints": 47
+      },
+      "wally": {
+        "sprintPoints": 34,
+        "climbPoints": 1,
+        "totalPoints": 35
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "wally",
+            "date": "2026-04-30",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-30",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-30",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "justin",
+            "date": "2026-05-01",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-29",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-29",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-29",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-29",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 76.59,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 128.99,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.98,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-04-26",
+        "distances": {
+          "justin": 4.95,
+          "marian": 3.3,
+          "nan": 5.1,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2.85,
+          "nan": 6.1,
+          "wally": 2.3
+        }
+      },
+      {
+        "date": "2026-04-28",
+        "distances": {
+          "justin": 7.5,
+          "marian": 6,
+          "nan": 5.1,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-29",
+        "distances": {
+          "justin": 1.8,
+          "marian": 1.9,
+          "nan": 3.1,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-04-30",
+        "distances": {
+          "justin": 1.6,
+          "marian": 2.6,
+          "nan": 3.1,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-05-01",
+        "distances": {
+          "justin": 2.3,
+          "marian": 2.3,
+          "nan": 1,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-05-02",
+        "distances": {
+          "justin": 4.4,
+          "marian": 4.4,
+          "nan": 2.2,
+          "wally": 2.7
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-10.json
+++ b/data/riders/snapshots/snapshot-10.json
@@ -1,0 +1,724 @@
+{
+  "segment": 10,
+  "stats": {
+    "asOf": "2026-05-05",
+    "entryNumber": 35,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 70.0,
+        "dailyAverageActual": 4.33,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.5,
+        "shortestDay": 1.1,
+        "daysBelowThreeKm": 12,
+        "consistencyStdev": 2.21,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 2.99,
+        "distanceRemaining": 115.0,
+        "estimatedDaysToFinish": 58,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 70.0,
+        "dailyAverageActual": 3.47,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 17,
+        "consistencyStdev": 1.86,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 3.41,
+        "distanceRemaining": 115.0,
+        "estimatedDaysToFinish": 58,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      },
+      "nan": {
+        "totalDistanceCapped": 70.0,
+        "dailyAverageActual": 3.25,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 6.1,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 16,
+        "consistencyStdev": 1.22,
+        "bestThreeDayCombo": 16.3,
+        "recentFiveDayAverage": 2.18,
+        "distanceRemaining": 115.0,
+        "estimatedDaysToFinish": 58,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 3
+      },
+      "wally": {
+        "totalDistanceCapped": 70.0,
+        "dailyAverageActual": 2.22,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 29,
+        "consistencyStdev": 1.13,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 2.52,
+        "distanceRemaining": 115.0,
+        "estimatedDaysToFinish": 58,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 4
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 31,
+        "climbPoints": 5,
+        "totalPoints": 36
+      },
+      "marian": {
+        "sprintPoints": 36,
+        "climbPoints": 6,
+        "totalPoints": 42
+      },
+      "nan": {
+        "sprintPoints": 40,
+        "climbPoints": 7,
+        "totalPoints": 47
+      },
+      "wally": {
+        "sprintPoints": 34,
+        "climbPoints": 1,
+        "totalPoints": 35
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "wally",
+            "date": "2026-04-30",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-30",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-30",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "justin",
+            "date": "2026-05-01",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-29",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-29",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-29",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-29",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te des Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 76.59,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 128.99,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.98,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-04-26",
+        "distances": {
+          "justin": 4.95,
+          "marian": 3.3,
+          "nan": 5.1,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2.85,
+          "nan": 6.1,
+          "wally": 2.3
+        }
+      },
+      {
+        "date": "2026-04-28",
+        "distances": {
+          "justin": 7.5,
+          "marian": 6,
+          "nan": 5.1,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-29",
+        "distances": {
+          "justin": 1.8,
+          "marian": 1.9,
+          "nan": 3.1,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-04-30",
+        "distances": {
+          "justin": 1.6,
+          "marian": 2.6,
+          "nan": 3.1,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-05-01",
+        "distances": {
+          "justin": 2.3,
+          "marian": 2.3,
+          "nan": 1,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-05-02",
+        "distances": {
+          "justin": 4.4,
+          "marian": 4.4,
+          "nan": 2.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-03",
+        "distances": {
+          "justin": 1.55,
+          "marian": 1.55,
+          "nan": 2.4,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-04",
+        "distances": {
+          "justin": 3.3,
+          "marian": 3.9,
+          "nan": 2.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-05-05",
+        "distances": {
+          "justin": 3.4,
+          "marian": 4.9,
+          "nan": 2.6,
+          "wally": 2.6
+        }
+      }
+    ]
+  }
+}

--- a/data/riders/snapshots/snapshot-11.json
+++ b/data/riders/snapshots/snapshot-11.json
@@ -1,0 +1,779 @@
+{
+  "segment": 11,
+  "stats": {
+    "asOf": "2026-05-09",
+    "entryNumber": 39,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 75.8,
+        "dailyAverageActual": 4.1,
+        "dailyAverageCapped": 1.94,
+        "longestDay": 8.5,
+        "shortestDay": 0.3,
+        "daysBelowThreeKm": 15,
+        "consistencyStdev": 2.24,
+        "bestThreeDayCombo": 21.0,
+        "recentFiveDayAverage": 2.35,
+        "distanceRemaining": 109.2,
+        "estimatedDaysToFinish": 56,
+        "estimatedFinishDate": "2026-07-06",
+        "place": 4
+      },
+      "marian": {
+        "totalDistanceCapped": 77.5,
+        "dailyAverageActual": 3.56,
+        "dailyAverageCapped": 1.99,
+        "longestDay": 9.1,
+        "shortestDay": 0.9,
+        "daysBelowThreeKm": 19,
+        "consistencyStdev": 1.97,
+        "bestThreeDayCombo": 19.1,
+        "recentFiveDayAverage": 4.46,
+        "distanceRemaining": 107.5,
+        "estimatedDaysToFinish": 54,
+        "estimatedFinishDate": "2026-07-04",
+        "place": 3
+      },
+      "nan": {
+        "totalDistanceCapped": 78.0,
+        "dailyAverageActual": 3.21,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 6.1,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 18,
+        "consistencyStdev": 1.18,
+        "bestThreeDayCombo": 16.3,
+        "recentFiveDayAverage": 2.82,
+        "distanceRemaining": 107.0,
+        "estimatedDaysToFinish": 53,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 1
+      },
+      "wally": {
+        "totalDistanceCapped": 78.0,
+        "dailyAverageActual": 2.34,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 30,
+        "consistencyStdev": 1.14,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 3.24,
+        "distanceRemaining": 107.0,
+        "estimatedDaysToFinish": 53,
+        "estimatedFinishDate": "2026-07-03",
+        "place": 2
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 31,
+        "climbPoints": 5,
+        "totalPoints": 36
+      },
+      "marian": {
+        "sprintPoints": 36,
+        "climbPoints": 8,
+        "totalPoints": 44
+      },
+      "nan": {
+        "sprintPoints": 40,
+        "climbPoints": 13,
+        "totalPoints": 53
+      },
+      "wally": {
+        "sprintPoints": 34,
+        "climbPoints": 5,
+        "totalPoints": 39
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "wally",
+            "date": "2026-04-30",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-30",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-30",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "justin",
+            "date": "2026-05-01",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Bugeat",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-29",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-29",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-29",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-29",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 77.45,
+        "category": 2,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-05-09",
+            "points": 6
+          },
+          {
+            "place": 2,
+            "rider": "wally",
+            "date": "2026-05-09",
+            "points": 4
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-05-09",
+            "points": 2
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": "HC",
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 128.99,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.98,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-04-26",
+        "distances": {
+          "justin": 4.95,
+          "marian": 3.3,
+          "nan": 5.1,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2.85,
+          "nan": 6.1,
+          "wally": 2.3
+        }
+      },
+      {
+        "date": "2026-04-28",
+        "distances": {
+          "justin": 7.5,
+          "marian": 6,
+          "nan": 5.1,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-29",
+        "distances": {
+          "justin": 1.8,
+          "marian": 1.9,
+          "nan": 3.1,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-04-30",
+        "distances": {
+          "justin": 1.6,
+          "marian": 2.6,
+          "nan": 3.1,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-05-01",
+        "distances": {
+          "justin": 2.3,
+          "marian": 2.3,
+          "nan": 1,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-05-02",
+        "distances": {
+          "justin": 4.4,
+          "marian": 4.4,
+          "nan": 2.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-03",
+        "distances": {
+          "justin": 1.55,
+          "marian": 1.55,
+          "nan": 2.4,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-04",
+        "distances": {
+          "justin": 3.3,
+          "marian": 3.9,
+          "nan": 2.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-05-05",
+        "distances": {
+          "justin": 3.4,
+          "marian": 4.9,
+          "nan": 2.6,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-05-06",
+        "distances": {
+          "justin": 2.7,
+          "marian": 6.2,
+          "nan": 3.1,
+          "wally": 4
+        }
+      },
+      {
+        "date": "2026-05-07",
+        "distances": {
+          "justin": 3.8,
+          "marian": 7.7,
+          "nan": 3.9,
+          "wally": 3.9
+        }
+      },
+      {
+        "date": "2026-05-08",
+        "distances": {
+          "justin": 0.35,
+          "marian": 2,
+          "nan": 2.3,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-09",
+        "distances": {
+          "justin": 1.5,
+          "marian": 1.5,
+          "nan": 2.2,
+          "wally": 3
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Lifts the gitignore on \`data/riders/snapshots/\` and commits the 12 snapshots that exist today (segs 00 preview through 11). The live \`daily-log.json\` / \`stats.json\` / \`points.json\` remain ignored — those continue to be regenerated each publish.

## Why

Snapshots are different from the other rider data files:

- **daily-log.json** — continuously appended to as riders log distances.
- **stats.json / points.json** — regenerated each publish from the current daily-log.
- **snapshots/snapshot-NN.json** — **write-once at publish time**, frozen against the published entry's \`dataCutoff\`, and the canonical source for the rider standings shown on each published entry's page.

Leaving snapshots gitignored means their values live only on the publisher's machine. A rebuild from a fresh clone regenerates them from daily-log.json, and that regeneration is non-deterministic against the original publish:

- The time-of-day finish-date bug (#541) is one source of drift — re-running the snapshot for seg 11 in the morning vs evening produces different \`estimatedFinishDate\` values.
- Post-publish hotfix corrections (e.g. today's seg 11 \`estimatedFinishDate\` edits for Nan and Wally) would be lost on rebuild.
- Future changes to the stats algorithm would silently retroactively change past published entries.

Tracking the snapshots makes published-entry standings reproducible and locks in the canonical values that readers saw at publish time.

Refs #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)