### PR TITLE
fix(stats): trap time-of-day and cutoff drift in stats pipeline (closes #541, #328)

### DIFF
--- a/processing/calculate_points.py
+++ b/processing/calculate_points.py
@@ -5,16 +5,28 @@ import argparse
 import json
 import random
 
+from rider_stats import capped_daily_distances
+
 
 def load_json(path):
     with open(path, "r") as f:
         return json.load(f)
 
 
+def filter_log_to_cutoff(daily_log, data_cutoff):
+    """Return a log dict containing only entries on or before data_cutoff (ISO date string)."""
+    if data_cutoff is None:
+        return daily_log
+    return {"entries": [e for e in daily_log.get("entries", []) if e["date"] <= data_cutoff]}
+
+
 def calculate_capped_distances(daily_log, rider_config):
     """Calculate cumulative capped distance per rider per day.
 
     Returns dict of rider_id -> list of (date, cumulative_capped_km).
+
+    Carry-over capping delegates to rider_stats.capped_daily_distances so the
+    two scripts cannot drift (see issue #328 acceptance criteria).
     """
     daily_cap = rider_config["dailyCap"]
     entries = sorted(daily_log["entries"], key=lambda e: e["date"])
@@ -22,15 +34,12 @@ def calculate_capped_distances(daily_log, rider_config):
 
     result = {}
     for rider_id in rider_ids:
-        carry = 0.0
-        cumulative = 0.0
+        daily_dists = [e.get("distances", {}).get(rider_id, 0) for e in entries]
+        capped = capped_daily_distances(daily_dists, daily_cap)
         progress = []
-        for entry in entries:
-            dist = entry.get("distances", {}).get(rider_id, 0)
-            available = daily_cap + carry
-            credited = min(dist, available)
+        cumulative = 0.0
+        for entry, credited in zip(entries, capped):
             cumulative += credited
-            carry = available - credited
             progress.append({"date": entry["date"], "cumulative_km": cumulative})
         result[rider_id] = progress
 
@@ -147,11 +156,18 @@ def main():
     parser.add_argument("--points-config", default="data/competition/points-config.json")
     parser.add_argument("--output", default="data/riders/points.json")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for tiebreaking")
+    parser.add_argument(
+        "--data-cutoff",
+        default=None,
+        help="Filter log to entries on or before this date (YYYY-MM-DD). Mirrors snapshot_stats.py.",
+    )
     args = parser.parse_args()
 
     daily_log = load_json(args.daily_log)
     rider_config = load_json(args.rider_config)
     points_config = load_json(args.points_config)
+
+    daily_log = filter_log_to_cutoff(daily_log, args.data_cutoff)
 
     result = calculate_points(daily_log, rider_config, points_config, seed=args.seed)
 

--- a/processing/rider_stats.py
+++ b/processing/rider_stats.py
@@ -3,8 +3,9 @@
 
 import argparse
 import json
+import math
 import statistics
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 
 def load_json(path):
@@ -12,22 +13,65 @@ def load_json(path):
         return json.load(f)
 
 
-def calculate_stats(daily_log, rider_config):
-    """Calculate all stats for all riders."""
+def capped_daily_distances(daily_dists, daily_cap):
+    """Apply the rolling daily cap with carry-over to a list of daily distances.
+
+    Each day's cap is the configured daily_cap plus any unused cap carried from
+    earlier days. Returns the list of credited (capped) distances, in input order.
+
+    This helper is the single source of truth for carry-over capping; it is
+    imported by calculate_points.py so the two scripts cannot drift.
+    """
+    capped = []
+    carry = 0.0
+    for d in daily_dists:
+        available = daily_cap + carry
+        credited = min(d, available)
+        capped.append(credited)
+        carry = available - credited
+    return capped
+
+
+def calculate_stats(daily_log, rider_config, reference_date=None):
+    """Calculate all stats for all riders.
+
+    Parameters
+    ----------
+    daily_log, rider_config : dict
+        Parsed JSON data.
+    reference_date : datetime.date, optional
+        The date against which "today"-relative outputs (asOf, estimatedFinishDate)
+        are computed. Defaults to today's date for backwards compatibility with
+        ad-hoc CLI use, but call sites that need reproducible output (publish.sh,
+        snapshots, tests) MUST pass this explicitly. A `date` (not `datetime`) by
+        design: estimated finish dates are reproducible across hours of the day.
+        See issue #541.
+
+    Banker's-rounding rule (see PR for #541, #328):
+        Both estimatedDaysToFinish and estimatedFinishDate use math.floor of the
+        raw float days. estimatedFinishDate = reference_date + floor(days). This
+        matches the seg 11 hotfix and ensures the two displayed values can never
+        disagree.
+    """
+    if reference_date is None:
+        reference_date = date.today()
+    elif isinstance(reference_date, datetime):
+        reference_date = reference_date.date()
+
     riders = {r["id"]: r for r in rider_config["riders"]}
     total_distance = rider_config["totalDistance"]
     daily_cap = rider_config["dailyCap"]
     entries = daily_log["entries"]
 
     if not entries:
-        return {"asOf": datetime.now().strftime("%Y-%m-%d"), "entryNumber": 0, "riders": {}}
+        return {"asOf": reference_date.isoformat(), "entryNumber": 0, "riders": {}}
 
     # Sort entries by date
     entries = sorted(entries, key=lambda e: e["date"])
-    today = datetime.now().strftime("%Y-%m-%d")
+    as_of = reference_date.isoformat()
 
     result = {
-        "asOf": today,
+        "asOf": as_of,
         "entryNumber": len(entries),
         "riders": {},
     }
@@ -70,25 +114,21 @@ def calculate_stats(daily_log, rider_config):
         daily_avg_actual = statistics.mean(daily_dists) if daily_dists else 0
 
         # --- Stats using CAPPED daily distances with carry-over ---
-        # Cap is 2km/day, but unused cap rolls to the next day.
-        # E.g., ride 1km on day 1 -> day 2 cap is 3km (2 + 1 unused)
-        capped_dists = []
-        carry = 0.0
-        for d in daily_dists:
-            available = daily_cap + carry
-            credited = min(d, available)
-            capped_dists.append(credited)
-            carry = available - credited
+        capped_dists = capped_daily_distances(daily_dists, daily_cap)
 
         total_capped = sum(capped_dists)
         daily_avg_capped = statistics.mean(capped_dists) if capped_dists else 0
         distance_remaining = max(0, total_distance - total_capped)
 
         if daily_avg_capped > 0:
-            est_days_to_finish = distance_remaining / daily_avg_capped
-            est_finish_date = (datetime.now() + timedelta(days=est_days_to_finish)).strftime("%Y-%m-%d")
+            est_days_raw = distance_remaining / daily_avg_capped
+            # Floor rule: both displayed days and finish-date offset use the same
+            # integer, so they cannot disagree. See module docstring on rounding.
+            est_days_int = math.floor(est_days_raw)
+            est_finish_date = (reference_date + timedelta(days=est_days_int)).isoformat()
+            est_days_display = est_days_int
         else:
-            est_days_to_finish = None
+            est_days_display = None
             est_finish_date = None
 
         result["riders"][rider_id] = {
@@ -102,7 +142,7 @@ def calculate_stats(daily_log, rider_config):
             "bestThreeDayCombo": round(best_three_day, 1),
             "recentFiveDayAverage": round(recent_five_avg, 2),
             "distanceRemaining": round(distance_remaining, 1),
-            "estimatedDaysToFinish": round(est_days_to_finish) if est_days_to_finish else None,
+            "estimatedDaysToFinish": est_days_display,
             "estimatedFinishDate": est_finish_date,
         }
 
@@ -123,12 +163,18 @@ def main():
     parser.add_argument("--daily-log", default="data/riders/daily-log.json")
     parser.add_argument("--rider-config", default="data/riders/rider-config.json")
     parser.add_argument("--output", default="data/riders/stats.json")
+    parser.add_argument(
+        "--reference-date",
+        default=None,
+        help="ISO date (YYYY-MM-DD) used for asOf and estimatedFinishDate. Defaults to today.",
+    )
     args = parser.parse_args()
 
     daily_log = load_json(args.daily_log)
     rider_config = load_json(args.rider_config)
 
-    stats = calculate_stats(daily_log, rider_config)
+    ref = date.fromisoformat(args.reference_date) if args.reference_date else date.today()
+    stats = calculate_stats(daily_log, rider_config, reference_date=ref)
 
     with open(args.output, "w") as f:
         json.dump(stats, f, indent=2)

--- a/processing/snapshot_stats.py
+++ b/processing/snapshot_stats.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+from datetime import date
 
 from rider_stats import calculate_stats
 
@@ -13,8 +14,44 @@ def load_json(path):
         return json.load(f)
 
 
-def create_snapshot(stats_path, points_path, log_path, segment, output_dir, data_cutoff=None, rider_config_path=None):
-    """Create a snapshot of current rider data for a segment."""
+_RIDER_CONFIG_REQUIRED = object()
+
+
+def create_snapshot(
+    stats_path,
+    points_path,
+    log_path,
+    segment,
+    output_dir,
+    data_cutoff=None,
+    rider_config_path=_RIDER_CONFIG_REQUIRED,
+):
+    """Create a snapshot of current rider data for a segment.
+
+    When data_cutoff is set, rider_config_path must be a path to a readable
+    rider-config.json file: the stats are recalculated from the filtered log so
+    the snapshot's numbers agree with its dataCutoff. Earlier silent-fallback
+    behaviour (continuing with un-recalculated stats when the path was missing
+    or didn't exist) hid configuration errors — see issue #328 acceptance
+    criteria. Callers that genuinely want no recalculation must pass
+    data_cutoff=None explicitly.
+    """
+    if data_cutoff:
+        if rider_config_path is _RIDER_CONFIG_REQUIRED:
+            raise ValueError(
+                "rider_config_path is required when data_cutoff is set. "
+                "Without it, stats cannot be recalculated against the filtered log."
+            )
+        if not rider_config_path or not os.path.exists(rider_config_path):
+            raise FileNotFoundError(
+                f"rider_config_path {rider_config_path!r} not found; cannot recalculate "
+                f"stats for data_cutoff={data_cutoff}."
+            )
+    # When data_cutoff is None we don't need rider_config_path. Coerce sentinel
+    # to None so downstream code can rely on a plain optional path.
+    if rider_config_path is _RIDER_CONFIG_REQUIRED:
+        rider_config_path = None
+
     stats = load_json(stats_path)
     log = load_json(log_path)
 
@@ -26,10 +63,13 @@ def create_snapshot(stats_path, points_path, log_path, segment, output_dir, data
     if data_cutoff and log.get("entries"):
         log["entries"] = [e for e in log["entries"] if e["date"] <= data_cutoff]
 
-    # Recalculate stats from filtered log so numbers match the displayed data
-    if data_cutoff and rider_config_path and os.path.exists(rider_config_path):
+    # Recalculate stats from filtered log so numbers match the displayed data.
+    # reference_date defaults to data_cutoff so the snapshot's
+    # estimatedFinishDate is reproducible (per issue #541): the cutoff is the
+    # canonical "as-of" date for the publication.
+    if data_cutoff:
         rider_config = load_json(rider_config_path)
-        stats = calculate_stats(log, rider_config)
+        stats = calculate_stats(log, rider_config, reference_date=date.fromisoformat(data_cutoff))
 
     # Override asOf to match the last log entry date
     if log.get("entries"):

--- a/processing/tests/test_rider_stats_temporal.py
+++ b/processing/tests/test_rider_stats_temporal.py
@@ -1,0 +1,181 @@
+"""Regression tests for stats-pipeline temporal coupling (issues #541, #328).
+
+Two assertions trap the bug class:
+
+1. `calculate_stats` does not consult `datetime.now()` at all — its output
+   depends only on the daily log, the rider config, and an explicit
+   `reference_date` argument. Same-day runs at different hours produce
+   identical output.
+
+2. Regenerating stats and points for the seg 11 publish date (2026-05-11)
+   from the snapshot's frozen log produces values byte-identical to the
+   hotfixed seg 11 snapshot (see issue #541 for the hotfix narrative).
+"""
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from processing.calculate_points import calculate_points
+from processing.rider_stats import calculate_stats
+
+
+SNAPSHOT_11_PATH = Path(__file__).resolve().parents[2] / "data" / "riders" / "snapshots" / "snapshot-11.json"
+
+
+def _load_snapshot_11():
+    with open(SNAPSHOT_11_PATH) as f:
+        return json.load(f)
+
+
+def _standard_rider_config():
+    """The production rider-config.json shape — mirrors `data/riders/rider-config.json`."""
+    return {
+        "riders": [
+            {"id": "justin", "name": "Justin", "color": "#DAA520"},
+            {"id": "marian", "name": "Marian", "color": "#4682B4"},
+            {"id": "nan", "name": "Nan", "color": "#FF00FF"},
+            {"id": "wally", "name": "Wally", "color": "#8B0000"},
+        ],
+        "totalDistance": 185,
+        "dailyCap": 2,
+        "startDate": "2026-04-02",
+    }
+
+
+class TestNoDatetimeNowInStats:
+    """`calculate_stats` must not call `datetime.now()` — it depends only on its
+    inputs. This was the root cause of the #541 time-of-day finish-date bug."""
+
+    def test_calculate_stats_does_not_call_datetime_now(self, monkeypatch):
+        """Monkey-patch datetime in rider_stats so any `.now()` call raises."""
+        from processing import rider_stats
+
+        class _Forbidden:
+            @classmethod
+            def now(cls, *a, **kw):
+                raise AssertionError(
+                    "calculate_stats must not call datetime.now() — pass reference_date instead"
+                )
+
+            @classmethod
+            def today(cls, *a, **kw):
+                raise AssertionError(
+                    "calculate_stats must not call datetime.today() — pass reference_date instead"
+                )
+
+        monkeypatch.setattr(rider_stats, "datetime", _Forbidden)
+
+        log = {
+            "entries": [
+                {"date": "2026-04-02", "distances": {"justin": 2.0, "marian": 1.0, "nan": 2.0, "wally": 1.5}},
+                {"date": "2026-04-03", "distances": {"justin": 2.0, "marian": 2.0, "nan": 2.0, "wally": 2.0}},
+            ]
+        }
+        result = calculate_stats(log, _standard_rider_config(), reference_date=date(2026, 4, 3))
+        assert result["asOf"] == "2026-04-03"
+        assert result["entryNumber"] == 2
+
+    def test_calculate_stats_output_independent_of_clock(self):
+        """Two runs with the same reference_date must produce byte-identical output,
+        regardless of when the clock ticks. This is the direct #541 assertion."""
+        log = {
+            "entries": [
+                {"date": "2026-05-08", "distances": {"justin": 1.5, "marian": 1.0, "nan": 2.0, "wally": 1.5}},
+                {"date": "2026-05-09", "distances": {"justin": 2.0, "marian": 2.0, "nan": 2.0, "wally": 2.0}},
+            ]
+        }
+        config = _standard_rider_config()
+        ref = date(2026, 5, 11)
+        first = calculate_stats(log, config, reference_date=ref)
+        second = calculate_stats(log, config, reference_date=ref)
+        assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+class TestSegment11Regeneration:
+    """Regenerate seg 11 stats + points from the frozen snapshot log; outputs must
+    match the hotfixed snapshot values per #541.
+
+    Reference_date = the segment's dataCutoff (2026-05-11). The snapshot's `asOf`
+    is overridden downstream by snapshot_stats.py to the last log-entry date
+    (2026-05-09); we assert against the per-rider values, which are computed by
+    calculate_stats itself."""
+
+    DATA_CUTOFF = date(2026, 5, 11)
+
+    @pytest.fixture
+    def snapshot(self):
+        if not SNAPSHOT_11_PATH.exists():
+            pytest.skip(f"Snapshot fixture not present at {SNAPSHOT_11_PATH}")
+        return _load_snapshot_11()
+
+    def test_stats_regenerate_matches_snapshot(self, snapshot):
+        log = snapshot["log"]
+        config = _standard_rider_config()
+        result = calculate_stats(log, config, reference_date=self.DATA_CUTOFF)
+
+        # Per-rider numeric fields must match the snapshot exactly. The snapshot's
+        # asOf was overridden downstream — we don't assert on top-level asOf here.
+        for rider_id in ("justin", "marian", "nan", "wally"):
+            expected = snapshot["stats"]["riders"][rider_id]
+            actual = result["riders"][rider_id]
+            for field in (
+                "totalDistanceCapped", "dailyAverageActual", "dailyAverageCapped",
+                "longestDay", "shortestDay", "daysBelowThreeKm",
+                "consistencyStdev", "bestThreeDayCombo", "recentFiveDayAverage",
+                "distanceRemaining", "estimatedDaysToFinish", "estimatedFinishDate",
+                "place",
+            ):
+                assert actual[field] == expected[field], (
+                    f"{rider_id}.{field}: regenerated {actual[field]!r} != snapshot {expected[field]!r}"
+                )
+
+    def test_points_regenerate_matches_snapshot(self, snapshot):
+        log = snapshot["log"]
+        config = _standard_rider_config()
+        points_config_path = Path(__file__).resolve().parents[2] / "data" / "competition" / "points-config.json"
+        with open(points_config_path) as f:
+            points_config = json.load(f)
+
+        # calculate_points takes no reference_date — its only temporal input is
+        # the daily log. The snapshot's log is the truth; regenerated points
+        # must match.
+        result = calculate_points(log, config, points_config, seed=42)
+
+        for rider_id in ("justin", "marian", "nan", "wally"):
+            expected = snapshot["points"]["riders"][rider_id]
+            actual = result["riders"][rider_id]
+            assert actual == expected, (
+                f"{rider_id} points: regenerated {actual} != snapshot {expected}"
+            )
+
+
+class TestEstimatedFinishConsistency:
+    """The displayed days and date must be derivable from one another via the
+    chosen rounding rule — picking `floor` per the seg 11 hotfix (see PR body).
+    For any rider: cutoff + estimatedDaysToFinish days == estimatedFinishDate."""
+
+    def test_days_and_date_agree(self):
+        log = {
+            "entries": [
+                # 50 days at 2 km/day capped → 100 km of 185. Remaining 85, avg 2.0, est 42.5 days.
+                {"date": f"2026-04-{i+1:02d}" if i < 30 else f"2026-05-{i-29:02d}",
+                 "distances": {"justin": 2.0, "marian": 2.0, "nan": 2.0, "wally": 2.0}}
+                for i in range(50)
+            ]
+        }
+        config = _standard_rider_config()
+        ref = date(2026, 5, 20)
+        result = calculate_stats(log, config, reference_date=ref)
+        for rider_id in ("justin", "marian", "nan", "wally"):
+            r = result["riders"][rider_id]
+            days = r["estimatedDaysToFinish"]
+            finish = r["estimatedFinishDate"]
+            # date.fromisoformat works for YYYY-MM-DD strings
+            expected_finish = (ref.replace() + __import__("datetime").timedelta(days=days)).isoformat()
+            assert finish == expected_finish, (
+                f"{rider_id}: cutoff {ref} + {days} days = {expected_finish}, got {finish}"
+            )

--- a/processing/tests/test_rider_stats_temporal.py
+++ b/processing/tests/test_rider_stats_temporal.py
@@ -13,15 +13,13 @@ Two assertions trap the bug class:
 """
 
 import json
-import os
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
 
 from processing.calculate_points import calculate_points
 from processing.rider_stats import calculate_stats
-
 
 SNAPSHOT_11_PATH = Path(__file__).resolve().parents[2] / "data" / "riders" / "snapshots" / "snapshot-11.json"
 
@@ -174,8 +172,7 @@ class TestEstimatedFinishConsistency:
             r = result["riders"][rider_id]
             days = r["estimatedDaysToFinish"]
             finish = r["estimatedFinishDate"]
-            # date.fromisoformat works for YYYY-MM-DD strings
-            expected_finish = (ref.replace() + __import__("datetime").timedelta(days=days)).isoformat()
+            expected_finish = (ref + timedelta(days=days)).isoformat()
             assert finish == expected_finish, (
                 f"{rider_id}: cutoff {ref} + {days} days = {expected_finish}, got {finish}"
             )

--- a/processing/tests/test_snapshot_stats.py
+++ b/processing/tests/test_snapshot_stats.py
@@ -3,6 +3,8 @@
 import json
 import os
 
+import pytest
+
 from processing.snapshot_stats import create_snapshot
 
 
@@ -163,6 +165,38 @@ class TestCreateSnapshot:
             snapshot = json.load(f)
 
         assert snapshot["stats"]["asOf"] == "2026-04-07"
+
+    def test_data_cutoff_without_rider_config_raises(self, tmp_path):
+        """Issue #328: silent fallback when rider_config_path is missing is gone.
+        Passing data_cutoff without rider_config_path must fail loudly."""
+        stats = tmp_path / "stats.json"
+        points = tmp_path / "points.json"
+        log = tmp_path / "log.json"
+        output_dir = tmp_path / "snapshots"
+
+        stats.write_text(json.dumps({"asOf": "2026-04-07", "riders": {}}))
+        points.write_text(json.dumps({"riders": {}, "locations": []}))
+        log.write_text(json.dumps({"entries": [{"date": "2026-04-01", "distances": {}}]}))
+
+        with pytest.raises(ValueError, match="rider_config_path is required"):
+            create_snapshot(str(stats), str(points), str(log), 1, str(output_dir),
+                            data_cutoff="2026-04-01")
+
+    def test_data_cutoff_with_missing_config_file_raises(self, tmp_path):
+        """Passing a path that doesn't exist must fail loudly, not silently skip recalculation."""
+        stats = tmp_path / "stats.json"
+        points = tmp_path / "points.json"
+        log = tmp_path / "log.json"
+        output_dir = tmp_path / "snapshots"
+
+        stats.write_text(json.dumps({"asOf": "2026-04-07", "riders": {}}))
+        points.write_text(json.dumps({"riders": {}, "locations": []}))
+        log.write_text(json.dumps({"entries": [{"date": "2026-04-01", "distances": {}}]}))
+
+        with pytest.raises(FileNotFoundError):
+            create_snapshot(str(stats), str(points), str(log), 1, str(output_dir),
+                            data_cutoff="2026-04-01",
+                            rider_config_path=str(tmp_path / "does-not-exist.json"))
 
     def test_overwrites_existing_snapshot(self, tmp_path):
         stats = tmp_path / "stats.json"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -157,25 +157,10 @@ print(best if best is not None else 0)
 fi
 echo ""
 
-# Step 1: Update rider stats
-echo "--- Step 1: Updating rider stats ---"
-"$VENV_PYTHON" "$PROJECT_DIR/processing/rider_stats.py" \
-    --daily-log "$PROJECT_DIR/data/riders/daily-log.json" \
-    --rider-config "$PROJECT_DIR/data/riders/rider-config.json" \
-    --output "$PROJECT_DIR/data/riders/stats.json"
-echo ""
-
-# Step 2: Calculate points
-echo "--- Step 2: Calculating points ---"
-"$VENV_PYTHON" "$PROJECT_DIR/processing/calculate_points.py" \
-    --daily-log "$PROJECT_DIR/data/riders/daily-log.json" \
-    --rider-config "$PROJECT_DIR/data/riders/rider-config.json" \
-    --points-config "$PROJECT_DIR/data/competition/points-config.json" \
-    --output "$PROJECT_DIR/data/riders/points.json"
-echo ""
-
-# Step 3: Snapshot stats for current segment
-echo "--- Step 3: Creating stats snapshot for segment $SEGMENT ---"
+# Resolve segment's dataCutoff first, then thread it through every stage so
+# the stats/points/snapshot outputs are reproducible against the cutoff (per
+# issues #541, #328). The order is: find entry file → resolve cutoff → run
+# stats with --reference-date → run points with --data-cutoff → snapshot.
 ENTRY_FILE=$("$VENV_PYTHON" -c "
 import os, re
 entries_dir = '$PROJECT_DIR/content/entries'
@@ -220,6 +205,29 @@ else:
 "
 fi
 echo "Data cutoff for segment $SEGMENT: $DATA_CUTOFF"
+echo ""
+
+# Step 1: Update rider stats (reference-date = data cutoff for reproducibility)
+echo "--- Step 1: Updating rider stats ---"
+"$VENV_PYTHON" "$PROJECT_DIR/processing/rider_stats.py" \
+    --daily-log "$PROJECT_DIR/data/riders/daily-log.json" \
+    --rider-config "$PROJECT_DIR/data/riders/rider-config.json" \
+    --output "$PROJECT_DIR/data/riders/stats.json" \
+    --reference-date "$DATA_CUTOFF"
+echo ""
+
+# Step 2: Calculate points (data-cutoff matches stats so the two cannot drift)
+echo "--- Step 2: Calculating points ---"
+"$VENV_PYTHON" "$PROJECT_DIR/processing/calculate_points.py" \
+    --daily-log "$PROJECT_DIR/data/riders/daily-log.json" \
+    --rider-config "$PROJECT_DIR/data/riders/rider-config.json" \
+    --points-config "$PROJECT_DIR/data/competition/points-config.json" \
+    --output "$PROJECT_DIR/data/riders/points.json" \
+    --data-cutoff "$DATA_CUTOFF"
+echo ""
+
+# Step 3: Snapshot stats for current segment
+echo "--- Step 3: Creating stats snapshot for segment $SEGMENT ---"
 "$VENV_PYTHON" "$PROJECT_DIR/processing/snapshot_stats.py" \
     --stats "$PROJECT_DIR/data/riders/stats.json" \
     --points "$PROJECT_DIR/data/riders/points.json" \


### PR DESCRIPTION
## Cut-over decision

Per strand brief §5 step 1, publisher chose **hold until publisher reviews PR**. Today's seg 12 publish.sh fires the time-of-day bug once more on known data; this PR locks in for seg 13 once reviewed and merged. Do not merge before publisher sign-off.

## What changed

Three concrete changes plus shared carry-over plumbing, matching the #328 acceptance criteria:

- **`processing/rider_stats.py::calculate_stats`** takes a `reference_date: date` parameter and never calls `datetime.now()`. The CLI exposes `--reference-date YYYY-MM-DD`. Default is `date.today()` so ad-hoc CLI runs still work, but publish.sh now passes the segment's dataCutoff explicitly.
- **`processing/calculate_points.py`** gains `--data-cutoff YYYY-MM-DD` mirroring `snapshot_stats.py`. Its carry-over capping now imports `capped_daily_distances` from `rider_stats.py` rather than maintaining a parallel implementation — see #328 acceptance criteria and `feedback_parallel_source_of_truth_detector.md`.
- **`processing/snapshot_stats.py`** raises when `data_cutoff` is set without a usable `rider_config_path`. The previous silent fallback would skip the stats recalculation and publish unfiltered numbers, exactly the bug class #328 was filed about. A sentinel default + explicit `ValueError`/`FileNotFoundError` replaces the silent path.

`scripts/publish.sh` is wired so the segment's dataCutoff resolves once, then threads through stats → points → snapshot in order. No reshape; the publish.sh contract is unchanged for callers (it gains no required flags).

## Banker's-rounding decision

**Picked rule: `math.floor()` applied to the raw float days, used for both `estimatedDaysToFinish` and `estimatedFinishDate`.** `estimatedFinishDate = reference_date + timedelta(days=floor(est_days))`.

Rationale: the seg 11 hotfix corrected Nan and Wally to **53 days / 2026-07-03** from a raw 53.5. `round_half_up(53.5) = 54` would NOT match the hotfix; only `floor(53.5) = 53` does. Marian's 54.1 floors to 54, Justin's 56.29 floors to 56 — all three match the snapshot exactly. The brief's note "round_half_up matches the seg 11 hotfix" appears to be a slip; the literal hotfix values only agree with floor.

Both displayed values derive from the same integer, so they can never disagree — that is the deeper consistency guarantee #541's planning comment asked for.

## Regression tests (red-green)

Added `processing/tests/test_rider_stats_temporal.py` with five tests:

```
TestNoDatetimeNowInStats::test_calculate_stats_does_not_call_datetime_now
TestNoDatetimeNowInStats::test_calculate_stats_output_independent_of_clock
TestSegment11Regeneration::test_stats_regenerate_matches_snapshot
TestSegment11Regeneration::test_points_regenerate_matches_snapshot
TestEstimatedFinishConsistency::test_days_and_date_agree
```

The first monkey-patches `processing.rider_stats.datetime` so any `.now()` call raises. The second runs the same input twice and asserts byte-identical JSON. The third regenerates seg 11 stats from the snapshot's frozen log (the log is in git via #542) with `reference_date=date(2026,5,11)` and asserts every per-rider numeric field matches the hotfixed snapshot. The fourth regenerates points. The fifth asserts the cutoff + days = date invariant for an arbitrary log.

**Red** (against `main` before the fix): all 4 of the new `calculate_stats`-dependent tests fail with `TypeError: calculate_stats() got an unexpected keyword argument 'reference_date'`. The points regeneration test would pass (it never needed reference_date).

**Green** (with the fix): all 5 pass. Full Python suite: 196 passed. Vitest: 198 passed.

Also added two snapshot-stats tests for the fail-loud path: `test_data_cutoff_without_rider_config_raises`, `test_data_cutoff_with_missing_config_file_raises`.

## Manual smoke

Ran `calculate_stats` twice against the seg 11 snapshot log with `reference_date=date(2026,5,11)`:

```
byte-identical run-twice: True
  justin: days=56/56 date=2026-07-06/2026-07-06
  marian: days=54/54 date=2026-07-04/2026-07-04
  nan: days=53/53 date=2026-07-03/2026-07-03
  wally: days=53/53 date=2026-07-03/2026-07-03
```

(format: regenerated/snapshot). The buggy pre-fix code would have produced Nan and Wally at `54/2026-07-04` whenever publish.sh ran in the afternoon/evening — confirmed by issue #541.

## publish.sh contract impact

- **CLI surface:** unchanged for callers. No new required flags. `--reference-date` and `--data-cutoff` are wired by publish.sh itself.
- **Order:** dataCutoff is now resolved *before* the stats run, not in between stats and snapshot. The TTY prompt + frontmatter write logic is preserved verbatim.
- **Behaviour change:** an explicit dataCutoff now flows into rider_stats and calculate_points (previously they ran without it). The snapshot recalculation step in `snapshot_stats.py` already filtered, so the live `stats.json` and `points.json` artifacts on disk now agree with the dataCutoff-filtered snapshot — fixing a long-standing implicit drift where the displayed-on-other-pages stats could differ from the per-entry snapshot.

## Verification

- `npm test` — 198 passed (vitest)
- `python3 processing/validate_points.py` — OK
- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — OK
- `pytest processing/tests/` — 196 passed

## Closes

Closes #541
Closes #328