### PR TITLE
data: seg 20-22 verification (closes #499)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -407,7 +407,7 @@
     "description": "Ruins of two 1st-3rd century Gallo-Roman funerary temples with carved granite on the Plateau de Millevaches.",
     "links": [
       {
-        "url": "https://fr.wikipedia.org/wiki/Tours_de_Bonneval",
+        "url": "https://fr.wikipedia.org/wiki/Ruines_gallo-romaines_des_Cars",
         "label": "Wikipedia (fr)"
       }
     ],

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -127,8 +127,9 @@
   },
   "Mont Bessou": {
     "type": "climb",
-    "lat": 45.5701029,
-    "lng": 2.1231273
+    "lat": 45.57157,
+    "lng": 2.02363,
+    "note": "Summit coordinate updated 2026-05-12 (issue #499) to the polyline position at the points-config summit km 152.31 / segment 22 / elev 892m (road crest). Old coord (45.5701029, 2.1231273) sat at km 161.18 / segment 23 / elev 973m — the geographic 977m summit, off-route from the road by ~1.3 km. Per the #477 precedent (Puy de Lachaud), coord aligned to points-config km, not to geographic peak. Mont Bessou remains the highest point in Corrèze at 977m; the road passes under the peak rather than over it."
   },
   "Côte des Gardes": {
     "type": "climb",


### PR DESCRIPTION
Closes #499. Milestone: v1.4.19.

Verification strand for segs 20–22 (km ~128–154: Bugeat → Plateau de Millevaches → Mont Bessou). Three concrete data bugs surfaced; two landed here, one filed as a follow-up.

## Audit summary

| Claim | Source | Result |
|---|---|---|
| GPX polyline integrity segs 20/21/22 | `segment-{20,21,22}.gpx` vs `segments.json` | ✅ km math matches (lengths 5.999 / 8.004 / 5.989) |
| Elevation extents segs 20/21/22 | `segments.json` vs GPX | ✅ min/max match |
| Mont Bessou summit km vs GPX local max | points-config km 152.31 vs GPX max km 152.25 | ✅ 60m offset, acceptable |
| Mont Bessou gradient 2.7% | hand-recomputed from GPX | ✅ 2.66%, diff +0.04pp |
| **Mont Bessou town-coords coord** | `town-coords.json` vs polyline at points-config km | ❌ **FIXED** — was 8.91 km off (seg 23 / geographic summit); now aligned to road crest at km 152.31 |
| Bugeat keyed to seg 21 | `segments.json` + `town-coords.json` | ✅ 24m off polyline at km 143.64 |
| 2024 TdF Stage 11 re-keyed to seg 22 (#514) | `historical-tdf.json` | ✅ re-keying held; Puy Mary 1589m ↔ Mont Bessou 977m parallel reads cleanly; no detail leaks back to segs 14-16 |
| **Les Cars Gallo-Roman Site Wikipedia link** | `attractions.json` | ❌ **FIXED** — was pointing to `Tours_de_Bonneval`; corrected to `Ruines_gallo-romaines_des_Cars` |
| Stele des Maquisards proximity | `attractions.json` | ✅ matches stored |
| Tourbière de Longeyroux (km 154.4) | `attractions.json` | ✅ valid, keyed to seg 23 (just outside seg 22) |
| Plateau de Millevaches attractions density | `attractions.json` km 134-154 | ✅ verified empty (Parc itself is the attraction; pattern from brief held) |
| Notable_points segs 20-22 | `segments.json` | ✅ empty (consistent with rest of file; no convention shift required) |
| **Sprint - Bugeat km/seg drift** | `points-config.json` km 130 / seg 19 vs town at km 143.67 / seg 21 | ❌ **FILED as #549** — out of write set (points-config is climb-data strand territory) |
| `npm test` (198 tests) | runtime | ✅ pass |
| `validate_points.py` + `validate_entries.py` + `audit_segment_data.py 20/21/22` | runtime | ✅ all clean |
| `npm run build` | runtime | ✅ complete |

## Mont Bessou coord — the headline fix

Old coord (45.5701029, 2.1231273) sat at km 161.18 / segment 23 on the polyline, 47m off-route — i.e. it was pointing at the geographic 977m summit, not the road crest. Strange consequence: anything rendering the Mont Bessou marker on a seg 22 map showed it 8.91 km past where the climb actually crests.

New coord (45.57157, 2.02363) sits exactly on the seg 22 polyline at km 152.31 (0m offset, elev 892m), matching the points-config summit km. Mont Bessou remains the highest point in Corrèze at 977m; the road passes under the peak rather than over it. The 1.3km geographic-vs-road offset is preserved as a `note` field on the coord, since it's exactly the kind of geological-narrative hook downstream drafting strands may want.

This is the third instance of the "climb coord ≠ points-config summit km" bug class (after Puy de Lachaud #477 and the Naves fix in #516). See retro-input notes for proposed assertion to catch the class in CI.

## Cross-strand concurrency

- **#498** (segs 17-19): worktree exists at `/home/jhs/code/tdf26-verify-498`. No overlapping km ranges with this strand.
- **#500** (segs 23-26): strand presence unknown to this session. No overlapping km ranges. If a PR from #500 lands first and touches `town-coords.json` or `attractions.json`, expect a trivial merge.

## Forward signals for downstream drafting strands

- **Seg 22 Mont Bessou as candidate home for the geological-transition story deferred from seg 11.** The riders pass under the peak, not over it. Granite, watershed, Millevaches etymology, the literal Stage 9 high point all converge there.
- **Plateau de Millevaches attractions are genuinely sparse.** Drafting strands should lean on Parc identity and heathland/peat-bog ecology, not classical "things to see."
- **Stele des Maquisards description** ("Maquis du Mont Gargan" framing) is loose — Mont Gargan is in Haute-Vienne ~30km west. Description could be tightened in a later content pass to acknowledge Maquis Liberté / FTP activity on the Plateau itself. Not blocking; flagged for the drafting strand.

## Claims I did not verify in this strand

- ASO categorisation of Mont Bessou per #492 — read-only, accepted as carry-forward (Cat 4, ASO=true per points-config).
- Mont Bessou geographic summit 977m as highest point in Corrèze — accepted from CLAUDE.md + Wikipedia; not cross-checked against IGN.
- Pre-publish weather/image rights review — segs 20-22 publish mid-June 2026; scrutiny window not yet open.
- Sprint - Bugeat fix path — filed as #549, not resolved here.

## Test plan

- [x] `npm test` — 198 tests pass
- [x] `python3 processing/validate_points.py` — OK
- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — OK
- [x] `python3 processing/audit_segment_data.py --segment {20,21,22}` — all clean (Mont Bessou stored-vs-computed km now matches)
- [x] `npm run build` — complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)