### PR TITLE
research: segs 14-16 block dossier (km 92-112, Monédières)

### DIFF
--- a/content/research/segs-14-16-block-research.md
+++ b/content/research/segs-14-16-block-research.md
@@ -1,0 +1,330 @@
+# Block research dossier — segs 14-16 (km 92-112)
+
+> Compiled 2026-05-13 by the segs 14-16 research strand. Feeds drafting strands for segs 14, 15, 16. Tracking issue: [#562](https://github.com/gneeek/tdf26/issues/562). Mirrors the shape of `segs-11-13-block-research.md` (PR #501).
+
+## Cross-segment threads
+
+**The earned summit.** This 20 km block is the route's first real climb out of the Limousin valley country. Seg 14 is the approach: Saint-Augustin on the southern threshold of the Monédières, the road climbing gently through 522-567 m, the massif visible to the north. Seg 15 is the summit beat: Chaumeil at km 100.30, Suc au May at km 105.15 (908 m), the maypole-summit that gives the day its first big number. Seg 16 is the descent off the massif toward the Vézère corridor. This is the **Barthes "develops" beat** per `project_barthes_callback.md` — seg 6 planted, seg 12 tightened, seg 15 earns it. The Monédières framing reserved across segs 11-13 finally spends here.
+
+**Direction reversal vs 2020.** Stage 12 of the 2020 Tour (Chauvigny → Sarran, Hirschi solo) crossed Suc au May from the **north** — the peloton descended into Chaumeil from the Treignac side, climbed Suc au May, and dropped south through Saint-Augustin toward Sarran. The 2026 Stage 9 does the **opposite**: south up through Saint-Augustin (seg 14), through Chaumeil (seg 15), over Suc au May, and **descends NNW** off the massif (seg 16) toward Treignac. The Inner Ring's 2020 preview is explicit: "the race drops into Chaumeil and there's a tight turn for the Suc au May," followed by a descent "with some more climbs after Saint-Augustin." The 2026 directional inversion is a writable beat for seg 15 — the pros climb Suc au May from the harder side this time, and the descent off the massif is the day's first technical test.
+
+**The 1987 double-finish.** Saturday 11 July 1987 is the only day on record when both the men's Tour de France and the women's Tour de France Féminin finished a stage in the same village on the same day. Men's Stage 11 (Poitiers → Chaumeil, 255 km): Martial Gayant (Système U) won solo from a 13 km breakaway; his teammate Charly Mottet lost the yellow jersey on the same stage. Women's Stage 3 (Linards → Chaumeil, 72.5 km): Roberta Bonanomi (Italy) won ahead of Maria Canins and Jeannie Longo, taking the yellow jersey; Longo crashed twice and went on to win the overall (8-26 July 1987). `data/historical-tdf.json` already has both events keyed to seg 15.
+
+**The amateur dress rehearsal.** L'Agglomérée 2026 ran Sunday 5 April 2026 from Tulle Auzelou. The 105 km course refuels at Saint-Augustin twice (km 23 outbound, km 48 return) before reaching Tulle — a route shape that implies the cyclosportive climbs Suc au May from the **same direction** as the 2026 Stage 9 (Saint-Augustin / Chaumeil approach, south side). By the time seg 14 publishes on Wed 2026-05-20, the local amateurs have been over this same climb in this same direction for six weeks. Seg 11 had Auzelou as a departure beat; seg 15 has the climb itself.
+
+**The Hirschi / Suc au May template.** Marc Hirschi (Sunweb) won the 2020 stage solo, launching what most sources frame as a Suc-au-May-descent attack with 25 km to go — i.e. the road off the summit was the launching pad even when the climb itself was approached from the easier side. In 2026, with the climb approached from the harder side and a longer day still ahead, the same logic applies in reverse: Suc au May is far enough out (km 105 of 185) that solo escapes off the summit are speculative, but the road shape — short, steep, then a fast and technical NNW descent — is identical to the road Hirschi used to win.
+
+**Bourrée and accordion and rugby's other country.** Chaumeil is small (population 164 in 2023) and famous out of proportion to its size for one reason: Jean Ségurel (1908-1978), Chaumeil-born accordionist, composer of *Bruyères corréziennes* (1936), founder of the Bol d'Or des Monédières cycling criterium (1952), Chevalier de la Légion d'honneur 1968 (presented by de Gaulle). His wife was elected mayor of Chaumeil. The Bol d'Or, the Musée Jean Ségurel at the Maison des Monédières, the Bourrée des Monédières as both a regional sub-style of the bourrée and a tune Ségurel recorded — all converge here. The carnyx-and-rugby beats of segs 9-13 give way in seg 15 to accordion-and-criterium. The cycling lineage Ségurel built (Coppi 1953, Anquetil 1955 + 1962, Géminiani 1956-58, Poulidor 1963 + 1967 + 3rd in 1959, Hinault 1982) is exactly the post-war pantheon a 2026 stage finally reaches the same village to honour at full Tour scale.
+
+**The maquis above the heath.** The Monédières sheltered an FTP-Corrèze network through 1943-44. Camp Roland, in the massif, was named after **Auguste Vangierdegom ("Roland")**, the first FTP combatant killed in action in Corrèze, age 22, on the night of 13-14 July 1943. The original detachment was at Puy-Chassagnoux under Marcel Gibiat ("Metallo"); surviving comrades from Camp Guy Mocquet established Camp Roland in the Monédières as a memorial unit. The seg 14 attraction `Maquis de Chaumeil Memorial` (45.434, 1.855, 249 m off the polyline at km 96.76) is almost certainly this stele; the dedication itself is not in the digital sources we retrieved. **Verify the stele's inscription on the ground before any seg 14 prose names a specific group or fighter** — but the corridor's maquis story is the Maquis Roland story.
+
+**Sarran adjacency (and the Chirac burial myth).** The Musée du Président Jacques Chirac at Sarran (45.44262, 1.91898) sits 3.17 km off the route at km 99.7 — within the precedent set by Cascades de Gimel (4.3 km, kept in #470). The museum opened **15 December 2000** in a Jean-Michel Wilmotte building and holds about 5,000 diplomatic gifts received by Chirac during the 1995-2007 presidency. The Chirac family château is the **Château de Bity** at Sarran (classified Monument Historique). **Chirac is buried at Cimetière du Montparnasse in Paris, not at Sarran** — the October 2019 Sarran ceremony was a memorial gathering, not an interment. `data/attractions.json` repeats the Sarran-burial framing and is wrong; filed as issue #564 — do not reproduce it in entry prose.
+
+**Pairing with seg 4: Henry de Jouvenel returns.** The Suc au May table d'orientation, the oldest in the Limousin, was inaugurated on **25 August 1935 by Henry de Jouvenel** — the same Jouvenel whose Maison de la Sirène in Collonges-la-Rouge (seg 4) was a place he kept with Colette. The seg 15 callback is in the existing `data/attractions.json` and is verified against fr.wikipedia.org/wiki/Suc_au_May.
+
+**Suc au May points-config drift (#513).** `data/competition/points-config.json` has Suc au May at km 105.15, length 3.8 km, gradient 7.1%, **category HC**. The Tourisme Corrèze 2026 announcement says the climb is **Cat 4**. ASO has not published the official roadbook gradient. Drafters writing seg 15 must know the climb's polka-dot category is contested; this strand surfaces but does not resolve.
+
+## Segment 14 (km 92-98) — Saint-Augustin, approach to the massif
+
+### Geography & geology
+
+- Start 45.40632, 1.82682, elevation 522 m, on the Naves-commune-edge plateau. End 45.43862, 1.86929, elevation 567 m. Mid (the bourg of Saint-Augustin) 45.42442, 1.83625 (per `data/town-coords.json`); the polyline runs 9 m off the bourg centre at km 94.52. Elevation gain 76 m, loss 31 m. Max gradient 7.5%, max descent -4.0%. This is the segment that climbs *toward* the massif without entering the climb proper — the road rises, falls back, then rises again, never steeper than 7.5%.
+- **The commune is part of the Parc naturel régional de Millevaches en Limousin** and sits on the southern flank of the Monédières. The southernmost named *puy* of the massif, **Puy de Chauzeix (893 m)**, is in the Saint-Augustin commune. Elevation range across the commune as a whole: 355-897 m.
+- Geology: granitic basement of the Limousin, Variscan emplacement 360-290 Ma. Same rock as the Naves country in segs 11-13 but the relief is now stronger — the heath-and-bog *paysage* of the Monédières becomes legible at this elevation.
+- **Suc au May is visible** from much of seg 14. From the upper Saint-Augustin approach a rider can see the massif's main skyline (Puy de la Monédière 922 m, Puy de la Jarrige 909 m, Suc au May 908 m, Puy Messou 907 m).
+- **Suc au May etymology**, raised here because the *visible-from-seg-14* horizon is the thing being named: Wikipedia FR gives the Occitan *suc* = "sommet" (summit). One regional tourism source ([lacorreze.com](https://www.lacorreze.com/regions/monedieres/suc_au_may.htm)) glosses the full name as "lo suc als mais," reading *may/mais* as the Occitan word for the spring-festival maypole and tying the toponym to a fertility-rite tradition. The maypole reading is colourful and writable, but **not in Wikipedia FR's etymology section** — flag as a regional-tourism gloss to footnote carefully, not as bedrock.
+
+### Local history & archaeology
+
+- Saint-Augustin was founded around an **Augustinian priory established in the 10th century**, per the canonical regional history site (correze-histoire-patrimoine.fr/saint-augustin). The commune name follows the priory, not the saint Augustin de Limoges directly. Population 427 (2023 INSEE), area 29.31 km².
+- Pre-Roman / Roman: **a Gallic burial near the Boiroux hamlet** was excavated in 1992 and dated **40-30 BCE**, containing amphorae and grave goods. Gallo-Roman tile fragments and hypocaust traces have been reported in the bourg itself. Iron Age and Neolithic surface finds across the commune.
+- **Église Saint-Augustin de Saint-Augustin** is the bourg set-piece. 13th-century, modified 14th-16th centuries. Inscribed Monument Historique 1929 (Mérimée notice PA00099811; the exact 1929 date varies between sources — Wikipedia FR cites 25 September 1929 for the church; correze-histoire-patrimoine.fr cites 29 November 1929 for the retable as a classified *objet* — likely both are true, **verify against the Mérimée notice directly**). Damaged by lightning 1985; roof rebuilt 1986.
+- **The retable** is the church's set-piece interior: commissioned **1681** from **Pierre Duhamel** (Tulle woodcarver), executed with menuisier Antoine Cessac. Central Crucifix flanked by Saint Augustine (left, with the flaming heart — Augustinian iconographic emblem) and Saint Roch (right, with dog and staff). **Same Duhamel atelier that built the Retable de Naves a generation later in 1704** — a verified pair-writing thread between seg 12 (Naves, the cousin retable) and seg 14 (Saint-Augustin, the earlier retable). Both retables came out of the same Tulle workshop, separated by ~23 years.
+- **Tourondel hamlet** (1.3 km north of the bourg, in seg 14 territory): 17th-19th c. granite farm complex with a small château featuring a round tower with machicolations; historic four à pain. The `data/attractions.json` entry attaches a local tradition that an old wooden chapel at Tourondel inspired the nave vault of the parish church — **the dossier could not locate a primary source for this tradition**; treat as oral / unverified, flag in the seg 14 brief.
+- **Maquis de Chaumeil memorial** (`data/attractions.json`, 45.434, 1.855, 249 m off polyline at km 96.76, inside seg 14). Almost certainly the **Maquis Roland** stele, named for Auguste Vangierdegom ("Roland"), the first FTP combatant killed in action in Corrèze on the night of 13-14 July 1943, age 22. The original Camp Roland was established in the Monédières after his death by surviving comrades of Camp Guy Mocquet; the original detachment was at Puy-Chassagnoux under Marcel Gibiat ("Metallo"). Primary source: Jean-Yves Boursier, *Chroniques du maquis (1943-1944): FTP du camp Jean Pierson et d'ailleurs* (book reference; bibliographic detail to be verified at draft time). **The stele's actual dedication is not in the digital sources retrieved** — a ground-truth photo is needed before any seg 14 prose names a specific fighter or unit. Treat the Maquis Roland identity as the strongest working hypothesis.
+
+### Cycling context
+
+- **No prior Tour de France stage has visited Saint-Augustin commune itself**; `data/historical-tdf.json` carries no seg 14 entry. The 2020 Stage 12 *descent* from Suc au May toward Sarran did pass through the Saint-Augustin road network (per the Inner Ring 2020 preview), but in the *opposite direction* from the 2026 climb — riders descended through Saint-Augustin in 2020; in 2026 they climb through it. **Candidate framing for the seg 14 drafter:** the road through Saint-Augustin has been ridden by the modern Tour, but always going *down*. 2026 is the first time the road is climbed.
+- **L'Agglomérée 2026** (5 April 2026) refuels at Saint-Augustin twice on the 105 km course — km 23 outbound (the southern leg out of Tulle) and km 48 (the return leg after Suc au May). Saint-Augustin is the cyclosportive's Suc au May threshold village too. For seg 14 drafting: the village has been a local-amateur waystation through April-May 2026; by the time the segment publishes, the village is already in cycling-day mode.
+- **No categorised climb in seg 14**. The Suc au May climb begins at the seg 14/15 boundary (km 98) per points-config.
+
+### Famous local people
+
+- **The Wikipedia FR entry for Saint-Augustin (Corrèze)** lists three *personnalités*: Pierre Monteil (writer/scholar, b. 1925), Jean Coudert (magistrate and former deputy mayor, 1905-1985), Élie Buge (test pilot, 1923-1967). None has overwhelming corridor weight; if seg 14 wants a local-person beat, the **Sarran-Chirac adjacency** is stronger material (Chirac museum 3.17 km off-route at km 99.7, technically inside seg 14 by km on the eastern half of the segment; Bity château is the family seat, not the burial site).
+
+### Culture
+
+- The commune itself has no large public festival the dossier could pin to a date in May. Local cuisine and land-use is consistent with the wider Corrèze plateau (cattle pasture, oak-chestnut bocage, *farcidure* and *millassou* dumplings).
+- The Tourondel four à pain is a small object beat: a working bread oven preserved at the hamlet, useful as a "what survives of village life before electrification" thread.
+
+### Literary / musical
+
+- The seg 14 corridor opens the reserved Monédières literary frame; the major anchors (Léon Dautrement, Bourrée des Monédières, Jean Ségurel) belong by content to seg 15, but the *opening* — the moment the heath becomes visible — is seg 14's. Drafters: use the visible massif as the threshold (the long Limousin novel-of-place tradition has a category for this — *paysage à l'orée*, the landscape at its edge); the named anchors land at Chaumeil.
+
+## Segment 15 (km 98-106) — Chaumeil, Suc au May, the summit
+
+### Geography & geology
+
+- Start 45.43862, 1.86929 (567 m). End 45.47539, 1.84875 (853 m). Chaumeil bourg at 45.4555541, 1.8808583, sits at ~km 100.30. The Suc au May road peaks at km 105.15 at ~889 m (per the elevation profile); the **actual summit at 908 m** sits ~442 m off the road, reached by a 15-minute footpath from a small parking area on the D26. Seg 15 elevation gain 364 m. Max road gradient 14.9%; average climb gradient on the categorised section 7.1%.
+- **The Monédières massif** is a small upland on the southwestern edge of the Plateau de Millevaches. **Granitic basement (leucogranite) surrounded by metamorphic rocks (micaschists, gneiss), Variscan orogeny 360-290 Ma** — *not* volcanic, despite the "sucs" / "puys" naming that, in the Cantal, does denote truncated volcanic cones. Drafters: do not write the Monédières as "volcanic." The *suc / puy* terminology is Occitan vocabulary for summit / hill, not a geological claim.
+- **The massif's highest named peak is contested between two readings.** Wikipedia FR (`Monédières` article) lists 33 peaks; the highest are **Puy de la Monédière 922 m** and **Puy de la Jarrige 909 m**; Suc au May (908 m) "is more commonly featured on tourist maps" but is not the highest. **Mont Bessou (977 m) in seg 22 remains the highest point in Corrèze département.** Drafters: do not write Suc au May as "highest in the Monédières" — write it as the most-photographed, most-named, most-visited summit of the massif. The framing the massif itself uses is "the *fierce* one," not "the highest."
+- The **brandes / heath plant communities** are the defining ecology: *Calluna vulgaris* (bruyère commune), *Erica cinerea* (bruyère cendrée), *Ulex minor* (ajonc nain), genêt, bourdaine, myrtille, arnica and gentiane at higher elevations. Site classified Natura 2000 (DOCOB "Monédières002"). The heath is a **paysage culturel** — historically maintained by sheep grazing and periodic burning, in retreat since the 1960s as upland sheep grazing was abandoned. The Parc naturel régional de Millevaches en Limousin is the contemporary conservation body.
+
+### Local history
+
+- **Chaumeil commune fundamentals.** Population 164 (2023 INSEE) — small enough that the village's outsized place in French cycling memory is itself a beat. Area 31.70 km², elevation 524-911 m. Demonym Chaumeillois / Chaumeilloises. Etymology: from prélatin *calmis* ("plateau désert, lande") + Latin suffix *-iculus*, giving "small heath" — Wikipedia FR (`Chaumeil`) is explicit. The Occitan *chaumo / chalmo* is the cognate that becomes the modern French *chaume*.
+- The commune's history is short on dramatic incident — no Gallo-Roman set-piece comparable to Tintignac, no medieval ruin comparable to Turenne. Chaumeil's story is the *post-1900 cultural* story: the Bourrée, Jean Ségurel, the Bol d'Or, the slow accretion of the Monédières as a culturally marked region.
+
+### Cultural figures (the major spend)
+
+- **Jean Ségurel** (1908-1978). **Born 13 October 1908 at Chaumeil; died 29 December 1978 at Chaumeil (cardiac arrest, age 70); buried at Chaumeil cemetery.** Accordionist, composer, chef d'orchestre. Composed ***Bruyères corréziennes*** in **1936** (lyrics by Jean Leymarie) — by 1945 the recording had pressed 600,000 copies. Founded **Les Troubadours corréziens** in the early 1930s with schoolteachers Jean Leymarie and Roger Leyssène. Founded the **Bol d'Or des Monédières** cycling criterium in **1952**. **Chevalier de la Légion d'honneur 1968**, presented by Charles de Gaulle. Authored 600+ compositions. **His wife was elected mayor of Chaumeil** — a Chaumeil micro-story the seg 15 drafter can lean on. Primary sources: fr.wikipedia.org/wiki/Jean_Ségurel; BnF authority record data.bnf.fr/13958098/jean_segurel; *Jean Ségurel: Un accordéon dans la bruyère* (book biography, libraria-occitana.org).
+- **Musée Jean Ségurel** at the Maison des Monédières, Chaumeil bourg (ground floor; paired with the tourist office; open seasonally). Primary source: tourisme-egletons.com/musee-jean-segurel-chaumeil.
+- **Henry de Jouvenel and the Suc au May table d'orientation.** Inaugurated **25 August 1935** by Jouvenel (then senator of the Corrèze, former minister, former ambassador). 132nd such table placed in France and North Africa. Hexagonal Volvic stone base, engraving on enamelled lava by M. Seurat (Auvergne enamelled-lava factory). Modern measure: 908 m (the inaugural plaque cited 911 m). **The cross-callback to seg 4 (Maison de la Sirène, Collonges-la-Rouge) is verified** — the same Jouvenel who summered with Colette in Collonges climbed up here in 1935 to dedicate the Limousin's first panoramic orientation marker. Primary sources: fr.wikipedia.org/wiki/Suc_au_May; detours-en-limousin.com/Suc-au-May.
+
+### The Dautrement quote
+
+- **Léon Dautrement (1899-1979)** is the historian credited with the phrase "*morceau de Monédières perdu dans le bas Limousin*" describing **Sainte-Fortunade** (commune south of Tulle, well outside this block). The dossier owed this strand the verification, and the verification is *partial*:
+  - **Dautrement himself is real and well-documented.** Born 24 July 1899 at Branceilles (Corrèze), died 9 February 1979 at Brive. President of the Société Scientifique, Historique et Archéologique de la Corrèze (SSHAC) from 1963 until his death. Schoolteacher (SNI union member), socialist activist, FFI Resistance fighter. Author of *Le Limousin et le pays corrézien*, *La Corrèze à vol d'oiseau et en zig-zag*, and *Histoire de la Corrèze pour les écoliers*. A *collège* in Meyssac is named after him. Primary source: Maitron (maitron.fr/dautrement-leon-alphonse-emeric) — the canonical biographical dictionary of the French labour and Resistance movement, primary-quality reference.
+  - **The specific Sainte-Fortunade quote is not located in any web-accessible source.** The phrase does not appear in Google's index. It is almost certainly from one of Dautrement's regional history books (most likely *Le Limousin et le pays corrézien*), but the relevant volume is not digitised. **Recommendation to drafters: do not reproduce the quote in published prose without finding a primary citation** (SSHAC bulletin / BnF / Tulle BFM library). If the quote is used, footnote it as "attributed to Dautrement, reference pending" — and consider whether the *Monédières-as-a-thing-you-can-find-far-from-the-massif* framing it implies is needed at all in seg 14-16, where the massif itself is in front of the rider.
+- The Dautrement / Sainte-Fortunade quote was previously framed as a reserved seg 14-16 anchor; with verification incomplete, **the dossier recommends it be carried forward as a seg 9-10 (Tulle / Sainte-Fortunade) anchor** if the quote ever surfaces — the geography is wrong for the Monédières block. Seg 14-16 drafters can spend the *Dautrement-as-Corrèze-historian* framing without the specific quote.
+
+### Other Monédières literary anchors
+
+- **Pierre Bergounioux** (b. 1949, Brive). The corridor's strongest contemporary literary voice. Heavily Corrézien; best-known landscape work *Un peu de bleu dans le paysage* (reviewed in *journal-ipns.org*). Bergounioux's writing about Corrèze emphasises geological time, erosion, and "the inner resonance of the external spectacle" (per a Sémiotique des paysages study, unilim.fr/actes-semiotiques/3451). **Strong drafter material for seg 15 voice work.**
+- **Joseph Roux** (1834-1905). Tulle-born félibre, majoral of Félibrige 1876, canon of Tulle cathedral. Author of *Pensées* and *Nouvelles Pensées* (1887). First Limousin félibre to write Occitan in classical orthography. Used carefully: he is the canonical Limousin literary voice, but his *Pensées* are aphoristic rather than specifically about Monédières geography.
+- **Antonin Malroux, *Le Soleil de Monédière*.** **CAUTION — DROP.** This novel is set in the **Cantal** commune of *Monédière* (singular, near Salers), not the Corrèze Monédières (plural). Malroux is Cantal-born. A tempting confusion; not corridor material.
+- **Bertrand Levergeois / "Le Roi des Monédières."** **DROP — unverified.** No sources tie Bertrand Levergeois to Corrèze or to "the King of the Monédières."
+
+### The Bourrée des Monédières
+
+- The Bourrée des Monédières is **both** a regional sub-style of the Limousin / Auvergnat bourrée *and* a specific tune crystallised by Jean Ségurel. Per Wikipedia FR (`Musique limousine`): "La bourrée est une danse propre au territoire limousin … parmi les variantes … la *bourrée des Monédières*." Per Wikipedia FR (Ségurel): the piece was played by violinists of the Monédières region — particularly Chaumeil violinists — and Ségurel "collected and popularised" the version that has become canonical. The tune predated him; his recording fixed the name.
+- For drafters: do not write the Bourrée des Monédières as a generic Auvergnat bourrée. It is the *Chaumeil-violinists' bourrée*, with a Ségurel-recorded canon. Primary sources: fr.wikipedia.org/wiki/Musique_limousine; *Folklore du Bas-Limousin* (Les Pastoureaux de la Couze, violons-populaires-nouvelle-aquitaine.fr); *Dits, Chants et Danses Populaires du Limousin*.
+
+### Cycling context
+
+- **The Bol d'Or des Monédières.** Post-Tour criterium founded 1952 by Ségurel. Ran 1952-1967, revived 1981-2002. **Winners read like a roll-call of the post-war peloton: Coppi (1953), Anquetil (1955 + 1962), Géminiani (1956-1958), Poulidor (1963 + 1967; 3rd in 1959 behind Gérard Saint and Ercole Baldini), Hinault (1982).** The **Côte des Géants** (the climb the 2017 Tour du Limousin used as its Chaumeil-circuit climb) takes its name from this era — "the giants" who climbed it after their Tour stages. Already in `data/historical-tdf.json` keyed to seg 15. Primary source: Wikipedia FR `Bol d'Or des Monédières`; Arsène Maulavé, *Le Bol d'Or des Monédières* (book, ISBN 9782915484175).
+- **Paris-Corrèze (2001-2012).** UCI 2.1 stage race created in 2001 by **Laurent Fignon** (1983/1984 Tour winner) with Corrézien motorsport champion **Max Mamers** and the Conseil général de la Corrèze. From 2005, the final stage closed with five laps of the historic Bol d'Or des Monédières circuit at Chaumeil — explicit homage. Six confirmed Chaumeil finishes: 2007 (Vigeois → Chaumeil, won by **Edvald Boasson Hagen** aged 20), 2008 (Brive → Chaumeil), 2009 (**Tulle → Chaumeil**, the strongest single-stage corridor overlap), 2010, 2011 (Objat → Chaumeil), 2012 (Objat → Chaumeil, final edition). The race did not run after 2012. Re-keyed from segs 25-27 to seg 15 during the seg 23-27 verification (#500) per the #502 tour-history dossier. Already in `data/historical-tdf.json`. Primary source: Wikipedia FR `Paris-Corrèze`; velo19.com.
+- **2020 Tour de France, Stage 12 (Chauvigny → Sarran, Thursday 10 September 2020).** First Tour de France appearance of Suc au May. Marc Hirschi (Sunweb) won solo. 218 km — longest stage of the 2020 Tour. Approach from the north (Treignac side); descent south through Saint-Augustin; finish at Sarran as a tribute to the Chirac family. Hirschi's winning solo move launched on or near the Suc au May descent with ~25 km to go. Already in `data/historical-tdf.json` keyed to seg 15. Inner Ring preview (inrng.com/2020/09/tour-de-france-stage-12-preview-sarran) is the primary corridor source.
+- **2017 Tour du Limousin, Stage 3** (Saint-Pantaléon-de-Larche → Chaumeil, Thursday 17 August 2017, 184.7 km, 4,700 m, won by **Cyril Gautier**, AG2R-La Mondiale). Climbs included Côte de la Vaysse and Côte de Lestards; three finishing circuits over the Côte des Géants in Chaumeil. The closest pro-cycling shadow on the Stage 9 corridor before the 2026 Tour. Already in `data/historical-tdf.json` keyed to seg 15.
+- **The 1987 double-finish** (men's Stage 11 Poitiers → Chaumeil + women's Stage 3 Linards → Chaumeil) — see Cross-segment threads above. Both events in `data/historical-tdf.json`.
+- **L'Agglomérée 2026** climbs Suc au May from the south (Saint-Augustin / Chaumeil approach), the same direction as the 2026 Stage 9 — the amateur dress rehearsal for the seg 15 climb. The seg 11 anchor (Auzelou departure) earlier in the corridor pairs with the seg 15 climb here.
+
+### The contested category
+
+- **Issue #513** flags the gradient/category drift on Suc au May:
+  - `data/competition/points-config.json`: km 105.15, 3.8 km, **gradient 7.1%, category HC**.
+  - Tourisme Corrèze 2026 announcement: **Cat 4**, no published length/gradient.
+  - ASO has not published the official roadbook profile as of this dossier's writing.
+- Drafters should know the category is contested and frame the climb on its road shape (short, steep, max gradient 14.9% per the elevation profile), not on a categorisation that may shift before publish day. Do not resolve here; flag for the seg 15 drafter.
+
+## Segment 16 (km 106-112) — descent off the Monédières
+
+### Geography & geology
+
+- Start 45.47539, 1.84875 (853 m). End 45.4682, 1.80576 (592 m). Elevation gain 1 m, loss 262 m. Max descent gradient -8.6%; average -4.4%. The descent runs NNW from the Suc au May road's high point toward the Treignac corridor. Treignac itself sits at km 121.99 in seg 17 — the descent **does not enter the Treignac commune**; seg 16 ends 10 km short of the medieval town.
+- **Granitic basement of the Monédières gives way on the descent to micaschists** as the road drops toward the Vézère valley. The transition is not sharp; the rider notices the change of soils more in roadside cuts and pasture colour than in any single feature.
+- **Sucs visible from the descent.** From the upper km 106-108 stretch most of the named Monédières peaks remain in view to the east (Puy de la Monédière, Puy de la Jarrige, Puy Messou). The Plateau de Millevaches opens to the north. No specific named viewpoint is documented on the seg 16 polyline — the descent itself is the view.
+- **Communes traversed.** Seg 16 has no listed town in `data/segments.json`. The polyline most likely passes through **Chaumeil commune (upper)** and into **Lestards or Madranges (lower)**. **Lestards is corridor-plausible** based on the Tour du Limousin 2017 race route (which used Côte de Lestards on this descent line). **Verify against the segment-16 GPX before any seg 16 prose names a specific commune lower down.**
+
+### The Lestards thatched-roof church
+
+- **Église Saint-Martial-de-Lestards** is the only thatched-roof church in France. 11th-century building, thatched-roof history: between 1909 and 1976 it was slate-roofed; the thatched roof was rebuilt in 1977. Inscribed Monument Historique 1998, classified 2002. Lestards commune population ~50.
+- **Verify whether the seg 16 polyline passes within sight of the Lestards bourg.** If yes, this is the strongest seg 16 attraction. If the bourg is meaningfully off-route, surface as a "near but off-route" candidate (per the Cascades de Gimel / Sarran-museum precedent).
+- Primary sources: terresdecorreze.com; tourismecorreze.com; haute-correze.fr/lestards.
+
+### Cycling context
+
+- **No prior Tour de France visit on this exact descent line**, though the **2020 Stage 12** crossed the road in the opposite direction (climbing toward Suc au May from Treignac). The 2017 Tour du Limousin Stage 3 used **Côte de Lestards** as one of its climbs en route to Chaumeil — that climb is on the seg 16 descent line, **but climbed in the opposite direction**.
+- The Côte des Géants — the climb the Bol d'Or des Monédières used as its circuit climb and the climb the 2017 Tour du Limousin's three finishing circuits crested — is **east of Chaumeil**, on the criterium circuit's east-side stretch toward Lestards / Pradines. **Not on the direct seg 16 descent line** (which heads NNW), but part of the same broader Chaumeil-area road network. The Stage 9 route does not climb the Côte des Géants; framing it in seg 16 prose risks confusion with the climb the riders actually do.
+
+### Vézère watershed
+
+- **Treignac sits on the Vézère.** The watershed boundary between the Corrèze / Vimbelle catchment (which has held the route since seg 9) and the Vézère catchment crosses *somewhere* in this corridor. Working hypothesis: the watershed is crossed near the Suc au May summit itself (i.e. at the seg 15 / seg 16 boundary), making the seg 16 descent the route's entry into the Vézère catchment. **Verify against Géoportail / Sandre** before any seg 16 prose makes a hydrography claim. If true, this is a small but writable watershed-transition beat: the day's first climb is also the day's watershed.
+
+### Famous local people
+
+- Seg 16 has no documented village set-piece comparable to Saint-Augustin (seg 14) or Chaumeil (seg 15); local-person beats are weak here. The natural draw is back toward Chaumeil (Ségurel) or forward toward Treignac (out of scope, seg 17). Drafters writing seg 16 should accept that the local-person beat is thinner — and lean into the descent itself.
+
+### Literary / musical
+
+- Nothing distinct to seg 16 beyond the broader Monédières frame already spent in seg 15. A possible quiet beat: the descent as the moment the rider leaves the heath behind and re-enters the forested upland — the *paysage à l'orée* of seg 14 mirrored in reverse.
+
+## Local media candidates
+
+A new research topic added during this strand at the publisher's request: regional newspapers, radio stations, and community outlets with corridor-specific coverage that drafters could quote or cite. Findings are grouped by tier.
+
+### Tier 1 — high local-colour potential
+
+- **La Vie Corrézienne.** Weekly, founded **1944 at the Liberation**. **First director was Edmond Michelet**, the Brive Resistance figure already in the seg 1 corridor material — a verified cross-corridor callback. Published Friday, ~15,000 copies, 48 pages, 240 volunteer correspondents + 2 journalists. HQ Brive-la-Gaillarde. Voice-of-the-villages outlet. URL: https://www.laviecorrezienne.fr (canonical) or via leguidepratique.com/guide/pays-de-tulle/medias.
+- **La Montagne (édition Corrèze).** Daily, the standard regional reference. Centre France group; Tulle and Brive offices. Strong cycling and cultural-event coverage. URL: https://www.lamontagne.fr/correze.
+- **France Bleu Limousin / ici Limousin.** Public radio, generalist; rebranded as *ici Limousin* in the Radio France network restructuring. Tulle office at 134 avenue Victor-Hugo. Multiple L'Agglomérée and Tour stage-preview pieces in the archive. URL: https://www.francebleu.fr/limousin.
+
+### Tier 2 — verified, narrower
+
+- **France 3 Nouvelle-Aquitaine / Limousin.** Regional public TV. Strong long-form video coverage (e.g. a "Pierre Bergounioux, la passion d'écrire" documentary exists). URL: https://france3-regions.franceinfo.fr/nouvelle-aquitaine/correze.
+- **Tourisme Corrèze.** Departmental tourism office; the canonical source for monument descriptions, opening hours, and official patrimoine. Many tourist-attraction descriptions in `data/attractions.json` already trace here. URL: https://www.tourismecorreze.com.
+- **Office de Tourisme Ventadour-Egletons-Monédières.** Covers **Chaumeil, Sarran, the Monédières-east** — the most corridor-specific tourism site for seg 14-15. Canonical Musée Jean Ségurel, Chaumeil village, Suc au May, and Chirac museum entries. URL: https://www.tourisme-egletons.com.
+- **Terres de Corrèze tourism office.** Covers **Lestards and the Treignac edge** — most useful for seg 16 / seg 17 boundary material. Has the canonical thatched-roof church entry. URL: https://www.terresdecorreze.com.
+
+### Tier 3 — specialist
+
+- **Archives départementales de la Corrèze.** Fonds Henri-Queuille (148J) and other corridor archives; free online access. URL: https://www.archives.correze.fr.
+- **Velo19.com.** Amateur but exhaustive Corrèze cycling history site; Bol d'Or and Paris-Corrèze palmarès. Useful for cycling footnotes. URL: http://velo19.com.
+- **Mémoire filmique en Nouvelle-Aquitaine.** Audiovisual archive; carries the *Le Bol d'Or des Monédières* documentary dossier with searchable regional film footage of the criterium. URL: https://www.memoirefilmiquenouvelleaquitaine.fr.
+- **journal-ipns.org.** Plateau de Millevaches independent journal — "Information / Politique / Nouvelles / Sociales." Covers Bergounioux, the Plateau, cultural life of the wider region. The voice-of-the-Plateau outlet, distinct from departmental dailies. URL: https://www.journal-ipns.org.
+- **Violons Populaires en Nouvelle-Aquitaine** (CRMTL / Camina network). Folk-music and traditional-dance resource. Primary for Bourrée des Monédières research; carries *Folklore du Bas-Limousin* and *Dits, Chants et Danses Populaires du Limousin* entries. URL: https://violons-populaires-nouvelle-aquitaine.fr.
+
+### Tier 4 — flagged / weak / dropped
+
+- **L'Écho de la Corrèze.** **Defunct since 6 November 2019.** Cannot be cited as current; historical archives only.
+- **Le Populaire du Centre.** Limousin regional daily but weaker on Corrèze (more Haute-Vienne focus).
+- **Commune of Chaumeil website.** Not located in this round; flag for verification.
+- **Commune of Saint-Augustin website** (http://www.saintaugustin-19.fr) — exists but returned 403 on fetch from this dossier; flag for browser verification.
+- **Tulle Agglo** (https://www.tulleagglo.fr) — agglomeration umbrella; useful for L'Agglomérée framing.
+
+The headline finding for the publisher: **La Vie Corrézienne (founded by Edmond Michelet, 1944) is the voice-of-the-villages outlet** the seg 14-16 drafters can reach for, with a verified cross-corridor callback to seg 1's Michelet beat. **Office de Tourisme Ventadour-Egletons-Monédières** is the most corridor-specific tourism source. **Velo19.com** is the single best Corrèze-specific cycling-history reference.
+
+## Sources
+
+### Wikipedia / Wikimedia (FR + EN)
+
+- **Saint-Augustin (Corrèze)** — https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) — commune fundamentals (population 427, 2023), demonym, *personnalités*, Augustinian-priory founding, location in the PNR Millevaches.
+- **Chaumeil** — https://fr.wikipedia.org/wiki/Chaumeil — population 164 (2023), area, etymology (*calmis*), demonym Chaumeillois.
+- **Monédières** — https://fr.wikipedia.org/wiki/Mon%C3%A9di%C3%A8res — massif geography, 33 peaks, highest peaks list (Puy de la Monédière 922 m, Puy de la Jarrige 909 m, Suc au May 908 m, Puy Messou 907 m).
+- **Suc au May** — https://fr.wikipedia.org/wiki/Suc_au_May — etymology (Occitan *suc* = sommet), 908 m, table d'orientation inaugurated 25 August 1935 by Henry de Jouvenel, oldest in the Limousin.
+- **Jean Ségurel** — https://fr.wikipedia.org/wiki/Jean_S%C3%A9gurel — biographical fundamentals (b. 13 Oct 1908 Chaumeil, d. 29 Dec 1978 Chaumeil), *Bruyères corréziennes* 1936, Bol d'Or 1952, Légion d'honneur 1968 from de Gaulle, wife as mayor of Chaumeil.
+- **Bol d'Or des Monédières** — https://fr.wikipedia.org/wiki/Bol_d%27Or_des_Mon%C3%A9di%C3%A8res — criterium history, palmarès, Côte des Géants name origin.
+- **Paris-Corrèze** — https://fr.wikipedia.org/wiki/Paris-Corr%C3%A8ze — Fignon / Mamers / Conseil général founding, Chaumeil final-stage history.
+- **Tour de France 2020** — https://en.wikipedia.org/wiki/2020_Tour_de_France — Stage 12 Hirschi solo win, Sarran finish.
+- **Tour de France Féminin 1987** — https://en.wikipedia.org/wiki/1987_Tour_de_France_F%C3%A9minin — Stage 3 Linards → Chaumeil, Bonanomi win.
+- **1987 Tour de France** — https://en.wikipedia.org/wiki/1987_Tour_de_France — Stage 11 Poitiers → Chaumeil, Gayant solo win.
+- **Tour du Limousin** — https://fr.wikipedia.org/wiki/Tour_du_Limousin-Nouvelle-Aquitaine — race history including 2017 Stage 3 Chaumeil finish.
+- **Musée du président Jacques-Chirac** — https://fr.wikipedia.org/wiki/Mus%C3%A9e_du_pr%C3%A9sident_Jacques-Chirac — 15 December 2000 opening, Wilmotte building, 5,000 gifts.
+- **Jacques Chirac** — https://fr.wikipedia.org/wiki/Jacques_Chirac — burial at Cimetière du Montparnasse, Paris 14e (correction to `data/attractions.json` per #564).
+- **Lestards** — https://fr.wikipedia.org/wiki/Lestards — commune fundamentals, thatched-roof church.
+- **Géologie du Limousin** — https://fr.wikipedia.org/wiki/G%C3%A9ologie_du_Limousin — granitic basement of the Limousin, Variscan emplacement 360-290 Ma, leucogranites of the Monédières / Millevaches.
+- **Musique limousine** — https://fr.wikipedia.org/wiki/Musique_limousine — Limousin bourrée including the *bourrée des Monédières* sub-style.
+
+### Regional history / archaeology
+
+- **Correze-histoire-patrimoine.fr — Saint-Augustin** — https://www.correze-histoire-patrimoine.fr/saint-augustin/ — church history, 1681 Duhamel retable, Tourondel hamlet, Boiroux Gallic burial.
+- **Mérimée notice PA00099811** — https://www.pop.culture.gouv.fr/notice/merimee/PA00099811 — Église Saint-Augustin Monument Historique listing.
+- **Maitron — Léon Dautrement** — https://maitron.fr/dautrement-leon-alphonse-emeric — canonical biographical dictionary entry (b. 24 July 1899 Branceilles, d. 9 Feb 1979 Brive, SSHAC president 1963-1979, FFI Resistance).
+- **Saintpardouxlacroisille.net — Camp Roland / Maquis Roland** — http://www.saintpardouxlacroisille.net/stp_30d_009.htm — local-history account of Auguste Vangierdegom ("Roland"), first FTP killed in action in Corrèze (13-14 July 1943), Camp Roland establishment.
+
+### Official tourism / commune
+
+- **Tourisme Corrèze — Suc au May** — referenced via tourismecorreze.com and tourisme-egletons.com.
+- **Office de Tourisme Ventadour-Egletons-Monédières — Musée Jean Ségurel** — https://www.tourisme-egletons.com/musee-jean-segurel-chaumeil/.
+- **Détours en Limousin — Suc au May** — https://www.detours-en-limousin.com/Suc-au-May — table d'orientation history, Jouvenel inauguration.
+- **Lacorreze.com — Suc au May (Monédières)** — https://www.lacorreze.com/regions/monedieres/suc_au_may.htm — tourism-site etymology gloss (*lo suc als mais*, maypoles); cite as regional-tourism source, not as Wikipedia-grade primary.
+- **Terres de Corrèze — Lestards** — https://www.terresdecorreze.com (canonical thatched-roof church entry).
+- **Haute-Corrèze — Lestards** — https://haute-correze.fr/lestards.
+
+### Cycling resources
+
+- **Inner Ring — Tour de France Stage 12 preview (Chauvigny → Sarran)** — https://inrng.com/2020/09/tour-de-france-stage-12-preview-sarran — corridor description, "drops into Chaumeil and there's a tight turn for the Suc au May," descent through Saint-Augustin.
+- **Cycling Stage — Tour de France 2020 Stage 12** — https://cyclingstage.com/cycling/tour-de-france-2020-stage-12.
+- **Cyclingnews — Tour de France 2020 Stage 12** — https://www.cyclingnews.com/races/tour-de-france-2020/stage-12/results — Hirschi solo win, 25 km final move.
+- **L'Agglomérée 2026 cyclosportive** — https://lagglomeree.agglo-tulle.fr/epreuves/cyclosportive — 5 April 2026 date, 85 / 105 km routes, Saint-Augustin double ravito on the 105 km course.
+- **Battistrada — L'Agglomérée 2026** — https://www.battistrada.com/fr/calendrier-cyclosportives/edition/tulle-agglo-cyclosportive-2026/47469 — independent calendar listing with route detail.
+- **Velo19** — http://velo19.com — Corrèze cycling history archive; Bol d'Or and Paris-Corrèze palmarès.
+
+### Music / folklore
+
+- **Violons Populaires en Nouvelle-Aquitaine — Folklore du Bas-Limousin / Pastoureaux de la Couze** — https://violons-populaires-nouvelle-aquitaine.fr/portfolio/les-pastoureaux-de-la-couze-folklore-du-bas-limousin/.
+- **Violons Populaires — Dits, Chants et Danses Populaires du Limousin** — https://violons-populaires-nouvelle-aquitaine.fr/portfolio/dits-chants-et-danses-populaires-du-limousin/.
+- **BnF authority record — Jean Ségurel** — https://data.bnf.fr/13958098/jean_segurel/ — bibliographic anchor for Ségurel footnotes.
+- **Libraria Occitana — *Jean Ségurel: Un accordéon dans la bruyère*** — https://www.libraria-occitana.org/en/product/jean-segurel-un-accordeon-dans-la-bruyere/ — Ségurel biography (book).
+- **Mémoire filmique en Nouvelle-Aquitaine — *Le Bol d'Or des Monédières*** — https://www.memoirefilmiquenouvelleaquitaine.fr — regional documentary dossier on the criterium.
+
+### Literature / regional figures
+
+- **Sémiotique des paysages — Bergounioux essay** — https://www.unilim.fr/actes-semiotiques/3451 — corridor-relevant Bergounioux landscape framing.
+- **Cairn — La Géographie (2017)** — https://www.cairn.info/revue-la-geographie-2017-3-page-50.htm — Bergounioux and geographical resonance.
+- **Journal IPNS — Bergounioux review** — https://www.journal-ipns.org — review of *Un peu de bleu dans le paysage*.
+- **Wikipedia FR — Joseph Roux** — https://fr.wikipedia.org/wiki/Joseph_Roux — Tulle-born félibre, *Pensées*.
+
+### Local media
+
+- **La Vie Corrézienne** — https://www.laviecorrezienne.fr.
+- **La Montagne (édition Corrèze)** — https://www.lamontagne.fr/correze.
+- **France Bleu Limousin (ici Limousin)** — https://www.francebleu.fr/limousin.
+- **France 3 Nouvelle-Aquitaine / Corrèze** — https://france3-regions.franceinfo.fr/nouvelle-aquitaine/correze.
+- **Office de Tourisme Ventadour-Egletons-Monédières** — https://www.tourisme-egletons.com.
+- **Terres de Corrèze tourism office** — https://www.terresdecorreze.com.
+- **Tourisme Corrèze** — https://www.tourismecorreze.com.
+- **Archives départementales de la Corrèze** — https://www.archives.correze.fr.
+- **Tulle Agglo** — https://www.tulleagglo.fr.
+- **Journal IPNS** — https://www.journal-ipns.org.
+
+### Wikimedia Commons image candidates
+
+- **Saint-Augustin (Corrèze)** — Category:Saint-Augustin_(Corrèze) on Wikimedia Commons. Notable files: `File:Saint-Augustin_Église_10.jpg` (church), `File:Le_tourondel_chateau.JPG` (Tourondel château), `File:Le_tourondel_four_a_pain.JPG` (bread oven), `File:Saint-Augustin_Vue_du_village.jpg` (panoramic), `File:Château_du_Tourondel_par_Ernest_Rupin.png` (Rupin historical drawing).
+- **Chaumeil** — Category:Chaumeil. `File:Chaumeil_-_Monument_hommage_à_Jean_Ségurel_A.jpg` (Ségurel monument, hero candidate), `File:Chaumeil_-_Sépulture_de_Jean_Ségurel.jpg` (Ségurel grave), `File:Musée_de_la_Maison_des_Monédières_à_Chaumeil_01.jpg`, `File:Chaumeil_-_La_place.jpg`, `File:Chaumeil_-_La_place_de_l'église.jpg`.
+- **Suc au May** — Category:Suc_au_May. `File:Suc_au_may.jpg`, `File:SucauMay.JPG`, `File:TOsucMay.JPG` (the table d'orientation itself, direct illustration of the 1935 artifact), `File:Vue_depuis_le_Suc_au_May.jpg`, `File:Plateau_limousin_depuis_le_Suc_au_May.JPG`, `File:Passage_Tour_de_France_2020.jpg` (2020 stage passage, direct cycling-history image).
+- **Lestards** — Category:Lestards. `File:Lestards_Eglise_Saint-Martial_11.jpg` and 12-19 (thatched-roof church), `File:Lestards_Eglise_Saint-Martial_La_nef.jpg` (interior), `File:Lestards_Eglise_Saint-Martial_Pieta.jpg` (interior Pietà), `File:Lestards_La_fontaine.jpg`, `File:Lestards1315.jpg`.
+
+Wikimedia Commons default licence is CC BY-SA 4.0 (verify per-file before publication; per-file licence is authoritative).
+
+## Carryforwards out of scope
+
+### To `data/attractions.json` (data issue filed)
+
+- **Issue #564**: `Musée du Président Jacques Chirac` description currently says "Chirac is buried in the Sarran communal cemetery" — he is buried at Cimetière du Montparnasse, Paris 14e. Fix at data-strand time; do not reproduce in entry prose.
+
+### To later segments
+
+- **Treignac (seg 17).** Medieval bridge, Pont de la Tourmente, Gorges de la Vézère, Saut du Loup rapids, Église Notre-Dame-des-Bans. The descent of seg 16 *approaches* Treignac but does not enter the commune. All Treignac material is reserved.
+- **Plateau de Millevaches (segs 18-22).** The plateau opens to the north of the seg 16 descent corridor; the Monédières are formally distinct from Millevaches and the dossier should not poach Millevaches framing here.
+- **Côte de la Croix de Pey (seg 19).** Already keyed in `data/historical-tdf.json` (2020 Stage 12, opposite direction). Out of scope.
+- **Mont Bessou (seg 22).** Highest point in Corrèze, 977 m. Reserved.
+- **Meymac / Abbaye Saint-André (segs 23-24).** Reserved per `project_meymac_voice.md` (Saintsbury voice candidate).
+- **Ussel (segs 25-26).** Reserved.
+
+### To `data/historical-tdf.json` (potential data-strand additions)
+
+- **No new candidate additions surfaced for segs 14-16.** The existing seg 15 entries (1987 men's + women's double-finish, 2017 Tour du Limousin Stage 3, 2020 Tour Stage 12 / Suc au May debut, Bol d'Or des Monédières criterium, Paris-Corrèze final stages) cover the corridor's pro-cycling history thoroughly. The dossier verified each entry against Wikipedia FR and Inner Ring primary sources; no inaccuracies found in the existing `historical-tdf.json` entries for this block.
+
+### To future research strands
+
+- **Lestards on the seg 16 polyline.** Whether the route actually passes within sight of the Lestards bourg, or whether it's a "near but off-route" candidate. Needs GPX polyline check before any seg 16 prose names Lestards.
+- **Vézère watershed crossing.** Exact location of the catchment boundary between the Corrèze/Vimbelle and Vézère drainages. Needs a Géoportail / Sandre hydrography lookup.
+- **Maquis Roland stele dedication.** Ground-truth photo of the seg 14 memorial at km 96.76 (45.434, 1.855) to confirm the stele's specific dedication. The Maquis Roland identity is the strongest working hypothesis; verification by ground photo before any seg 14 prose names a specific unit.
+- **Léon Dautrement Sainte-Fortunade quote.** Primary citation pending. Likely from *Le Limousin et le pays corrézien* (Dautrement); the relevant volume is not digitised. SSHAC bulletin, Tulle BFM library, or Brive municipal archives are next steps. **Geography-wise, the quote belongs to seg 9-10 (Sainte-Fortunade itself), not to this block** — drafters writing seg 14-16 should not need it.
+
+### Reserved (do not use anywhere in this block)
+
+- Saintsbury voice / Mascaron / Meymac abbey — seg 24.
+- The "highest point in Corrèze" framing — Mont Bessou, seg 22.
+- The Plateau de Millevaches as a *paysage* — segs 18-22.
+
+## Open questions for the publisher / drafters
+
+1. **Suc au May category (#513).** Three readings in play: points-config says HC at 7.1% over 3.8 km; Tourisme Corrèze says Cat 4 with no published length/gradient; ASO has not published the 2026 official roadbook. Drafters need to know the polka-dot category is contested. The dossier recommends framing the climb on its road shape (max 14.9% per the elevation profile) rather than the categorisation, until the ASO roadbook lands. Surface, do not resolve.
+
+2. **Maquis Roland identification.** The seg 14 memorial at km 96.76 (45.434, 1.855) is almost certainly the Camp Roland stele commemorating Auguste Vangierdegom ("Roland"), first FTP combatant killed in Corrèze 13-14 July 1943. **A ground-truth photo of the stele's dedication is the missing piece** before any seg 14 prose names a specific fighter or unit. Recommend: a publisher / contributor visit before seg 14 publish, or a phone call to the Office de Tourisme Ventadour-Egletons-Monédières (Egletons OT) to verify the stele's exact text.
+
+3. **Léon Dautrement Sainte-Fortunade quote.** Dautrement is real and well-sourced; the specific quote "*morceau de Monédières perdu dans le bas Limousin*" is not located online. The quote's geography (Sainte-Fortunade, far south of the Monédières) means the seg 14-16 drafters should not need it. **Recommend the quote is reframed as a seg 9-10 carryforward** if and when a primary citation surfaces from SSHAC archives. Drafters of this block can use Dautrement-as-historian framing without the specific quote.
+
+4. **Saint-Augustin commune website fetch.** http://www.saintaugustin-19.fr returned 403 to the research subagent. **Verify in a browser** before any seg 14 prose claims a fact attributed to the commune-of-Saint-Augustin official source.
+
+5. **Mérimée notice PA00099811 dates.** Two dates in play for the Église Saint-Augustin classification: Wikipedia FR cites 25 September 1929 (church inscription); correze-histoire-patrimoine.fr cites 29 November 1929 (retable as classified *objet*). Both are likely true (church inscrit + retable separately classified); verify against the Mérimée notice directly before any seg 14 prose cites either date.
+
+6. **Lestards on the seg 16 polyline.** The Lestards bourg's relationship to the seg 16 descent line needs a GPX polyline check. If the bourg is on or very near the polyline, the thatched-roof church is the segment's strongest set-piece. If meaningfully off-route, frame as "near but off-route" per the Cascades de Gimel precedent.
+
+7. **Vézère watershed crossing.** Working hypothesis: crossed at or near the Suc au May summit, making seg 16's descent the entry into the Vézère catchment. **Verify via Géoportail / Sandre** before any seg 16 prose claims a watershed beat.
+
+8. **Suc au May etymology gloss.** Wikipedia FR is conservative: *suc* = Occitan for "sommet." The richer "lo suc als mais" / maypoles framing comes from a regional-tourism source (lacorreze.com), not a Wikipedia-grade primary. **Drafters who want the maypole reading should footnote it as a regional gloss**, not as bedrock etymology.
+
+9. **Anchor allocation between seg 14 and seg 15.** Per the strand brief, the Monédières framing reserved through segs 11-13 spends across the block; the dossier surfaces all of it; the drafters divide it. Recommended allocation:
+   - **Seg 14**: Saint-Augustin as threshold village, the Duhamel retable pair (with the seg 12 Naves retable), the Maquis Roland memorial, the massif becoming visible.
+   - **Seg 15**: Chaumeil + Ségurel + Bol d'Or + Bourrée des Monédières + Suc au May + Henry de Jouvenel (seg 4 callback). The Barthes "develops" beat.
+   - **Seg 16**: descent off the massif, Lestards (if on-route), the watershed transition, the 2020 Stage 12 directional inversion. Quieter; deliberately so.
+
+10. **L'Agglomérée 2026 corridor tie-in.** The cyclosportive's 105 km course climbs Suc au May from the same side as the 2026 Stage 9. **Recommend a press scan of La Vie Corrézienne and La Montagne** for L'Agglomérée 2026 reportage before seg 15 drafting; current-events material from the 5 April 2026 event would let seg 15 cite specific local riders, accidents, or anecdotes.
+
+11. **Local media tie-in.** La Vie Corrézienne (founded 1944 by Edmond Michelet, the Brive Resistance figure already in seg 1) is a verified voice-of-the-villages outlet with a strong cross-corridor callback. Office de Tourisme Ventadour-Egletons-Monédières is the most corridor-specific tourism site. **Recommend the seg 14-16 drafters reach for these specifically** when local-colour quotes are needed, rather than the national dailies.
+
+12. **Highest-peak framing.** Suc au May at 908 m is **not** the highest peak in the Monédières (Puy de la Monédière 922 m, Puy de la Jarrige 909 m sit higher) and **not** the highest point in Corrèze (Mont Bessou 977 m, seg 22). Drafters: write Suc au May as the *most-named*, *most-photographed*, *most-visited*, or *most-fierce* summit — not the *highest*.


### PR DESCRIPTION
## Summary

- Adds `content/research/segs-14-16-block-research.md`, the block research dossier for segs 14 / 15 / 16 (km 92-112: Saint-Augustin → Suc au May → descent off the Monédières).
- Mirrors the shape of `content/research/segs-11-13-block-research.md` (PR #501) — second instance of the block-research-then-N-drafts technique applied to this corridor.
- Feeds three downstream drafting strands: seg 14 (briefed already, unblocks on merge), seg 15 (spawns from this dossier), seg 16 (spawns from this dossier).

Closes #562.

## Dossier contents

- **Cross-segment threads** — the earned summit, the 2020 → 2026 directional inversion on Suc au May, the 1987 men's + women's Tour double-finish at Chaumeil, the L'Agglomérée 2026 dress rehearsal, the Bol d'Or des Monédières lineage, the Maquis Roland above the heath, Sarran adjacency and the Chirac burial myth, the seg 4 callback (Henry de Jouvenel).
- **Per-segment sections** — seg 14 (Saint-Augustin, the Duhamel retable pair with Naves, the Maquis Roland memorial), seg 15 (Chaumeil, Jean Ségurel fully verified, Suc au May, Bourrée des Monédières, the Dautrement quote), seg 16 (descent, Lestards thatched-roof church, Vézère watershed).
- **Local media candidates** (publisher's added research topic) — tier-1 outlets La Vie Corrézienne, La Montagne, France Bleu Limousin; tier-2 Office de Tourisme Ventadour-Egletons-Monédières (most corridor-specific); tier-3 Velo19, journal-ipns, the CRMTL music network.
- **Sources** — Wikipedia, regional history sites (correze-histoire-patrimoine, Maitron for Dautrement biographical record), tourism offices, cycling resources (Inner Ring 2020 preview, Cyclingnews 2020 results, L'Agglomérée), music sources, and Wikimedia Commons image candidates.
- **Carryforwards out of scope** — Treignac (seg 17), Plateau de Millevaches (segs 18-22), Mont Bessou (seg 22), Meymac/Saintsbury (segs 23-25), Ussel.
- **Open questions for the publisher / drafters** — Suc au May category drift (#513), Maquis Roland ground-truth photo, Dautrement quote verification, Lestards polyline check, Vézère watershed crossing.

## Cross-issue surfacing

- **#513** (Suc au May points-config drift, HC vs Cat 4) — surfaced for the seg 15 drafter; not resolved here per scope discipline.
- **#564** (filed by this strand) — `data/attractions.json` Musée Chirac description incorrectly says Chirac is buried at Sarran. He is buried at Cimetière du Montparnasse, Paris 14e. Flagged for the data strand; do not reproduce in entry prose.

## Verification

- `npm test` — 198 tests pass (27 files).
- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — passes.
- `python3 processing/validate_points.py` — passes.

## Notes

- Strand runs in auto-mode per the v1.4.18 retro learning (research suits auto-mode). No AskUserQuestion checkpoints fired.
- Subagent surfaced four corrections to repo assumptions: (1) Monédières are granitic not volcanic, (2) Suc au May is not the massif's highest peak (Puy de la Monédière 922 m is), (3) Chirac burial location (#564 filed), (4) Bruyères corréziennes year is 1936 not 1948.
- The Dautrement Sainte-Fortunade quote could not be located online despite Dautrement himself being well-sourced (Maitron biographical record). Dossier recommends drafters of this block do not use the quote without a primary citation, and that it is reframed as a seg 9-10 (Sainte-Fortunade-as-geography) carryforward if SSHAC archives ever surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)