### PR TITLE
infra: validate_entries.py traps unbalanced MDC blocks (closes #561)

### DIFF
--- a/processing/tests/fixtures/mdc-balanced/01-balanced.md
+++ b/processing/tests/fixtures/mdc-balanced/01-balanced.md
@@ -1,0 +1,20 @@
+---
+segment: 99
+title: "Balanced MDC fixture"
+publishDate: 2000-01-01
+images: []
+imagesOptional: true
+draft: false
+---
+
+# Balanced fixture
+
+A paragraph before the block.
+
+::inline-figure{src="/img/a.jpg" alt="A" author="Test" license="CC BY-SA 4.0"}
+::
+
+Another paragraph.
+
+::press-card{publication="Test" headline="Headline" url="https://example.invalid"}
+::

--- a/processing/tests/fixtures/mdc-unbalanced/01-unbalanced.md
+++ b/processing/tests/fixtures/mdc-unbalanced/01-unbalanced.md
@@ -1,0 +1,18 @@
+---
+segment: 99
+title: "Unbalanced MDC fixture"
+publishDate: 2000-01-01
+images: []
+imagesOptional: true
+draft: false
+---
+
+# Unbalanced fixture
+
+This entry opens an MDC block and never closes it. Nuxt Content would render
+the remainder of the entry as block content, producing a broken page.
+
+::inline-figure{src="/img/a.jpg" alt="A" author="Test" license="CC BY-SA 4.0"}
+
+The next paragraph is intended as body text, not as MDC content, but no `::`
+ever closes the block above.

--- a/processing/tests/test_validate_entries.py
+++ b/processing/tests/test_validate_entries.py
@@ -159,3 +159,142 @@ class TestFrontmatterUpdate:
         assert 'title: "Test Entry"' in content
         assert "draft: false" in content
         assert "# Test Entry" in content
+
+
+def write_body(dir_path, filename, body, draft=False):
+    """Write an entry with arbitrary body content under standard frontmatter."""
+    path = os.path.join(dir_path, filename)
+    fm = [
+        "segment: 99",
+        'title: "Test"',
+        "publishDate: 2000-01-01",
+        "images: []",
+        "imagesOptional: true",
+        f"draft: {'true' if draft else 'false'}",
+    ]
+    content = "---\n" + "\n".join(fm) + "\n---\n\n" + body + "\n"
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+class TestMdcBalanceCheck:
+    """Test the per-file MDC block balance scan."""
+
+    def test_balanced_single_block_no_errors(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          '::inline-figure{src="/x.jpg"}\n::\n')
+        assert mdc_balance_check(path) == []
+
+    def test_unbalanced_open_reports_opener_line(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          '::inline-figure{src="/x.jpg"}\n\nBody text never closed.\n')
+        errors = mdc_balance_check(path)
+        assert len(errors) == 1
+        assert "unclosed MDC block `::inline-figure`" in errors[0]
+        assert ":10:" in errors[0]  # opener is on line 10 after 8-line frontmatter + blank
+
+    def test_orphan_close_reports_close_line(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          'No open block here.\n\n::\n')
+        errors = mdc_balance_check(path)
+        assert len(errors) == 1
+        assert "unmatched MDC close" in errors[0]
+
+    def test_nested_balanced_no_errors(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          '::card\n::inline-figure{src="/x.jpg"}\n::\n::\n')
+        assert mdc_balance_check(path) == []
+
+    def test_inline_form_not_counted_as_open(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          'Some :inline-figure{src="/x.jpg"} text with a single colon.\n')
+        assert mdc_balance_check(path) == []
+
+    def test_code_fence_skipped(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          '```md\n::inline-figure{src="/x.jpg"}\n```\n')
+        assert mdc_balance_check(path) == []
+
+    def test_frontmatter_dash_does_not_open_block(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        # Standard frontmatter is already in write_body; just confirm a body
+        # with no MDC markers returns no errors.
+        path = write_body(entries_dir, "01.md", 'Plain prose only.\n')
+        assert mdc_balance_check(path) == []
+
+    def test_multiple_opens_unbalanced_lists_each(self, entries_dir):
+        from validate_entries import mdc_balance_check
+
+        path = write_body(entries_dir, "01.md",
+                          '::card\n\n::figure\n\nbody\n')
+        errors = mdc_balance_check(path)
+        assert len(errors) == 2
+        assert any("`::card`" in e for e in errors)
+        assert any("`::figure`" in e for e in errors)
+
+
+class TestMdcCliIntegration:
+    """Test the CLI main loop aggregates MDC errors and exits non-zero."""
+
+    def test_cli_green_on_balanced_dir(self, entries_dir, capsys):
+        import validate_entries as ve
+
+        write_body(entries_dir, "01.md",
+                   '::inline-figure{src="/x.jpg"}\n::\n')
+        # Stub argv
+        import sys
+        old_argv = sys.argv
+        sys.argv = ["validate_entries", "--entries-dir", entries_dir, "--non-interactive"]
+        try:
+            ve.main()
+        finally:
+            sys.argv = old_argv
+        out = capsys.readouterr().out
+        assert "MDC blocks balanced" in out
+
+    def test_cli_red_on_unbalanced_dir(self, entries_dir, capsys):
+        import validate_entries as ve
+
+        write_body(entries_dir, "01.md",
+                   '::inline-figure{src="/x.jpg"}\n\nbody never closed.\n')
+        import sys
+        old_argv = sys.argv
+        sys.argv = ["validate_entries", "--entries-dir", entries_dir, "--non-interactive"]
+        try:
+            with pytest.raises(SystemExit) as exc:
+                ve.main()
+            assert exc.value.code == 1
+        finally:
+            sys.argv = old_argv
+        out = capsys.readouterr().out
+        assert "Unbalanced MDC blocks detected" in out
+
+    def test_cli_skips_draft_entries(self, entries_dir, capsys):
+        import validate_entries as ve
+
+        write_body(entries_dir, "01.md",
+                   '::inline-figure{src="/x.jpg"}\n\nbody never closed.\n',
+                   draft=True)
+        import sys
+        old_argv = sys.argv
+        sys.argv = ["validate_entries", "--entries-dir", entries_dir, "--non-interactive"]
+        try:
+            ve.main()
+        finally:
+            sys.argv = old_argv
+        out = capsys.readouterr().out
+        assert "Unbalanced" not in out

--- a/processing/validate_entries.py
+++ b/processing/validate_entries.py
@@ -1,7 +1,9 @@
 """Validate entry frontmatter before publishing.
 
 Checks that entries being published today have at least one image,
-or have imagesOptional: true set in frontmatter.
+or have imagesOptional: true set in frontmatter. Also checks all
+non-draft entries for unbalanced MDC blocks (`::name{...}` opens
+without matching `::` closes) which render as broken pages.
 """
 
 import argparse
@@ -9,6 +11,11 @@ import os
 import re
 import sys
 from datetime import date
+
+MDC_OPEN_RE = re.compile(r'^(::+)([A-Za-z][A-Za-z0-9_-]*)(\s*\{.*\})?\s*$')
+MDC_CLOSE_RE = re.compile(r'^(::+)\s*$')
+CODE_FENCE_RE = re.compile(r'^(```+|~~~+)')
+FRONTMATTER_FENCE = '---'
 
 
 def parse_frontmatter(filepath):
@@ -90,6 +97,79 @@ def find_entries_to_validate(entries_dir, today=None):
     return results
 
 
+def mdc_balance_check(filepath):
+    """Scan an entry body for unbalanced MDC block markers.
+
+    Returns a list of error strings (empty when balanced).
+    """
+    with open(filepath) as f:
+        lines = f.read().splitlines()
+
+    in_frontmatter = False
+    frontmatter_done = False
+    code_fence = None
+    stack = []
+    errors = []
+
+    for lineno, raw in enumerate(lines, start=1):
+        line = raw.rstrip()
+
+        if not frontmatter_done:
+            if lineno == 1 and line == FRONTMATTER_FENCE:
+                in_frontmatter = True
+                continue
+            if in_frontmatter:
+                if line == FRONTMATTER_FENCE:
+                    in_frontmatter = False
+                    frontmatter_done = True
+                continue
+            frontmatter_done = True
+
+        fence_match = CODE_FENCE_RE.match(line)
+        if fence_match:
+            fence_char = fence_match.group(1)[0]
+            if code_fence is None:
+                code_fence = fence_char
+            elif code_fence == fence_char:
+                code_fence = None
+            continue
+        if code_fence is not None:
+            continue
+
+        open_match = MDC_OPEN_RE.match(line)
+        close_match = MDC_CLOSE_RE.match(line)
+        if open_match:
+            stack.append((open_match.group(2), lineno))
+        elif close_match:
+            if not stack:
+                errors.append(
+                    f'{filepath}:{lineno}: unmatched MDC close `::` with no open block'
+                )
+            else:
+                stack.pop()
+
+    for name, opened_at in stack:
+        errors.append(
+            f'{filepath}:{opened_at}: unclosed MDC block `::{name}` (no matching `::`)'
+        )
+
+    return errors
+
+
+def find_entries_for_mdc_check(entries_dir):
+    """Return absolute paths of every non-draft markdown entry."""
+    paths = []
+    for filename in sorted(os.listdir(entries_dir)):
+        if not filename.endswith('.md'):
+            continue
+        filepath = os.path.join(entries_dir, filename)
+        fm = parse_frontmatter(filepath)
+        if fm.get('draft') is True:
+            continue
+        paths.append(filepath)
+    return paths
+
+
 def set_images_optional(filepath):
     """Add imagesOptional: true to an entry's frontmatter."""
     with open(filepath) as f:
@@ -113,16 +193,26 @@ def set_images_optional(filepath):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Validate entry images before publishing')
+    parser = argparse.ArgumentParser(description='Validate entries before publishing')
     parser.add_argument('--entries-dir', required=True, help='Path to content/entries directory')
     parser.add_argument('--non-interactive', action='store_true',
                         help='Fail instead of prompting (for CI)')
     args = parser.parse_args()
 
+    mdc_errors = []
+    for filepath in find_entries_for_mdc_check(args.entries_dir):
+        mdc_errors.extend(mdc_balance_check(filepath))
+
+    if mdc_errors:
+        print('Unbalanced MDC blocks detected:')
+        for err in mdc_errors:
+            print(f'  {err}')
+        sys.exit(1)
+
     entries = find_entries_to_validate(args.entries_dir)
 
     if not entries:
-        print('All entries have images or are marked imagesOptional.')
+        print('All entries have images or are marked imagesOptional; MDC blocks balanced.')
         return
 
     for entry in entries:


### PR DESCRIPTION
## Summary

Extends `processing/validate_entries.py` to detect unbalanced MDC block syntax (`::name{...}` opens vs `::` closes) per non-draft entry before `nuxt generate` runs in `publish.sh`. Captures the retro-v1.4.18 deliverable named in `docs/planning/v1.4.19-scope.md` under "MDC pre-render validator". Closes #561.

Tracked via strand brief `docs/strands/strand-mdc-validator.md`.

## Parsing model

Line-oriented stack scan. For each non-draft entry:

1. Skip the leading frontmatter block (`---` ... `---`).
2. Track an in-fence flag for fenced code blocks (` ``` ` / `~~~`); MDC markers inside fences are opaque.
3. A line matching `^::[A-Za-z][A-Za-z0-9_-]*(\s*\{.*\})?\s*$` pushes the block name onto a stack.
4. A line matching `^::\s*$` pops the stack; an empty stack at pop time records an "unmatched close" error.
5. Any block names left on the stack at EOF record an "unclosed block" error at their opener line.

This matches Nuxt Content's own line-driven MDC handling for tdf26's current usage shape: all entries in `content/entries/` use single-line `::name{...}` openers with a bare `::` closer (8 entries, 31 paired blocks, 0 imbalances in the survey).

## Scope boundary

- Out of scope: inline form `:name{...}` (single colon, single token, no balancing needed).
- Out of scope: full MDC syntax validation (attribute parsing, slot syntax, named slots). The deliverable is a balance check, not a parser.
- Drafts (`draft: true`) are skipped — drafts may legitimately be in-flight with imbalance.

## Verification — red/green

**RED — synthetic unbalanced fixture:**

```
$ python3 processing/validate_entries.py --entries-dir processing/tests/fixtures/mdc-unbalanced --non-interactive
Unbalanced MDC blocks detected:
  processing/tests/fixtures/mdc-unbalanced/01-unbalanced.md:15: unclosed MDC block `::inline-figure` (no matching `::`)
exit=1
```

**GREEN — synthetic balanced fixture:**

```
$ python3 processing/validate_entries.py --entries-dir processing/tests/fixtures/mdc-balanced --non-interactive
All entries have images or are marked imagesOptional; MDC blocks balanced.
exit=0
```

**GREEN — current `content/entries/` (no production entry trips the new check):**

```
$ python3 processing/validate_entries.py --entries-dir content/entries --non-interactive
All entries have images or are marked imagesOptional; MDC blocks balanced.
exit=0
```

## Test plan

- [x] `processing/.venv/bin/python -m pytest processing/tests/test_validate_entries.py` — 20 passed (9 existing + 11 new)
- [x] `processing/.venv/bin/python -m pytest processing/tests/` — full Python suite, 200 passed
- [x] `processing/.venv/bin/python -m ruff check processing/` — clean
- [x] `npm test` — 198 passed (27 files)
- [x] CLI red on unbalanced fixture, green on balanced fixture, green on current content
- [x] No production entries flagged by the new check (8 entries with MDC blocks: 05, 06, 07, 08, 09, 10, 11, 12 — all balanced)

## Notes

- Brief named label `infra`; that label does not exist in this repo. Issue #561 was filed with `process` + `python` instead.
- New fixtures live under `processing/tests/fixtures/{mdc-balanced,mdc-unbalanced}/` for reuse if a future strand extends the validator.
- Retro inputs appended to `project_next_planning_notes.md` per strand template §10.