### PR TITLE
feat(entry-card): editorial thumbnail selection (closes #535)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ coverage/
 
 # Output of processing/suggest_images.py — regenerable, noisy in diffs
 data/image-suggestions/
+
+# Download cache for processing/pick_entry_thumbnails.py — regenerable
+data/.thumbnail-dimension-cache.json

--- a/components/EntryCard.vue
+++ b/components/EntryCard.vue
@@ -3,11 +3,11 @@
     <NuxtLink :to="entry.path || entry._path" :class="showThumbnail ? 'flex gap-4 items-start' : 'block'">
       <template v-if="showThumbnail">
         <img
-          :src="entry.images[0].src"
-          :alt="entry.images[0].alt || ''"
+          :src="thumbnailImage.src"
+          :alt="thumbnailImage.alt || ''"
           loading="lazy"
           class="w-20 h-20 sm:w-28 sm:h-28 rounded object-cover flex-shrink-0"
-          :style="entry.images[0].objectPosition ? { objectPosition: entry.images[0].objectPosition } : null"
+          :style="thumbnailImage.objectPosition ? { objectPosition: thumbnailImage.objectPosition } : null"
         >
         <div class="min-w-0 flex-1">
           <span v-if="entry.segment > 0" class="text-sm text-correze-red font-semibold">
@@ -33,6 +33,8 @@
 </template>
 
 <script setup>
+import thumbnailManifest from '~/data/entry-thumbnails.json'
+
 const props = defineProps({
   entry: { type: Object, required: true },
   density: { type: String, default: 'standard', validator: v => ['standard', 'compact'].includes(v) },
@@ -44,4 +46,14 @@ const { formatDate } = useFormatDate()
 const showThumbnail = computed(() =>
   props.density === 'standard' && props.entry.images && props.entry.images.length > 0,
 )
+
+const thumbnailImage = computed(() => {
+  const images = props.entry.images || []
+  const manifestEntry = thumbnailManifest[String(props.entry.segment)]
+  if (manifestEntry) {
+    const match = images.find(img => img.src === manifestEntry.src)
+    if (match) return match
+  }
+  return images[0]
+})
 </script>

--- a/data/entry-thumbnails.json
+++ b/data/entry-thumbnails.json
@@ -1,0 +1,55 @@
+{
+  "10": {
+    "reason": "landscape ratio=1.50 idx=0",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/La_Corr%C3%A8ze_%C3%A0_Tulle.JPG/1280px-La_Corr%C3%A8ze_%C3%A0_Tulle.JPG"
+  },
+  "11": {
+    "manual": true,
+    "reason": "publisher override: prefer carnyx (portrait with objectPosition: top)",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/3/3d/CarnyxDeTintignac1.jpg"
+  },
+  "12": {
+    "reason": "landscape ratio=1.50 idx=0",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Naves_Panorama.jpg/1280px-Naves_Panorama.jpg"
+  },
+  "13": {
+    "reason": "landscape ratio=1.50 idx=1",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Paysage_rural_Chamboulive.JPG/1280px-Paysage_rural_Chamboulive.JPG"
+  },
+  "14": {
+    "reason": "landscape ratio=1.51 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/Le_tourondel_chateau.JPG/1280px-Le_tourondel_chateau.JPG"
+  },
+  "2": {
+    "reason": "landscape ratio=1.50 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Turenne_fda.jpg/500px-Turenne_fda.jpg"
+  },
+  "3": {
+    "reason": "landscape ratio=1.51 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828497459402%29.jpg/960px-Collonges-la-Rouge_%28Corr%C3%A8ze%29._%2828497459402%29.jpg"
+  },
+  "4": {
+    "reason": "fallback-no-landscape",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Meyssac_-_%C3%89glise_03.jpg/960px-Meyssac_-_%C3%89glise_03.jpg"
+  },
+  "5": {
+    "reason": "landscape ratio=1.50 idx=1",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Anem_%C3%B2c_%21_Per_la_lenga_occitana_%21-2.jpg/960px-Anem_%C3%B2c_%21_Per_la_lenga_occitana_%21-2.jpg"
+  },
+  "6": {
+    "reason": "landscape ratio=1.50 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Tumba_de_Antonio_Machado_en_Colliure.jpg/960px-Tumba_de_Antonio_Machado_en_Colliure.jpg"
+  },
+  "7": {
+    "reason": "landscape ratio=1.50 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Saint-Cernin-de-Larche_-_Dolmen_de_la_Chassagne_01.JPG/960px-Saint-Cernin-de-Larche_-_Dolmen_de_la_Chassagne_01.JPG"
+  },
+  "8": {
+    "reason": "landscape ratio=1.33 idx=2",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Beynat_-_mont%C3%A9e_de_la_place_du_Champ_de_Foire.jpg/960px-Beynat_-_mont%C3%A9e_de_la_place_du_Champ_de_Foire.jpg"
+  },
+  "9": {
+    "reason": "landscape ratio=1.50 idx=0",
+    "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/02-26_Sainte_Fortunade_-_%C3%A9glise_2.jpg/960px-02-26_Sainte_Fortunade_-_%C3%A9glise_2.jpg"
+  }
+}

--- a/pages/entries/index.vue
+++ b/pages/entries/index.vue
@@ -12,7 +12,6 @@
         v-for="entry in entries"
         :key="entry.path || entry._path"
         :entry="entry"
-        density="compact"
         :heading-level="2"
       />
     </section>

--- a/processing/pick_entry_thumbnails.py
+++ b/processing/pick_entry_thumbnails.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Pick the most landscape-shaped image per entry and write a thumbnail manifest.
+
+For each entry in content/entries/, reads the images frontmatter and resolves
+each image's width/height. Local images are read with PIL; remote Wikimedia
+Commons images are batched through the MediaWiki imageinfo API (up to 50
+titles per call) and cached locally.
+
+The chosen thumbnail is the image whose aspect ratio is closest to the target
+landscape ratio (3:2). Portrait images are never picked. If no landscape
+candidate exists, the manifest falls back to images[0] so the rendering does
+not regress. The Vue EntryCard reads this manifest at render time and falls
+back to entry.images[0] when no entry exists for a segment.
+
+Run as a pre-publish step when new images are added. Output is committed so
+the build does not depend on network availability.
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.parse import unquote
+
+import requests
+import yaml
+from PIL import Image
+
+WIKIMEDIA_PREFIX = "https://upload.wikimedia.org/"
+COMMONS_API = "https://commons.wikimedia.org/w/api.php"
+USER_AGENT = (
+    "tdf26-thumbnail-picker/1.0 "
+    "(https://github.com/gneeek/tdf26; gneeek@proton.me)"
+)
+TARGET_RATIO = 1.5  # 3:2 wins ties; portraits are rejected outright
+OBJECT_POSITION_BONUS = 0.05
+API_BATCH_SIZE = 50
+API_SLEEP_SECONDS = 1.0
+
+
+def parse_frontmatter(filepath):
+    with open(filepath) as f:
+        content = f.read()
+    m = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not m:
+        return {}
+    return yaml.safe_load(m.group(1)) or {}
+
+
+def wikimedia_filename(url):
+    """Extract the File:Name.ext title from any upload.wikimedia.org URL."""
+    if not url.startswith(WIKIMEDIA_PREFIX):
+        return None
+    # Thumbnail URL: .../commons/thumb/X/XX/Filename.jpg/WIDTHpx-Filename.jpg
+    # Original URL:  .../commons/X/XX/Filename.jpg
+    parts = url.split("/")
+    if "thumb" in parts:
+        idx = parts.index("thumb")
+        # Filename is two segments after the hex hash dirs
+        if idx + 3 < len(parts):
+            return unquote(parts[idx + 3])
+    else:
+        return unquote(parts[-1])
+    return None
+
+
+def get_local_dimensions(public_dir, src):
+    rel = src.lstrip("/")
+    path = Path(public_dir) / rel
+    if not path.exists():
+        return None
+    try:
+        with Image.open(path) as img:
+            return img.size
+    except Exception as e:
+        print(f"  local read failed for {path}: {e}", file=sys.stderr)
+        return None
+
+
+def fetch_wikimedia_dimensions(filenames, cache):
+    """Batch-query the Commons imageinfo API. Updates cache in place."""
+    pending = [f for f in filenames if f and f not in cache]
+    if not pending:
+        return
+    for i in range(0, len(pending), API_BATCH_SIZE):
+        batch = pending[i : i + API_BATCH_SIZE]
+        titles = "|".join(f"File:{name}" for name in batch)
+        try:
+            resp = requests.get(
+                COMMONS_API,
+                params={
+                    "action": "query",
+                    "format": "json",
+                    "prop": "imageinfo",
+                    "iiprop": "size",
+                    "titles": titles,
+                },
+                headers={"User-Agent": USER_AGENT},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            print(f"  API batch failed: {e}", file=sys.stderr)
+            for name in batch:
+                cache[name] = [None, None]
+            continue
+        # API returns a normalized title map and pages; build a name->info lookup
+        norms = {n["from"]: n["to"] for n in data.get("query", {}).get("normalized", [])}
+        pages = data.get("query", {}).get("pages", {}) or {}
+        results = {}
+        for page in pages.values():
+            title = page.get("title", "")
+            ii = page.get("imageinfo") or []
+            if title.startswith("File:") and ii:
+                results[title[len("File:") :]] = (ii[0].get("width"), ii[0].get("height"))
+        for name in batch:
+            normalized = norms.get(f"File:{name}", f"File:{name}")
+            key = normalized[len("File:") :] if normalized.startswith("File:") else normalized
+            if key in results:
+                w, h = results[key]
+                cache[name] = [w, h]
+            else:
+                cache[name] = [None, None]
+        if i + API_BATCH_SIZE < len(pending):
+            time.sleep(API_SLEEP_SECONDS)
+
+
+def cost_for(ratio, has_object_position):
+    cost = abs(ratio - TARGET_RATIO)
+    if has_object_position:
+        cost -= OBJECT_POSITION_BONUS
+    return cost
+
+
+def resolve_dimensions(img, public_dir, remote_cache):
+    src = img.get("src", "")
+    if src.startswith("/"):
+        return get_local_dimensions(public_dir, src)
+    if src.startswith(WIKIMEDIA_PREFIX):
+        name = wikimedia_filename(src)
+        if name and name in remote_cache:
+            entry = remote_cache[name]
+            if entry and entry[0] and entry[1]:
+                return tuple(entry)
+    return None
+
+
+def pick_thumbnail(images, public_dir, remote_cache):
+    landscape_candidates = []
+    for idx, img in enumerate(images):
+        dims = resolve_dimensions(img, public_dir, remote_cache)
+        if dims is None:
+            continue
+        w, h = dims
+        if not w or not h:
+            continue
+        ratio = w / h
+        if ratio < 1.0:
+            continue  # never pick a portrait
+        has_op = bool(img.get("objectPosition"))
+        landscape_candidates.append((cost_for(ratio, has_op), idx, img, ratio))
+    if not landscape_candidates:
+        if images:
+            return images[0], "fallback-no-landscape"
+        return None, "no-images"
+    landscape_candidates.sort(key=lambda t: (t[0], t[1]))
+    _, idx, img, ratio = landscape_candidates[0]
+    return img, f"landscape ratio={ratio:.2f} idx={idx}"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--entries-dir", default="content/entries")
+    p.add_argument("--public-dir", default="public")
+    p.add_argument("--output", default="data/entry-thumbnails.json")
+    p.add_argument("--cache", default="data/.thumbnail-dimension-cache.json")
+    p.add_argument("--segment", type=int, help="Process only this segment number")
+    p.add_argument("--min-segment", type=int, help="Only process segments >= this")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    entries_dir = Path(args.entries_dir)
+    public_dir = Path(args.public_dir)
+    output_path = Path(args.output)
+    cache_path = Path(args.cache)
+
+    remote_cache = {}
+    if cache_path.exists():
+        remote_cache = json.loads(cache_path.read_text())
+
+    # Pass 1: collect entries and the full set of Wikimedia filenames to resolve.
+    entries_to_process = []
+    needed_filenames = set()
+    for filename in sorted(os.listdir(entries_dir)):
+        if not filename.endswith(".md"):
+            continue
+        filepath = entries_dir / filename
+        fm = parse_frontmatter(filepath)
+        seg = fm.get("segment")
+        if seg is None or seg <= 0:
+            continue
+        if args.segment is not None and seg != args.segment:
+            continue
+        if args.min_segment is not None and seg < args.min_segment:
+            continue
+        images = fm.get("images") or []
+        entries_to_process.append((seg, images))
+        for img in images:
+            name = wikimedia_filename(img.get("src", ""))
+            if name:
+                needed_filenames.add(name)
+
+    fetch_wikimedia_dimensions(sorted(needed_filenames), remote_cache)
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(remote_cache, indent=2, sort_keys=True) + "\n")
+
+    existing = {}
+    if output_path.exists():
+        existing = json.loads(output_path.read_text())
+
+    for seg, images in entries_to_process:
+        if existing.get(str(seg), {}).get("manual"):
+            print(f"seg {seg:>2}: manual override preserved")
+            continue
+        if not images:
+            print(f"seg {seg:>2}: no images, skipping")
+            existing.pop(str(seg), None)
+            continue
+        chosen, reason = pick_thumbnail(images, public_dir, remote_cache)
+        if chosen is None:
+            existing.pop(str(seg), None)
+            print(f"seg {seg:>2}: {reason}")
+            continue
+        previous = existing.get(str(seg), {}).get("src")
+        existing[str(seg)] = {"src": chosen["src"], "reason": reason}
+        marker = "" if previous == chosen["src"] else "  *CHANGED*"
+        match_first = " (=images[0])" if chosen["src"] == images[0].get("src", "") else ""
+        print(f"seg {seg:>2}: {reason}{match_first}{marker}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n")
+    print(f"\nWrote {output_path} ({len(existing)} entries)")
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/pick_entry_thumbnails.py
+++ b/processing/pick_entry_thumbnails.py
@@ -17,7 +17,6 @@ the build does not depend on network availability.
 """
 
 import argparse
-import io
 import json
 import os
 import re

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -1,6 +1,9 @@
 gpxpy>=1.6.2
 geopy>=2.4.1
 numpy>=2.4.4
+Pillow>=10.0.0
+PyYAML>=6.0
+requests>=2.31.0
 pytest>=9.0.3
 pytest-cov>=7.1.0
 ruff>=0.15.12


### PR DESCRIPTION
## Summary

Replaces `EntryCard.vue`'s "first image in frontmatter" thumbnail with an editorially-controlled selector. Build-time heuristic picks the most landscape-shaped image per entry; output is committed as `data/entry-thumbnails.json`; the build does not depend on network availability. EntryCard falls back to `images[0]` for any segment not in the manifest.

## Mechanism picked at design checkpoint

**Build-time heuristic (aspect ratio)** — one of the four options from the strand brief. Per-image flag was rejected because it requires retroactive frontmatter edits on already-published entries; manifest was rejected as too manual; heuristic chosen as the right tradeoff between author burden and editorial control. Manual overrides supported via `"manual": true` on a manifest entry — the script preserves these on re-run.

## What changed

- **`processing/pick_entry_thumbnails.py`** (new) — iterates `content/entries/*.md`, resolves image dimensions (local images via PIL, Wikimedia images via batched MediaWiki imageinfo API with on-disk cache), picks the image whose aspect ratio is closest to 3:2, rejects portraits, falls back to `images[0]` when no landscape candidate exists. `--segment N` / `--min-segment N` flags supported.
- **`data/entry-thumbnails.json`** (new, committed) — 13 entries covering all published entries with images. Seg 11 carries `"manual": true` for the carnyx override.
- **`components/EntryCard.vue`** — reads manifest by segment number, falls back to `entry.images[0]`. Preserves `objectPosition` pass-through (PR #540) on whatever image is picked.
- **`pages/entries/index.vue`** — dropped `density="compact"`. The archive now renders thumbnails for all 14 published entries. The `density` prop's role is now layout-only as anticipated in the strand brief.
- **`processing/requirements.txt`** — added Pillow, PyYAML, requests (already on system, made explicit).
- **`.gitignore`** — `data/.thumbnail-dimension-cache.json` (regenerable download cache).

## What is NOT changed

- `content/entries/*.md` — published entries are byte-identical (per `feedback_content_change_rule.md`). The mechanism is forward-only authoring infrastructure for seg 15+; the side benefit is improved homepage/archive thumbnails for already-published entries via the heuristic running on their existing images.
- The MDC validator, rider-stats pipeline, points config, and seg-12 publish branch — none touched.

## Manifest picks summary

13 entries with images. Picks differ from `images[0]` for seg 2, 3, 5, 6, 7, 8, 11 (manual), 13, 14. Segs 4 (all-portrait fallback), 9, 10, 12 keep `images[0]`. Seg 1 has no images (no manifest entry needed).

## Test plan

- [x] `npm test` (198 tests pass)
- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` passes
- [x] `npm run build` succeeds
- [x] Dev preview at `/` and `/entries` walked through with publisher; sign-off received
- [x] Script re-run preserves `"manual": true` overrides (seg 11)

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)