### PR TITLE
data: seg 17-19 verification (closes #498)

### DIFF
--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -79,6 +79,17 @@
     ]
   },
   {
+    "segments": [17, 18, 19],
+    "events": [
+      {
+        "year": 2020,
+        "stage": "Stage 12",
+        "route": "Chauvigny to Sarran",
+        "description": "The same 218 km Hirschi-victory stage that crossed Suc au May (see seg 15) also crossed our segs 17-19 — in the opposite direction. Approaching from the north, the 2020 peloton rolled south through what is now our seg 17 corridor into Treignac, then climbed east up the road our 2026 route descends — the Côte de la Croix du Pey, categorised that day as Cat 3, 3.8 km at 6.1% (a tighter anchor than our points-config 7.0 km at 4.4%; both top out at the same Lestards-area crest). The stage then turned south for Suc au May. For the 2026 Stage 9, this same road network is traversed in reverse: down off Suc au May, through Treignac, up Croix du Pey to the Plateau de Millevaches."
+      }
+    ]
+  },
+  {
     "segments": [22],
     "events": [
       {

--- a/data/segments.json
+++ b/data/segments.json
@@ -313,7 +313,9 @@
     "min_elevation": 522,
     "max_elevation": 605,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Madranges"
+    ],
     "climbs": []
   },
   {
@@ -349,7 +351,9 @@
     "min_elevation": 619,
     "max_elevation": 851,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Lestards"
+    ],
     "climbs": [
       "Côte de la Croix de Pey"
     ]

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -66,10 +66,22 @@
     "lng": 1.83625,
     "source": "https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) (verified 2026-05-07; OSM place=village confirms). Bourg sits 9m off the polyline at km 94.52 (seg 14). Added during seg 14-16 verification (#478) — the route runs through the village; previously absent from town-coords.json and segments.json towns array."
   },
+  "Madranges": {
+    "type": "town",
+    "lat": 45.4756,
+    "lng": 1.7911,
+    "source": "https://en.wikipedia.org/wiki/Madranges (verified 2026-05-12). Plateau de Millevaches gateway commune (pop ~166, area 12.88 km²); bourg sits 102 m off the polyline at km 113.31 (seg 17). Added during seg 17-19 verification (#498) — previously absent from town-coords.json and segments.json towns array."
+  },
   "Treignac": {
     "type": "town",
     "lat": 45.5365916,
     "lng": 1.7935339
+  },
+  "Lestards": {
+    "type": "town",
+    "lat": 45.5164,
+    "lng": 1.8747,
+    "source": "https://en.wikipedia.org/wiki/Lestards (verified 2026-05-12). Hilltop commune on the Plateau de Millevaches (pop ~117, area 18.52 km², elevation 518–894 m); the bourg sits 12 m off the polyline at km 130.39 (seg 19). The Côte de la Croix de Pey climb is named after a granite cross on the historic Chemin des Croix (formerly Chemin des Morts) forest path linking Lestards to Treignac (cross itself at 45.51976, 1.886124, ~620 m off-route). Added during seg 17-19 verification (#498) — previously absent from town-coords.json and segments.json towns array."
   },
   "Bugeat": {
     "type": "town",
@@ -122,8 +134,9 @@
   },
   "Côte de la Croix de Pey": {
     "type": "climb",
-    "lat": 45.5192072,
-    "lng": 1.8741342
+    "lat": 45.523120,
+    "lng": 1.866130,
+    "note": "Summit coordinate updated 2026-05-12 (issue #498) to the polyline position at the points-config declared summit km 128.99 (ele 801 m). The previous coord (45.5192072, 1.8741342) sat ~333 m north of Lestards village and closest-approached the polyline at km 131.83 / ele 830 m, a 2.84 km divergence from the points-config km — flagged by `processing/audit_segment_data.py`. Same alignment principle as Côte de Naves (#490) and Puy de Lachaud (#477). Caveats captured here, not in the data: (1) the mycols/climbfinder community 'summit' of this climb is 821 m at the first crest of our route — km 129.375 in our GPX, ~0.4 km past the points-config km, on a small plateau where elevation peaks at 823 m before a brief dip; (2) the 2020 TdF Stage 12 categorised this climb as Cat 3, 3.8 km @ 6.1% (a tighter anchor than our 7.0 km @ 4.4%, both topping out at the same Lestards-area crest); (3) the road continues to a higher 851 m peak at km 132.52 before entering the Plateau de Millevaches plateau (seg 20 start). The points-config length/gradient is internally consistent with elevation/segment-19.json per tests/utils/climb-gradient.test.ts but diverges from mycols (6.4 km @ 5.1%) and 2020 ASO (3.8 km @ 6.1%) — drift family with Suc au May (#513), sister issue filed."
   },
   "Mont Bessou": {
     "type": "climb",

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -25,7 +25,9 @@ export const townKmPositions: Record<string, number> = {
   'Naves': 78.19,                // updated 2026-04-25, 373m from village; seg 12
   'Saint-Augustin': 94.52,       // 9m from village (route runs through bourg); seg 14 (added 2026-05-07, #478)
   'Chaumeil': 100.30,            // updated 2026-04-25, 35m from village; seg 15
+  'Madranges': 113.31,           // 102m from village; seg 17 (added 2026-05-12, #498)
   'Treignac': 121.95,            // updated 2026-04-25, 22m from village; seg 18
+  'Lestards': 130.39,            // 12m from village (route runs through bourg); seg 19 (added 2026-05-12, #498)
   'Bugeat': 143.67,              // updated 2026-04-25, 23m from village; seg 21
   'Meymac': 168.15,              // updated 2026-04-25, 47m from village; seg 25
   'Ussel': 182.5,                // route-entry point (city centre is 2.5km north of route)


### PR DESCRIPTION
## Summary

Closes #498. Data verification for segments 17-19 (km ~112-134, Madranges through Treignac and the Côte de la Croix de Pey to the Plateau de Millevaches gateway) ahead of the seg 17 publish on Sun 2026-05-31. Mirrors PR #470 (segs 9-10), PR #489 (segs 11-13), PR #514 (segs 14-16). Strand brief at `docs/strands/strand-498-verify-segs-17-19.md`.

## Per-claim audit table

| Claim | Source | Current value | Audit finding | Action |
|---|---|---|---|---|
| Seg 17/18/19 km boundaries | segments.json vs GPX cumulative | km 112-120, 120-126, 126-134 | matches GPX polyline within rounding (master track 184.88 km / Malemort-Ussel route 185.0 km nominal) | unchanged |
| Seg 17/18/19 elevation_gain / elevation_loss / min/max | segments.json vs elevation/segment-NN.json | stored values | minor smoothing-method drift vs per-segment elevation files; consistent with PR #489's finding | unchanged |
| Treignac town keying | segments.json + town-positions.ts + town-coords.json | seg 18, km 121.95, 22 m off | km matches (-0.00) per audit_segment_data; clean | unchanged |
| Treignac "Plus Beaux Villages de France" status (CARRYFORWARD) | Brief implicitly, CLAUDE.md staleness suspected | "medieval bridge, granite town" framing | Verified: Treignac is in **Petites Cités de Caractère** (label since 2018), **not** in Les Plus Beaux Villages de France (checked the official directory of 184 villages, Treignac not listed). The Wikipedia EN article's "designated one of France's most beautiful villages" wording is the upstream source of this confusion. | flagged for downstream drafters (no data change here); CLAUDE.md staleness already covered by #491 |
| Treignac historical facts (NEW) | Wikipedia EN, Petites Cités de Caractère | not in data | Verified: founded ~800 AD; first castle ~1000 on Vézère meander; three medieval charters (1205, 1284, 1438) establishing free city governed by four consuls; sacked by Rodrigue de Villandrando during Hundred Years' War; sacked again in 16th-c Wars of Religion. Notre-Dame des Bans (parish church, Gothic 13th-c, bell tower 1602). Notre-Dame de la Paix chapel has one of Europe's rare twisted bell towers. Old Bridge medieval (13th-14th c). Grain hall 12th-c, rebuilt 15th-c. | flagged for downstream drafters as content carryforward |
| Madranges on-route position (NEW) | OSM, Wikipedia EN (45.4756, 1.7911) | absent from data | route runs 102 m from the bourg at km 113.31 (seg 17) — the village was missing from town-coords, town-positions, and segments.json towns array. Plateau de Millevaches gateway commune (pop ~166); rare-for-Limousin combination of Catholic church + Protestant temple. | ✅ added in this PR |
| Lestards on-route position (NEW) | OSM, Wikipedia EN (45.5164, 1.8747) | absent from data | route runs 12 m from the bourg at km 130.39 (seg 19) — the village was missing from town-coords, town-positions, and segments.json towns array. Hilltop commune on the Plateau de Millevaches (pop ~117, elevation 518-894 m); the Côte de la Croix de Pey climb is named after a granite cross on the historic Chemin des Croix (forest path between Lestards and Treignac). | ✅ added in this PR |
| Côte de la Croix de Pey summit coord | town-coords.json (45.5192072, 1.8741342) vs points-config km 128.99 | stored | stored coord closest-approached the polyline at km 131.83 — a 2.84 km divergence from the declared summit km, flagged by `audit_segment_data.py`. Old coord sat ~333 m from Lestards village (which is now keyed separately as a town). | ✅ relocated to (45.523120, 1.866130), the polyline position at points-config summit km 128.99; same alignment principle as #490 (Côte de Naves) and #477 (Puy de Lachaud) |
| Côte de la Croix de Pey length × gradient | points-config (7.0 km @ 4.4%) vs mycols.app (6.4 km @ 5.1%) vs 2020 TdF Stage 12 ASO (3.8 km @ 6.1%) | 7.0 km @ 4.4%, Cat 3 | three sources pick different climb start points (all terminate at the Lestards-area crest); points-config passes `tests/utils/climb-gradient.test.ts` over its declared span [121.99, 128.99] (internal consistency holds) but differs from external sources | filed **#551** (sister of #513, drift family); category agreement (Cat 3) is the one point of consensus |
| Côte de la Croix de Pey "summit" disambiguation | GPX local maxima | declared km 128.99 = 801 m | the road climbs from Treignac (low km 122.14 / 477 m) over a first crest at km 129.375 / 823 m (matches mycols 821 m summit), dips briefly to km 130.48 / 807 m, then climbs to a higher 851 m peak at km 132.52 before entering the Plateau de Millevaches plateau (seg 20 start at km 134.21 / 821 m) | captured in coord `note`; #551 to track ASO-anchor reconciliation |
| Côte de la Croix de Pey on-route geography | town-coords + GPX | climb keyed to segs 18 + 19 (spans both per validate_points invariant) | clean | unchanged |
| Sprint - Bugeat | points-config | km 130.00, seg 19 | km 130 inside declared seg 19 (clean per audit) | unchanged |
| Attractions in segs 17-19 | attractions.json | 5 entries: Gorges de la Vezere, Pont Medieval de Treignac, Pont de la Tourmente, Eglise Notre-Dame-des-Bans, Lac des Bariousses | all 5 verified clean per audit_segment_data (stored nearest_km / nearest_distance_m match computed values within rounding) | unchanged |
| Notable attractions absence in seg 19 | attractions.json | seg 19 has no attractions | "verified empty" per the Plateau de Millevaches sparseness pattern (PR #514 finding); the Croix du Pey heritage cross itself sits ~620 m off-route on a forest path (Chemin des Croix), borderline by the precedent of Pont de la Tourmente (319 m) and PR #514's Suc au May Table d'orientation (442 m) | not added — name is captured via climb naming; conservative scope discipline |
| Notable attractions absence in seg 17 | attractions.json | seg 17 has no attractions | "verified empty" — descent corridor from Suc au May into Treignac with farmland and forest; no monuments historiques on the road | unchanged |
| Historical TdF in segs 17-19 | historical-tdf.json | empty for segs 17-19 | 2020 Stage 12 (Chauvigny → Sarran) crossed our segs 17-19 (in opposite direction) — entered Treignac from the north, climbed east up Côte de la Croix du Pey (cat 3, 3.8 km @ 6.1% that day) before continuing south for Suc au May. Already keyed to seg 15 for Suc au May (PR #514); the seg 19 keying captures the Croix du Pey crossing. | ✅ added new `[17, 18, 19]` group with 2020 Stage 12 entry (does not duplicate the [15] entry; different angle on the same stage) |
| 1987 men's Stage 11 (Poitiers→Chaumeil) route through segs 17-19 | inference from Chaumeil finish | not in data for these segs | the stage came from Poitiers (north) and finished at Chaumeil — plausible it traversed Treignac/Croix du Pey but no direct route-archive evidence found | not added; flagged here for downstream verification if needed |
| 2017 Tour du Limousin Stage 3 Côte de Lestards mention | historical-tdf.json (currently keyed seg 15) | description mentions "Côte de la Vaysse and Côte de Lestards before three finishing circuits over the Côte des Géants in Chaumeil" | the "Côte de Lestards" climb name maps directly to the Lestards village now keyed in seg 19 — strong indication the 2017 stage traversed seg 19 going opposite direction | **not re-keyed** in this PR (no archived stage map confirmed); flagged in this audit table for downstream drafters |

## Data changes

### `data/town-coords.json`
- **Madranges** added (`type: "town"`, `lat: 45.4756`, `lng: 1.7911`, 102 m off polyline at km 113.31, seg 17). Source: Wikipedia EN.
- **Lestards** added (`type: "town"`, `lat: 45.5164`, `lng: 1.8747`, 12 m off polyline at km 130.39, seg 19). Source: Wikipedia EN; note records Croix du Pey heritage-cross context.
- **Côte de la Croix de Pey** coord relocated from `(45.5192072, 1.8741342)` → `(45.523120, 1.866130)`. New coord is the polyline position at the points-config summit km 128.99 (ele 801 m). Note records: previous-coord drift, ASO/mycols length-gradient drift filed as #551, GPX-peak vs declared-summit ambiguity at the first crest.

### `data/town-positions.ts`
- **Madranges** added between Chaumeil and Treignac at km 113.31.
- **Lestards** added between Treignac and Bugeat at km 130.39.

### `data/segments.json`
- **Seg 17** `towns` array now `["Madranges"]` (was `[]`).
- **Seg 19** `towns` array now `["Lestards"]` (was `[]`).

### `data/historical-tdf.json`
- New `segments: [17, 18, 19]` grouping with one event: 2020 TdF Stage 12 Croix du Pey crossing (does **not** duplicate the existing [15] entry for the same stage; the [15] entry focuses on Suc au May, the new [17, 18, 19] entry focuses on the Croix du Pey climb and the reversed-direction parallel with our 2026 route).

## Items verified but unchanged

- Seg 17/18/19 `km_start`/`km_end`/lat-lng boundaries — match GPX polyline.
- Treignac town keying (km 121.95, 22 m off, seg 18) — clean per audit.
- All 5 attractions in segs 17-18 — clean per audit (Gorges de la Vezere, Pont Medieval de Treignac, Pont de la Tourmente, Eglise Notre-Dame-des-Bans, Lac des Bariousses).
- Sprint - Bugeat (km 130, seg 19) — clean per audit.
- `validate_points.py` invariants — all pass.

## Out of scope (deferred — filed as separate issues / flagged)

- **Côte de la Croix de Pey length/gradient drift** (points-config 7.0 km @ 4.4% vs mycols 6.4 km @ 5.1% vs 2020 ASO 3.8 km @ 6.1%). Filed as **#551**, sister to #513 (Suc au May) and #490 (Côte de Naves). Strand B / points-config territory.
- **CLAUDE.md image-source table staleness** — table keys "Treignac" to seg 17, but Treignac is in seg 18 per current segments.json (and has been since the v1.4.8 audit). Already covered by **#491** (CLAUDE.md known-waypoints staleness).
- **CLAUDE.md Treignac in `Known Waypoints` paragraph** — references Treignac without status; the Petites Cités de Caractère label is content carryforward worth surfacing when seg 18 drafts. Captured in audit table, not edited in CLAUDE.md.
- **2017 Tour du Limousin Stage 3 Côte de Lestards** — strong evidence the stage traversed seg 19 (climb name maps to our newly-keyed Lestards), but no archived stage map verified. Not re-keyed; flagged for the seg 19 drafting strand.
- **1987 men's Stage 11 Poitiers→Chaumeil route through segs 17-19** — plausible but unverified. Flagged here, not added.

## Carryforwards for downstream drafting strands (segs 17/18/19)

These belong to drafting, captured here for awareness:

- **Treignac** — Petites Cités de Caractère (label since 2018), **not** Plus Beaux Villages; "city of the meanders of the Vézère". Founding ~800 AD; first castle ~1000 on Vézère meander; three medieval charters; sacked twice (Rodrigue de Villandrando during Hundred Years' War, then 16th-c Wars of Religion). Notre-Dame de la Paix chapel has one of Europe's rare twisted bell towers — strong narrative hook. Three historic churches (Saint-Martin, Saint-Léobon, Saint-Jean) plus the current parish Notre-Dame des Bans.
- **Madranges** (seg 17) — Plateau de Millevaches gateway; foot of Monédières; watered by Boulou and Madrange streams (tributaries of the Vézère); rare-for-Limousin combination of Catholic church + Protestant temple. Pop ~166.
- **Lestards** (seg 19) — hilltop commune (518-894 m); church of Saint-Martial; the Côte de la Croix de Pey climb's namesake heritage cross sits on the Chemin des Croix (formerly Chemin des Morts) forest path linking Lestards to Treignac. Pop ~117.
- **Côte de la Croix de Pey** narrative — the climb is named after a granite cross (carved Christ's face emerging from the stone) on a heritage path off the cycling road, not at the road summit itself. Strong place-naming and Catholic-heritage narrative material. Two crests on the road (823 m at km 129.4, then a dip, then 851 m at km 132.5) — the 2026 stage tops the second, higher peak just before entering the Plateau de Millevaches plateau proper.
- **2020 TdF Stage 12 reversed parallel** — same road network, opposite direction. Hirschi's first-Suc-au-May stage also climbed Croix du Pey three years before our peloton descends it.
- **Plateau de Millevaches "thousand springs" framing** — CLAUDE.md notes the etymology is Celtic/Occitan for "thousand springs" (not "thousand cows"). The Plateau proper begins around segs 19-20 — seg 19 (Croix du Pey to plateau entry) is the natural place to plant this etymology before segs 20-22 develop it.

## Verification commands

```bash
npm test                                                                       # 198/198 pass
python3 processing/validate_points.py                                          # OK
python3 processing/validate_entries.py --entries-dir content/entries --non-interactive   # OK
python3 processing/audit_segment_data.py --segment 17                          # clean
python3 processing/audit_segment_data.py --segment 18                          # clean
python3 processing/audit_segment_data.py --segment 19                          # clean
npm run build                                                                  # complete
```

## Test plan

- [ ] `npm test` green (198/198)
- [ ] `processing/audit_segment_data.py` clean for segs 17, 18, 19 (no km-mismatch flags)
- [ ] `processing/validate_points.py` OK
- [ ] `processing/validate_entries.py` OK (non-interactive)
- [ ] dev preview: seg 17 page renders Madranges in towns
- [ ] dev preview: seg 19 page renders Lestards in towns AND the 2020 Stage 12 historical reference
- [ ] dev preview: seg 18 page still renders Treignac (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)