### PR TITLE
fix(attractions): Chirac burial location at Montparnasse, not Sarran (closes #564)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -655,7 +655,7 @@
     "category": "museum",
     "lat": 45.44262,
     "lng": 1.91898,
-    "description": "Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). Sarran was the Chirac family home; Chirac is buried in the Sarran communal cemetery. The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.",
+    "description": "Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). The Chirac family château (Château de Bity) is in the commune, and Bernadette Chirac was a Sarran municipal councillor; Chirac himself is buried at Cimetière du Montparnasse in Paris, with Sarran hosting the October 2019 memorial gathering rather than an interment. The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.",
     "links": [
       {
         "url": "https://www.museepresidentjcchirac.fr/",


### PR DESCRIPTION
## Summary

- `data/attractions.json` entry for the Musée du Président Jacques Chirac asserted Chirac was buried in Sarran. He is buried at Cimetière du Montparnasse, Paris 14e (per fr.wikipedia.org/wiki/Jacques_Chirac Sépulture infobox). The Sarran framing has been corrected to keep the legitimate connections (Château de Bity, Bernadette Chirac as councillor, October 2019 memorial gathering) while removing the wrong burial claim.
- Surfaced by the segs 14-16 block research strand (#562) and tracked in #564.

Closes #564.

## Pre-fix description

> Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). **Sarran was the Chirac family home; Chirac is buried in the Sarran communal cemetery.** The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.

## Post-fix description

> Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). **The Chirac family château (Château de Bity) is in the commune, and Bernadette Chirac was a Sarran municipal councillor; Chirac himself is buried at Cimetière du Montparnasse in Paris, with Sarran hosting the October 2019 memorial gathering rather than an interment.** The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.

## Source verified

- https://fr.wikipedia.org/wiki/Jacques_Chirac — Sépulture infobox names *Cimetière du Montparnasse, Paris 14e*. Body text confirms Bernadette Chirac elected conseillère municipale of Sarran in 1971, deuxième adjointe au maire from 1977, and the Chirac couple purchased Château de Bity on 3 March 1969 (commune of Sarran, monument historique).

## Sarran connections retained

- Château de Bity (Chirac family château in the commune).
- Bernadette Chirac as municipal councillor of Sarran.
- The Musée du Président Jacques Chirac itself (the gifts-museum at Sarran).
- October 2019 memorial gathering at Sarran (a memorial, not an interment).

## Scope

- Single-entry fix. Not an audit of `data/attractions.json` as a whole. Per the strand brief, if other entries surface similar issues during execution, file separate issues. None surfaced.
- The Chirac entry's `nearest_km` is 99.7, so it renders in seg 15's `NearbyAttractions` and on the seg 15 segment map. Seg 15 has not yet published, so no published reader surface contained the wrong text.
- Seg 14 entry prose (`content/entries/14-into-the-monedieres.md`) already uses the family-château framing without making a burial claim — published entry is unaffected.

## Verification

- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green.
- [x] `npm test` — 198/198 passing.
- [x] `npm run build` — green.
- [x] Production bundle contains the new "Cimetière du Montparnasse" text; "Sarran communal cemetery" count is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)