### PR TITLE
docs(strands): fix validate_entries.py path in template (closes #510)

### DIFF
--- a/docs/strands/STRAND-BRIEF-TEMPLATE.md
+++ b/docs/strands/STRAND-BRIEF-TEMPLATE.md
@@ -45,7 +45,7 @@ Only commands that actually exist in `package.json` / the codebase. Examples tha
 
 - `npm test`
 - `python3 processing/validate_points.py`
-- `python3 scripts/validate_entries.py`
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive`
 - `npm run build`
 - `npx nuxt prepare` (in worktrees, if `.nuxt/` not yet generated)
 


### PR DESCRIPTION
## Summary

- `docs/strands/STRAND-BRIEF-TEMPLATE.md` §6 listed `python3 scripts/validate_entries.py` (does not exist)
- Actual location is `processing/validate_entries.py` and the script requires `--entries-dir content/entries --non-interactive`
- Filed as #510 during the 2026-05-07 `/strand-brief` skill strand; fixed inline in planning 2026-05-12 per the v1.4.18 close-out sweep

## Test plan

- [x] Path verified: `processing/validate_entries.py` exists; `scripts/validate_entries.py` does not
- [x] Flag set verified against `processing/validate_entries.py --help`
- [x] Future strand briefs generated via `/strand-brief` already use the corrected form (skill template was authoritative; this template caught up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)