### PR TITLE
fix(points-config): Suc au May category, gradient, and points (closes #513)

### DIFF
--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -98,9 +98,9 @@
       "segment": 15,
       "km": 105.15,
       "length_km": 3.8,
-      "category": "HC",
+      "category": 2,
       "gradient": 7.1,
-      "points": [10, 8, 6, 4],
+      "points": [6, 4, 2, 1],
       "aso": true
     },
     {

--- a/processing/tests/test_validate_points.py
+++ b/processing/tests/test_validate_points.py
@@ -6,9 +6,11 @@ import os
 import pytest
 
 from processing.validate_points import (
+    CATEGORY_POINTS_SCALE,
     elevation_at_km,
     load_elevation_track,
     validate,
+    validate_category_points_scale,
     validate_elevation,
 )
 
@@ -157,3 +159,55 @@ class TestValidateElevation:
         track = load_elevation_track(elev_dir, segments)
         errors = validate_elevation(points.get("climbs", []), track)
         assert errors == [], f"real climbs have elevation divergences: {errors}"
+
+
+class TestValidateCategoryPointsScale:
+    """#513: catch drift between climb `category` and `points` array.
+
+    Note on scope: the original #513 Suc au May bug was a wrong category
+    label (HC where Cat 2 was correct), not a category↔points drift —
+    pre-fix points [10, 8, 6, 4] happened to match the project's HC scale,
+    so this assertion would NOT have fired against it. What this assertion
+    does catch is future drift between the two fields (e.g., someone edits
+    `category` to 3 without updating `points` from [6, 4, 2, 1]).
+    """
+
+    def test_drift_between_category_and_points_fires(self):
+        # Synthetic drift: category says Cat 2 but points are the Cat 3 array.
+        climbs = [{"name": "Drift Climb", "category": 2, "points": [4, 3, 2, 1]}]
+        errors = validate_category_points_scale(climbs)
+        assert any("Drift Climb" in e and "category 2" in e and "[6, 4, 2, 1]" in e for e in errors), errors
+
+    def test_post_fix_suc_au_may_passes(self):
+        climbs = [{"name": "Suc au May", "category": 2, "points": [6, 4, 2, 1]}]
+        assert validate_category_points_scale(climbs) == []
+
+    def test_pre_fix_suc_au_may_was_internally_self_consistent(self):
+        # Documents why the assertion did not catch the original #513 bug:
+        # the project's inferred scale extrapolates HC = [10, 8, 6, 4], which
+        # the pre-fix entry happened to match. The bug was the category label,
+        # not category↔points drift. See class docstring.
+        climbs = [{"name": "Suc au May", "category": "HC", "points": [10, 8, 6, 4]}]
+        assert validate_category_points_scale(climbs) == []
+
+    def test_each_canonical_scale_passes(self):
+        climbs = [
+            {"name": f"Test Cat {cat}", "category": cat, "points": pts}
+            for cat, pts in CATEGORY_POINTS_SCALE.items()
+        ]
+        assert validate_category_points_scale(climbs) == []
+
+    def test_unknown_category_fails(self):
+        climbs = [{"name": "Mystery", "category": "ZZ", "points": [1, 0, 0, 0]}]
+        errors = validate_category_points_scale(climbs)
+        assert any("no canonical points scale" in e for e in errors)
+
+    def test_real_data_passes(self):
+        root = os.path.join(os.path.dirname(__file__), "..", "..")
+        points_path = os.path.join(root, "data", "competition", "points-config.json")
+        if not os.path.exists(points_path):
+            pytest.skip("real data not found")
+        with open(points_path) as f:
+            points = json.load(f)
+        errors = validate_category_points_scale(points.get("climbs", []))
+        assert errors == [], f"real climbs have category-points drift: {errors}"

--- a/processing/validate_points.py
+++ b/processing/validate_points.py
@@ -49,6 +49,20 @@ ELEVATION_RISING_INTO_SUMMIT_TOL_M = 5.0
 # smoothing window in elevation_profile.py.
 GRADIENT_CONSISTENCY_REL_TOL = 0.20
 
+# Canonical points scale per climb category. The project uses a custom
+# 4-position rider-competition scale (not the official polka-dot scale):
+# rank-1 points = 2 × (5 − category) for numeric Cat 4–1, with HC continuing
+# the linear progression. #513 surfaced this as the source of truth after
+# the Suc au May entry (category="HC", points=[10,8,6,4]) was discovered to
+# be internally inconsistent with the existing Cat 2–4 entries.
+CATEGORY_POINTS_SCALE = {
+    4: [2, 1, 0, 0],
+    3: [4, 3, 2, 1],
+    2: [6, 4, 2, 1],
+    1: [8, 6, 4, 2],
+    "HC": [10, 8, 6, 4],
+}
+
 
 def load_elevation_track(elevation_dir, segments):
     """Concatenate per-segment elevation files into a single (cum_km, ele) sequence.
@@ -130,6 +144,33 @@ def validate_elevation(climbs, track):
                         f"{expected_gain:.0f}m gain; GPX shows {actual_gain:.0f}m "
                         f"({rel_err * 100:+.0f}% from expected, tolerance ±{int(GRADIENT_CONSISTENCY_REL_TOL * 100)}%)"
                     )
+    return errors
+
+
+def validate_category_points_scale(climbs):
+    """Each climb's points array must match the canonical scale for its category.
+
+    Catches drift between the `category` and `points` fields — for example, an
+    HC-labelled climb whose points array is actually the Cat 1 prefix
+    [10, 8, 6, 4] (the #513 Suc au May bug).
+    """
+    errors = []
+    for c in climbs:
+        name = c["name"]
+        category = c.get("category")
+        points = c.get("points")
+        expected = CATEGORY_POINTS_SCALE.get(category)
+        if expected is None:
+            errors.append(
+                f"climb {name!r}: category {category!r} has no canonical points scale "
+                f"(expected one of {sorted(CATEGORY_POINTS_SCALE.keys(), key=str)})"
+            )
+            continue
+        if points != expected:
+            errors.append(
+                f"climb {name!r}: category {category!r} expects points {expected}; "
+                f"got {points}"
+            )
     return errors
 
 
@@ -219,6 +260,7 @@ def main():
 
     errors = validate(points_config, segments)
     errors += validate_elevation(points_config.get("climbs", []), track)
+    errors += validate_category_points_scale(points_config.get("climbs", []))
 
     if errors:
         print(f"FAIL: {len(errors)} divergence(s):")


### PR DESCRIPTION
Closes #513.

## Summary

Resolves the three-field disagreement on the Suc au May entry in `data/competition/points-config.json`. Brings category and points into agreement with the ASO Stage 9 categorisation that Tourisme Corrèze, Le Dico du Tour, and CLAUDE.md all converge on, and adds a regression assertion against future category↔points drift.

## Disagreement matrix (pre-fix)

| Field | Source | Value |
|---|---|---|
| Category | points-config | HC |
| Category | Tourisme Corrèze official 2026 Stage 9 page | **Cat 2** (issue body misquoted this as "Cat 4/3") |
| Category | Le Dico du Tour 2020 TdF Stage 12 record | **Cat 2** |
| Category | CLAUDE.md § Categorized Climbs | **Cat 2** |
| Gradient | points-config | 7.1% |
| Gradient | CLAUDE.md / Le Dico du Tour (Chaumeil approach) | 7.7% |
| Gradient | Tourisme Corrèze | "près de 18%" (max, not average) |
| Gradient | Direct GPX over [101.35, 105.15] (declared 3.8 km window) | **7.07%** |
| Points | points-config | [10, 8, 6, 4] |
| Project's inferred 4-position scale | rank-1 = 2 × (5 − category); Cat 4=[2,1,0,0], Cat 3=[4,3,2,1], Cat 2=[6,4,2,1], extrapolating Cat 1=[8,6,4,2], HC=[10,8,6,4] | — |

## Fix

```diff
 {
   "name": "Suc au May",
   "segment": 15,
   "km": 105.15,
   "length_km": 3.8,
-  "category": "HC",
-  "gradient": 7.1,
-  "points": [10, 8, 6, 4],
+  "category": 2,
+  "gradient": 7.1,
+  "points": [6, 4, 2, 1],
   "aso": true
 }
```

(Gradient unchanged — see note below.)

## Publisher checkpoint (2026-05-24)

Single checkpoint per the brief. Publisher chose:
- **Category: Cat 2** (default recommendation)
- **Gradient: 7.7%** (their first preference)

The 7.7% choice was reverted to 7.1% during verification: `tests/utils/climb-gradient.test.ts` enforces ±0.3pp absolute between declared gradient and GPX-derived gradient over the declared span. 7.7% vs GPX 7.07% = +0.63pp diff, fails the invariant. 7.1% is within tolerance and matches the GPX measurement. Loosening the invariant or shortening `length_km` to accommodate 7.7% was out of scope per the brief.

The narrative reference "7.7%" in CLAUDE.md (Chaumeil-anchored) is preserved as published content; only the points-config data layer is changed here.

## Notes on the project's points scale

The brief stated a polka-dot scale (Cat 2 = `[5,3,2,1]`, HC = `[20,15,12,10,8,6,4,2]`) that does not match the project's existing data. The project uses its own 4-position rider-competition scale:

| Category | Project scale | Existing climbs |
|---|---|---|
| Cat 4 | `[2, 1, 0, 0]` | Malemort, Lagleygeolle, Miel, Bessou |
| Cat 3 | `[4, 3, 2, 1]` | Puy Boubou, Croix de Pey, Côte des Gardes |
| Cat 2 | `[6, 4, 2, 1]` | Côte de Naves, Puy de Lachaud |
| Cat 1 | `[8, 6, 4, 2]` (extrapolated) | none |
| HC | `[10, 8, 6, 4]` (extrapolated) | none after this PR |

Note that the pre-fix Suc au May entry (HC + `[10,8,6,4]`) was internally consistent under this extrapolated scale, which is why the existing `validate_points.py` ran green against it.

## Regression assertion

Added `validate_category_points_scale()` to `processing/validate_points.py` plus tests in `processing/tests/test_validate_points.py`. Catches future drift between `category` and `points` arrays (e.g., editing category from 2 to 3 without updating the points array). Wired into the validator's `main()` so it runs alongside the existing summit / gradient / span checks.

Per `feedback_assertion_bug_class.md`, hand-traced the diagnostic: the assertion catches **future field-pair drift**, but would not have fired against the original Suc au May bug because that bug was a wrong category label on a self-consistent (category, points) pair. Test `test_pre_fix_suc_au_may_was_internally_self_consistent` documents this.

## Verification

- `python3 processing/validate_points.py` — green pre-fix and post-fix.
- `pytest processing/tests/test_validate_points.py` — 23/23 pass (5 new tests).
- `pytest processing/tests/` — 213/213 pass.
- `ruff check processing/` — clean.
- `npm test` — 198/198 pass.
- `npm run build` — production build succeeds.
- Dev spot-check of seg 15 entry page: confirmed page still displays "7.7%" because the entry pages render from a hand-coded lookup in `components/StageDetails.vue`, not from `points-config.json`. See follow-up.

## Out-of-scope follow-ups filed

- **#588** — `components/StageDetails.vue` carries a hand-coded `CLIMB_DETAILS` lookup that disagrees with `points-config.json` on **every** climb's gradient (and one length). The entry-page rendering reads from that lookup, not from `points-config.json` — so this PR's data-layer fix has no visible reader-facing effect until #588 lands.
- **Seg 15 drafting strand handoff (no issue needed):** the seg 15 entry markdown currently contains a hardcoded "HC" string in an image alt/footnote — should be updated to "Cat 2" before publish.

## Sources verified

- [Tourisme Corrèze official 2026 Stage 9 page](https://www.tourismecorreze.com/fr/tour_de_france_2026_une_etape_100_correze.html) — "Suc au May, 2nd category; 4 difficultés classées en 2ème et 3ème catégorie"
- [Le Dico du Tour — Suc au May](https://www.ledicodutour.com/cols/cols_s/suc_au_may.html) — "3,8 km d'ascension à 7,7 %" from Chaumeil; 2020 TdF appearance recorded as Cat 2
- [Actus Limousin Stage 9 announcement](https://actus-limousin.fr/sport-et-loisirs/2025/10/23/le-suc-au-may-et-le-mont-bessou-au-programme-letape-100-correzienne-du-tour-de-france-2026-le-12-juillet/) — corroborates 2nd/3rd category mix on Stage 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)