### PR TITLE
content(seg 12): break 'X the Y will not Z' shape in polka-dot handoff

### DIFF
--- a/content/entries/12-naves-coming-home.md
+++ b/content/entries/12-naves-coming-home.md
@@ -38,7 +38,7 @@ What the bourg cannot keep out of itself, in the present, is the motorway. The A
 ::video-embed{embedUrl="https://www.youtube.com/embed/ZN8SlliQfbA" caption="Drone view of the Viaduc du Pays de Tulle (a.k.a. Viaduc des Angles), the A89 crossing south of Naves bourg: 854 m of deck and 160 m above the Corrèze valley, built 2000-2002." attribution="Video embedded from YouTube."}
 ::
 
-The road our riders are on falls now toward the Vimbelle, picks up the gradient on the other side, and starts the climb the polka-dot board will not count. At the bottom of the descent, where the road bridges the river and turns north, a white *panneau* at the verge points back to Naves and ahead to Orliac-de-Bar and Saint-Augustin: the country has finished with the bowl, and the road has its next destinations.
+The road our riders are on falls now toward the Vimbelle, picks up the gradient on the other side, and starts climbing again. The polka-dot board takes no notice of the next crest. At the bottom of the descent, where the road bridges the river and turns north, a white *panneau* at the verge points back to Naves and ahead to Orliac-de-Bar and Saint-Augustin: the country has finished with the bowl, and the road has its next destinations.
 
 ::street-view-embed{embedUrl="https://www.google.com/maps/embed?pb=!4v1778621609020!6m8!1m7!1sqxAow9AP035uaXomQWHEaw!2m2!1d45.33828842733281!2d1.792217846272367!3f249.47197221297014!4f8.701827119321607!5f0.4000000000000002" caption="The bottom of the descent off the Naves bowl, where the road bridges the Vimbelle and turns north. The white panneau at the verge points back to Naves and ahead to Orliac-de-Bar and Saint-Augustin."}
 ::


### PR DESCRIPTION
## Summary

Reword the closing handoff line of seg 12 to break the `X the Y will not Z` construction that has accumulated across recent entries.

Original:
> ...and starts the climb the polka-dot board will not count.

Reworded (option C of three candidates surfaced in the seg-13 drafting strand):
> ...and starts climbing again. The polka-dot board takes no notice of the next crest.

The load-bearing fact (next climb, not on the KOM board) is preserved; the construction is broken by splitting the sentence and making the second one declarative with the board as subject.

## Why

Publisher flagged 2026-05-12 that the polka-dot phrase rhymes with seg 12's earlier `the Naves bourg the riders will not enter`. A repo-wide grep showed the same shape in six of the last seven entries:

- seg 06: `Our four riders will not see Beynat`
- seg 07: `the riders will not see it`; `they will not see that either`
- seg 08 subtitle: `a ruin the riders will not see`
- seg 10: `A cyclist... will not see any of this`
- seg 11: `a thing the riders will not see and the helicopters will not show`
- seg 12: `the Naves bourg the riders will not enter`; `the climb the polka-dot board will not count`

Pattern captured in `feedback_will_not_shape.md` so subsequent entries avoid the shape.

## Scope override

This edit was applied from the seg-13 drafting strand (`feature/seg-13-draft`) on a separate branch to keep the seg-13 PR clean. The seg-13 brief excludes seg 12 from that strand's write-set; the publisher authorised this as a standalone PR.

## Test plan

- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green
- [x] `npm test` — 198 passed
- [ ] Dev preview render unchanged (prose-only, no frontmatter or component change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)