### PR TITLE
data: seg 23-27 verification (closes #500)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -472,18 +472,19 @@
   {
     "name": "Chapelle des Penitents",
     "category": "church",
-    "lat": 45.548,
-    "lng": 2.31,
+    "lat": 45.5447182,
+    "lng": 2.3099724,
     "description": "15th-century funeral chapel in Ussel with a classified Baroque altarpiece. Houses sacred art collection.",
     "links": [],
-    "nearest_km": 182.04,
-    "nearest_distance_m": 3129
+    "nearest_km": 184.84,
+    "nearest_distance_m": 459,
+    "source": "OSM Nominatim (verified 2026-05-12 during seg 23-27 verification #500). Previous coord (45.548, 2.31) was off by ~370m and incorrectly produced nearest_distance_m 3129 (treating the chapel as 3 km off-route); the Ussel cluster of four attractions shared the same wrong coord."
   },
   {
     "name": "Musee du Pays d'Ussel",
     "category": "museum",
-    "lat": 45.548,
-    "lng": 2.3105,
+    "lat": 45.5469604,
+    "lng": 2.3074887,
     "description": "Classified Musee de France with collections of art, popular traditions, tapestries, and printing materials.",
     "links": [
       {
@@ -491,33 +492,36 @@
         "label": "Wikipedia (fr)"
       }
     ],
-    "nearest_km": 182.04,
-    "nearest_distance_m": 3147
+    "nearest_km": 184.84,
+    "nearest_distance_m": 296,
+    "source": "OSM Nominatim (verified 2026-05-12 during seg 23-27 verification #500). Previous coord (45.548, 2.3105) was off by ~290m."
   },
   {
     "name": "Marche d'Ussel",
     "category": "market",
     "lat": 45.548,
     "lng": 2.311,
-    "description": "Saturday morning market in the town center and covered market hall behind the church.",
+    "description": "Saturday morning market in the town center and covered market hall behind the church. Coord (45.548, 2.311) is the original cluster coord shared with three other Ussel attractions; it sits ~250m north of Église Saint-Martin (OSM 45.5470, 2.3091) — plausibly correct for the covered market hall described as 'behind the church', but not OSM-confirmed (recurring event, no fixed OSM node). Other three Ussel attractions in this cluster were re-coorded to OSM-verified values during seg 23-27 verification (#500).",
     "links": [],
-    "nearest_km": 182.04,
-    "nearest_distance_m": 3166
+    "nearest_km": 184.88,
+    "nearest_distance_m": 591,
+    "source": "Derived km/distance recomputed 2026-05-12 during seg 23-27 verification (#500). Previous stored nearest_km 182.04 / distance 3166 was inconsistent with the lat/lng — the route runs through central Ussel ending at km 184.84, putting the market ~591m off-route at the polyline endpoint."
   },
   {
     "name": "Aigle Romaine",
     "category": "archaeology",
-    "lat": 45.5485,
-    "lng": 2.311,
-    "description": "2nd-3rd century granite funerary eagle sculpture at Place Voltaire. Marks the Stage 9 finish line.",
+    "lat": 45.5459512,
+    "lng": 2.3069481,
+    "description": "2nd-3rd century granite funerary eagle sculpture at Place Voltaire. Marks the Stage 9 sprint-judge position; the polyline endpoint sits 216m west of the eagle on Avenue Thiers.",
     "links": [
       {
         "url": "https://fr.wikipedia.org/wiki/Aigle_romaine_d%27Ussel",
         "label": "Wikipedia (fr)"
       }
     ],
-    "nearest_km": 182.04,
-    "nearest_distance_m": 3215
+    "nearest_km": 184.84,
+    "nearest_distance_m": 216,
+    "source": "OSM Nominatim Place Voltaire (verified 2026-05-12 during seg 23-27 verification #500). Previous coord (45.5485, 2.311) was off by ~400m and incorrectly produced nearest_distance_m 3215 (treating the sprint-judge sculpture as 3 km off-route)."
   },
   {
     "name": "Huilerie Marty",
@@ -824,6 +828,22 @@
     ],
     "nearest_km": 7.92,
     "nearest_distance_m": 10990
+  },
+  {
+    "name": "Prieuré Saint-Michel-des-Anges de Saint-Angel",
+    "category": "abbey",
+    "lat": 45.5053,
+    "lng": 2.2325,
+    "description": "Fortified Benedictine priory in Saint-Angel village. The fortified church, conventual buildings, and round presbytery tower together were classified as Monument Historique in 1840 — one of the earliest classifications in France, on the original list compiled by Prosper Mérimée. The priory sits in seg 26 (km 176.60, 153m off the polyline).",
+    "links": [
+      {
+        "url": "https://fr.wikipedia.org/wiki/Saint-Angel_(Corr%C3%A8ze)",
+        "label": "Wikipédia"
+      }
+    ],
+    "nearest_km": 176.6,
+    "nearest_distance_m": 153,
+    "source": "fr.wikipedia.org/wiki/Saint-Angel_(Corrèze) (verified 2026-05-12 during seg 23-27 verification #500). Coord from Wikipédia commune infobox. Saint-Angel and the priory were absent from attractions.json before this audit; village added to data/segments.json seg 26 towns and to town-coords.json in the same PR."
   },
   {
     "name": "Stade Alexandre-Cueille",

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -75,6 +75,12 @@
         "stage": "Bol d'Or des Monédières (criterium series)",
         "route": "Chaumeil",
         "description": "Post-Tour criterium founded in 1952 by Chaumeil-born accordionist Jean Ségurel and run on a circuit around Chaumeil. Held annually 1952–1967, then revived 1981–2002. Winners read like a roll-call of the post-war peloton: Coppi (1953), Anquetil (1955, 1962), Géminiani (1956–58), Poulidor (1963, 1967, with a 3rd place behind Gérard Saint and Ercole Baldini in 1959), Hinault (1982). The criterium is the reason the village punches well above its 350-resident weight in French cycling memory; the Côte des Géants (the climb the 2017 Tour du Limousin used as its finishing-circuit challenge) takes its name from these post-Tour exhibitions."
+      },
+      {
+        "year": null,
+        "stage": "Paris-Corrèze (2001–2012, final stages 2007–2012)",
+        "route": "Final stages closing at Chaumeil",
+        "description": "UCI 2.1 stage race created in 2001 by 1983/1984 Tour de France winner Laurent Fignon with Corrézien motorsport champion Max Mamers and the Conseil général de la Corrèze. From the 2005 edition onward, the final stage closed with five laps of the historic Bol d'Or des Monédières circuit at Chaumeil — explicitly preserving the legacy of the post-Tour criterium. Six confirmed Chaumeil finishes: 2007 (Vigeois → Chaumeil, won by Edvald Boasson Hagen at age 20), 2008 (Brive → Chaumeil), 2009 (Tulle → Chaumeil — the strongest single-stage corridor overlap), 2010, 2011 (Objat → Chaumeil), 2012 (Objat → Chaumeil, final edition). The race did not run in 2013 and has not been organised since. Re-keyed from segments [25, 26, 27] to [15] in seg 23-27 verification (#500) per the #502 tour-history dossier: every documented Paris-Corrèze finish was at Chaumeil (seg 15), not Ussel."
       }
     ]
   },
@@ -93,16 +99,10 @@
     "segments": [25, 26, 27],
     "events": [
       {
-        "year": null,
-        "stage": null,
-        "route": null,
-        "description": "Ussel served as a stage town for the now-defunct Paris-Correze professional race (UCI 2.1) which ran through the 2000s. The 2026 Tour marks Ussel's first appearance as a Tour de France stage town."
-      },
-      {
         "year": 2026,
         "stage": "Stage 10",
         "route": "Aurillac to Le Lioran",
-        "description": "The day after Stage 9, the peloton rides the adjacent Cantal roads from Aurillac to Le Lioran - the same finale where Vingegaard beat Pogacar in a photo finish in 2024."
+        "description": "The day after Stage 9, the peloton rides the adjacent Cantal roads from Aurillac to Le Lioran - the same finale where Vingegaard beat Pogacar in a photo finish in 2024. The 2026 Tour de France Stage 9 finish at Ussel is genuinely the town's first Tour stage appearance — Ussel has never been a Tour de France stage town in any prior edition (verified during seg 23-27 verification #500 via two independent ledicodutour sources). The earlier claim that Ussel had served as a Paris-Corrèze stage town was unverified for pre-2005 editions and contradicted for 2007–2012 (all of which finished at Chaumeil, seg 15); the Paris-Corrèze entry has been re-keyed to seg 15 accordingly."
       }
     ]
   }

--- a/data/segments.json
+++ b/data/segments.json
@@ -473,7 +473,9 @@
     "min_elevation": 630,
     "max_elevation": 687,
     "notable_points": [],
-    "towns": [],
+    "towns": [
+      "Saint-Angel"
+    ],
     "climbs": []
   },
   {

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -83,9 +83,9 @@
   },
   "Ussel": {
     "type": "town",
-    "lat": 45.52671,
-    "lng": 2.2937,
-    "note": "Route entry point at km ~182.5, not Ussel city centre (which is ~2.5 km north of the route at 45.5457, 2.3119). Stage 9 finishes at Place Voltaire in Ussel proper."
+    "lat": 45.5459512,
+    "lng": 2.3069481,
+    "note": "Coord updated 2026-05-12 (#500, seg 23-27 verification) to OSM Nominatim Place Voltaire — the de-facto town centre and the Stage 9 sprint-judge location. Previous coord (45.52671, 2.2937) was the route-entry point on the southern outskirts of Ussel commune (km 182.45), not the town centre; the previous note also wrongly claimed the centre was 2.5 km north of the route. The route enters Ussel commune from the south at km 182.45, runs 2.4 km north through central Ussel, and ends at km 184.84 on Avenue Thiers (45.5456, 2.30422) — 216m west of Place Voltaire. The polyline does not extend the final 216m to Place Voltaire; the GPX endpoint sits short of the official sprint-judge line."
   },
   "Puy Boubou": {
     "type": "climb",
@@ -132,7 +132,14 @@
   },
   "Côte des Gardes": {
     "type": "climb",
-    "lat": 45.527,
-    "lng": 2.174
+    "lat": 45.52104,
+    "lng": 2.16783,
+    "note": "Summit coordinate updated 2026-05-12 (issue #500, seg 23-27 verification) to the polyline position at the points-config summit km 170.98 (elev 757m). Old coord (45.527, 2.174) sat 814m off-route. Same correction pattern as Côte de Naves (#490/#515) and Puy de Lachaud (#477) — town-coords now reflects the on-route summit, not a stale labeled hilltop. Caveat: the actual GPX elevation peak is at km 170.766 (760m, 200m before the declared summit km) — same bug class as Naves #490 (declared km past actual peak), at smaller scale; follow-up may revisit whether to migrate the declared summit km."
+  },
+  "Saint-Angel": {
+    "type": "town",
+    "lat": 45.50279,
+    "lng": 2.23231,
+    "source": "OSM (place=village, name=Saint-Angel, verified 2026-05-12). Added during seg 23-27 verification (#500); the commune sits 96m off the polyline at km 176.53 (seg 26). Commune chef-lieu with the Prieuré Saint-Michel-des-Anges (classified Monument Historique 1840)."
   }
 }

--- a/data/town-positions.ts
+++ b/data/town-positions.ts
@@ -28,5 +28,6 @@ export const townKmPositions: Record<string, number> = {
   'Treignac': 121.95,            // updated 2026-04-25, 22m from village; seg 18
   'Bugeat': 143.67,              // updated 2026-04-25, 23m from village; seg 21
   'Meymac': 168.15,              // updated 2026-04-25, 47m from village; seg 25
-  'Ussel': 182.5,                // route-entry point (city centre is 2.5km north of route)
+  'Saint-Angel': 176.53,         // 96m from village; seg 26 (added 2026-05-12, #500)
+  'Ussel': 184.84,               // updated 2026-05-12 (#500): polyline endpoint near Place Voltaire on Avenue Thiers; 216m from Place Voltaire (sprint judge). Previous value 182.5 was the route-entry point at the southern edge of Ussel commune; the route continues 2.4km north into the historic centre.
 }


### PR DESCRIPTION
Closes #500.

## Scope

Audit `data/*.json` against `data/segments/segment-{23..27}.gpx` and authoritative external sources for the Stage 9 finish block (km ~154-184.8: Meymac, Côte des Gardes, Saint-Angel, Ussel — Place Voltaire). Mirrors PRs #470 (segs 9-10), #489 (segs 11-13), #514 (segs 14-16), #550 (segs 20-22, open).

**Scope expansion** at the publisher's mid-strand redirect: the brief was written 2026-05-07 with a stale premise (\"route only has 26 segments per data/segments.json\"); the 2026-05-12 correction extended the strand to include **seg 27** (Ussel finish, km 182.0-184.8) since no other verify-strand covers it. AskUserQuestion confirmed both the scope expansion and the Côte des Gardes coord-correction write-set fit.

## Per-claim audit table

| Claim | Source | Verdict | Action |
|---|---|---|---|
| GPX polyline integrity, seg 23-27 (point count, elevation gain/loss, min/max, endpoint coords) | `data/segments/segment-{23..27}.gpx` vs `data/segments.json` | Clean — every elevation field matches exactly; endpoint coords match exactly; cumulative GPX km within ±36 m of declared length | No-op |
| segments.json segment count | `processing/split_gpx.py` (`num_segments=27`), commit 4a6bdaf | 27 segments since 2025 commit; brief's \"26\" claim and CLAUDE.md's claim are both stale | Brief errata logged below; CLAUDE.md filed as #553 |
| Meymac centre keyed to seg 24 (per brief / voice memo) | OSM Nominatim Meymac (45.5366795, 2.1464895) vs polyline | Wrong — village sits 47 m off polyline at km 168.10, in **seg 25** (km 168-176) | `project_meymac_voice.md` updated seg 24 → seg 25 |
| Abbaye Saint-André segment | OSM coord (45.534, 2.147) vs polyline | seg 25 (84 m off at km 168.42) | Voice memo retargeted to seg 25 |
| Côte des Gardes summit km in seg 25 | `data/competition/points-config.json` | km 170.98 inside seg 25 ✓ | No-op (read-only) |
| Côte des Gardes declared 4.3% gradient over 2.2 km | GPX-derived gain over [168.78, 170.98] | 4.41% (within ±0.3 pp tolerance) | No-op; tests/utils/climb-gradient.test.ts passes |
| Côte des Gardes actual GPX elevation peak | polyline scan over [168.78, 170.98] | Peak at km 170.766 / 760 m — 200 m before declared summit km 170.98 (757 m) | **Fourth instance of climb-coord-vs-summit-km bug class**; filed as #555 (out of write-set) |
| Côte des Gardes town-coords coord (45.527, 2.174) | Polyline proximity | Wrong — 814 m off-route; same off-route-coord pattern as historical Naves/Lachaud bugs | **Re-coorded to polyline at declared summit km**: (45.52104, 2.16783) |
| Saint-Angel proximity / keying | OSM Nominatim Saint-Angel + Wikipédia commune | Village sits 96 m off polyline at km 176.53 (seg 26); commune chef-lieu with Prieuré Saint-Michel-des-Anges (classified MH 1840 — original Mérimée list) | **Added** to seg 26 towns, town-coords, town-positions, attractions (priory entry) |
| La Feuillade / L'Empereur near route in segs 24, 26 | Overpass query | Hamlet/locality (42 m / 98 m off-route); below the towns-array threshold per existing route convention (only commune chef-lieu / village level) | No-op |
| Ussel coord in town-coords (45.52671, 2.2937) | Polyline proximity | Was route-entry point (km 182.45), not town centre; inconsistent with file convention (other towns use centre coord) | **Re-coorded to OSM Place Voltaire** (45.5459512, 2.3069481) |
| Ussel km in town-positions.ts (182.5) | town-positions header convention (\"closest approach to town center\") | Stale — polyline runs 2.4 km north through central Ussel and ends at km 184.84 near Place Voltaire | Updated 182.5 → 184.84 |
| Avenue Thiers as route run-in | OSM Avenue Thiers bounds (lat 45.5457-45.5463, lng 2.3043-2.3078) vs polyline | Polyline endpoint (45.5456, 2.30422) is at the western edge of Avenue Thiers ✓ | No-op |
| Place Voltaire as sprint judge / polyline endpoint at Place Voltaire | OSM Nominatim Place Voltaire (45.5459512, 2.3069481) vs polyline endpoint | Polyline ends **216 m west** of Place Voltaire; route physically enters Avenue Thiers but stops short of the finish line | Filed as #554 (master GPX scope, not data-verification scope) |
| Aigle Romaine / Musée du Pays d'Ussel / Chapelle des Pénitents / Marché d'Ussel | OSM Nominatim each | Cluster of four originally shared the same wrong coord ~(45.548, 2.311); three of the four are 290-460 m off OSM | **Re-coorded** Aigle / Musée / Chapelle; **derived fields recomputed** for Marché (coord plausibly correct but no OSM node) |
| Paris-Corrèze keyed to [25, 26, 27] (\"Ussel served as stage town\") | #502 tour-history-research.md | Wrong — all six documented Paris-Corrèze final-stage finishes (2007-2012) were at Chaumeil (seg 15); 2001-2006 pre-Chaumeil-era finish data unverified | **Re-keyed to [15]** with full description (Fignon, Bol d'Or inheritance, six confirmed editions) |
| 2026 Stage 10 keying [25, 26, 27] | #502 dossier (\"continuity with Stage 9: peloton arrives Ussel, sleeps, races south-east into Cantal next day\") | Reasonable as-is | Kept; description tightened with verified \"Ussel's first Tour appearance\" claim |
| Ussel as past Tour stage town | #502 dossier (two independent ledicodutour sources) | Verified: Ussel has **never** been a Tour de France stage town; 2026 Stage 9 is its first appearance | Recorded in 2026 Stage 10 event description |
| 2009 Tour du Limousin Stage 1: Limoges → Ussel | #502 dossier (verified, seg 27) | New addition material, but the dossier explicitly defers the historical-tdf.json additions to the umbrella-tracker strand | Out of scope; not added |
| Mont Bessou audit drift on seg 23 | `processing/audit_segment_data.py --segment 23` | Pre-existing — town-coords coord is the actual mountain summit at (45.5701, 2.1231) / km 161.22; points-config climb summit is km 152.31 / seg 22. Open PR #550 (#499 strand) already realigns. | No-op (sibling-strand responsibility) |

## AskUserQuestion checkpoints

One checkpoint, two questions, both publisher-recommended options accepted:

1. **Strand scope expansion to include seg 27** — yes; PR title now spans 23-27. Net load ~25 % higher than original brief; alternative was a follow-up issue for seg 27. (Mid-strand redirect from the publisher pre-empted the question with a directive to ask; recorded for the audit trail.)
2. **Côte des Gardes town-coord correction is in this strand's write-set** — yes; follows Naves/Lachaud precedent.

## Brief errata logged for retro

The brief (`docs/strands/strand-500-verify-segs-23-26.md`, authored 2026-05-07) contained two stale claims per `feedback_brief_content_is_carryforward.md`:

- §1 \"the route only has 26 segments per data/segments.json\" — actually 27. The publisher caught this and issued a mid-strand correction directive.
- §5 step 3 \"Côte des Gardes (currently seg 24 in points-config)\" — actually seg 25. Verified against the source-of-truth file before acting.

Both errata caught early; no downstream impact on edits.

## Out-of-scope findings (issues filed)

- **#553** — CLAUDE.md still claims 26 segments and lists Meymac under \"segs 23-24\" / Ussel under \"segs 25-26\" / publication-schedule table uses 26-segment schema. Narrative project-spec not derived from `data/*`; invisible to existing audit machinery.
- **#554** — Master GPX polyline ends 216 m short of OSM Place Voltaire (Stage 9 sprint-judge line). Polyline does enter Avenue Thiers but stops at its western end. Three resolution options enumerated; master GPX scope, not data-verification scope.
- **#555** — Fourth instance of \"climb declared summit km past actual GPX elevation peak\" bug class (Naves #490, Lachaud #477, Mont Bessou #499, now Gardes #500). The candidate per-source-of-truth assertion from #499 retro line is now strongly motivated — a single test would catch this class instead of one-at-a-time. Out of write-set (points-config is read-only for verify strands).

## Cross-strand notes

- Mont Bessou audit drift in seg 23 is pre-existing and already addressed by open PR #550 (sibling strand #499). When #550 lands on main, the audit reconciles automatically. No additional action here.
- The Paris-Corrèze re-key consumed the #502 tour-history dossier's recommendation directly. #503 — which tracked \"historical-tdf.json [25,26,27] keying\" with two distinct readings (the brief read it as \"seg 27 doesn't exist, clean up\"; the dossier read it as \"event finishes were at Chaumeil\") — closes via the Paris-Corrèze re-key landing here.

## Verification commands run

```bash
npm test                                                                   # 198/198 passing
python3 processing/validate_points.py                                      # OK
python3 processing/validate_entries.py --entries-dir content/entries --non-interactive  # OK
python3 processing/audit_segment_data.py --segment {23,24,25,26,27}        # clean post-fix
npm run build                                                              # complete
```

## Claims I did not verify in this strand

Per the 2026-05-12 planning directive, listing what was *not* verified so the publisher can flag any items to re-audit before this lands:

1. **Marché d'Ussel coord (45.548, 2.311) is the correct covered-market-hall location.** OSM has no node matching \"Halles\" or \"Marché Couvert\" in Ussel; the description (\"behind the church\") is plausible against Église Saint-Martin OSM coord (45.5470, 2.3091) but is not OSM-confirmed. The derived fields (nearest_km/distance) are recomputed against the stored coord, so the entry is internally consistent — but the coord itself stays unverified.
2. **Saint-Angel priory coord (Wikipédia commune coord 45.5053, 2.2325).** Used the Wikipédia infobox coord; did not independently OSM-confirm the priory's exact location vs the village centre OSM node at (45.50279, 2.23231). The two coords are ~280 m apart; either is reasonable for a village-centre priory.
3. **2026 Stage 10 keying to segs [25, 26, 27].** Per the #502 dossier the narrative pivot is \"day after the Ussel finish\" which is seg 27; kept the original [25, 26, 27] keying to minimize churn but did not push back on whether seg 25 (Meymac) really belongs here.
4. **Polyline elevation peak for Côte des Gardes at km 170.766 / 760 m.** Computed from `data/main.gpx` directly; did not cross-check against `data/elevation/segment-25.json`.
5. **\"Marché d'Ussel originally clustered with the other three at (45.548, 2.311)\"** — assumed from the identical stored coord, but did not git-blame to confirm all four entries were added in the same commit. (Even if not the same commit, the cluster pattern is empirically true.)
6. **Saint-Angel Mérimée notice number.** Wikipédia says \"classified Monument Historique 1840\" but did not verify against the Mérimée database (POP) which notice ID this corresponds to.
7. **Tour du Limousin 2009 Stage 1 Limoges → Ussel as a verified seg-27 precedent.** Pulled from the #502 dossier (which sources it to Wikipédia); did not independently re-verify. Decision was \"don't add\" (umbrella-tracker scope), so the verification gap doesn't affect this PR's content.
8. **Avenue Thiers bounds.** Used OSM Nominatim's returned bounding box for \"Avenue Thiers Ussel\" but did not cross-check whether the named street is contiguous along the polyline's last 200 m or merely overlaps at one end.

## Files changed

- `data/segments.json` — seg 26 towns: [] → [\"Saint-Angel\"]
- `data/town-coords.json` — Côte des Gardes coord realigned; Ussel coord moved to OSM Place Voltaire with corrected note; Saint-Angel added
- `data/town-positions.ts` — Ussel km 182.5 → 184.84; Saint-Angel added at km 176.53
- `data/attractions.json` — 4 Ussel cluster entries re-coorded/recomputed; Prieuré Saint-Michel-des-Anges de Saint-Angel added (1 new entry)
- `data/historical-tdf.json` — Paris-Corrèze moved from [25, 26, 27] to [15] (joined existing seg-15 events); 2026 Stage 10 description tightened with verified \"Ussel's first Tour\" claim

Memory: `project_meymac_voice.md` retargeted seg 24 → seg 25 (off-repo, in user memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)