### PR TITLE
test(climbs): assertion catches summit-km drift from GPX peak (closes #518)

### DIFF
--- a/tests/utils/_track.ts
+++ b/tests/utils/_track.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import segmentsJson from '~/data/segments.json'
+
+export interface Segment {
+  segment: number
+  km_start: number
+  km_end: number
+}
+
+export interface ElevationFile {
+  distance: number[]
+  elevation: number[]
+}
+
+const repoRoot = resolve(__dirname, '..', '..')
+
+export function loadElevation(segNum: number): ElevationFile {
+  const p = resolve(repoRoot, `data/elevation/segment-${String(segNum).padStart(2, '0')}.json`)
+  return JSON.parse(readFileSync(p, 'utf8')) as ElevationFile
+}
+
+export function buildTrack(): Array<[number, number]> {
+  const track: Array<[number, number]> = []
+  for (const s of segmentsJson as Segment[]) {
+    const ev = loadElevation(s.segment)
+    for (let i = 0; i < ev.distance.length; i++) {
+      track.push([s.km_start + ev.distance[i], ev.elevation[i]])
+    }
+  }
+  track.sort((a, b) => a[0] - b[0])
+  return track
+}
+
+export function elevationAt(track: Array<[number, number]>, km: number): number {
+  if (km <= track[0][0]) return track[0][1]
+  if (km >= track[track.length - 1][0]) return track[track.length - 1][1]
+  for (let i = 0; i < track.length - 1; i++) {
+    if (track[i][0] <= km && km <= track[i + 1][0]) {
+      const span = track[i + 1][0] - track[i][0]
+      const t = span ? (km - track[i][0]) / span : 0
+      return track[i][1] + t * (track[i + 1][1] - track[i][1])
+    }
+  }
+  return track[track.length - 1][1]
+}

--- a/tests/utils/climb-gradient.test.ts
+++ b/tests/utils/climb-gradient.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
 
 import pointsConfig from '~/data/competition/points-config.json'
-import segmentsJson from '~/data/segments.json'
+import { buildTrack, elevationAt } from './_track'
 
 // Per-source-of-truth assertion. For every climb declared in points-config.json
 // with a non-null length_km, the declared gradient must match the gradient
@@ -15,56 +13,13 @@ import segmentsJson from '~/data/segments.json'
 // climb). The TS assertion is the tighter sibling — it catches the case where
 // the gradient field is rounded incorrectly or stale relative to the declared
 // span. It does NOT catch the case where the declared summit km itself is
-// wrong (e.g., on a rising flank past the actual GPX peak); that is a
-// different invariant and the subject of a separate follow-up.
+// wrong (e.g., on a rising flank past the actual GPX peak); the sibling
+// assertion in climb-summit-km.test.ts (#518) handles that bug class.
 //
 // Second instance of the per-source-of-truth detector pattern — first instance
 // landed in PR #448 (stage-totals derives uniqueCategorizedClimbs from the
 // same source as CATEGORIZED_CLIMBS, asserting they agree). #490+#492 strand
 // extends the regime to gradient × length × GPX-gain agreement.
-
-interface Segment {
-  segment: number
-  km_start: number
-  km_end: number
-}
-
-interface ElevationFile {
-  distance: number[]
-  elevation: number[]
-}
-
-const repoRoot = resolve(__dirname, '..', '..')
-
-function loadElevation(segNum: number): ElevationFile {
-  const p = resolve(repoRoot, `data/elevation/segment-${String(segNum).padStart(2, '0')}.json`)
-  return JSON.parse(readFileSync(p, 'utf8')) as ElevationFile
-}
-
-function buildTrack(): Array<[number, number]> {
-  const track: Array<[number, number]> = []
-  for (const s of segmentsJson as Segment[]) {
-    const ev = loadElevation(s.segment)
-    for (let i = 0; i < ev.distance.length; i++) {
-      track.push([s.km_start + ev.distance[i], ev.elevation[i]])
-    }
-  }
-  track.sort((a, b) => a[0] - b[0])
-  return track
-}
-
-function elevationAt(track: Array<[number, number]>, km: number): number {
-  if (km <= track[0][0]) return track[0][1]
-  if (km >= track[track.length - 1][0]) return track[track.length - 1][1]
-  for (let i = 0; i < track.length - 1; i++) {
-    if (track[i][0] <= km && km <= track[i + 1][0]) {
-      const span = track[i + 1][0] - track[i][0]
-      const t = span ? (km - track[i][0]) / span : 0
-      return track[i][1] + t * (track[i + 1][1] - track[i][1])
-    }
-  }
-  return track[track.length - 1][1]
-}
 
 const TOLERANCE_PP = 0.3
 

--- a/tests/utils/climb-summit-km.test.ts
+++ b/tests/utils/climb-summit-km.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+
+import pointsConfig from '~/data/competition/points-config.json'
+import { buildTrack, elevationAt } from './_track'
+
+// Per-source-of-truth assertion for the declared climb summit km. For every
+// climb with non-null length_km, the GPX elevation argmax within
+// [summit_km - length_km, summit_km + UPPER_PAD_KM] must sit within
+// ±TOLERANCE_KM and ±TOLERANCE_M of the declared summit. Catches the bug
+// class where the declared summit km sits on a rising flank, missing the
+// actual local elevation peak (Naves pre-PR-#516: declared 76.59, true
+// peak at 77.45, +30 m higher).
+//
+// Sibling to climb-gradient.test.ts (#490+#492). Where that assertion checks
+// the gradient × length × GPX-gain agreement over the declared span, this
+// assertion checks the placement of the summit point itself. They are
+// orthogonal — Naves passed gradient internal-consistency at its pre-fix
+// position (the declared span [73.79, 76.59] derived 5.54% against declared
+// 5.6%); only this assertion catches summit-km drift.
+//
+// Window design (strand #518): asymmetric `[summit - length_km, summit + 1.5]`.
+// Symmetric ±length_km crosses into adjacent terrain on this stage (climbs
+// sit 5-20 km apart, length_km up to 7 km), so the argmax picks up an
+// unrelated later peak. The 1.5 km upper pad catches Naves-class drift
+// (~0.86 km) with margin and stays inside Naves's local terrain (the
+// adjacent rise at km 79.82 sits 2.37 km past the post-fix Naves summit,
+// safely outside the upper pad).
+//
+// Tolerance rationale: elevation sample spacing is ~0.25–0.31 km, which is
+// a structural floor on km-tolerance. 0.35 km sits just above the floor;
+// 10 m elevation tolerance is ~2× the typical peak-to-adjacent-sample drop
+// at the climbs in this dataset.
+
+interface Climb {
+  name: string
+  segment: number
+  km: number
+  length_km: number | null
+  gradient: number
+}
+
+const TOLERANCE_KM = 0.35
+const TOLERANCE_M = 10
+const UPPER_PAD_KM = 1.5
+
+// Climbs whose declared summit km is known to drift from the GPX argmax.
+// Each maps to the follow-up issue tracking the data fix. The assertion
+// is asserted-but-skipped for these; remove from the map when the data
+// fix lands (see PR that closes the referenced issue).
+const KNOWN_FAILING: Record<string, number> = {
+  'Côte de Lagleygeolle': 589,
+  'Puy de Lachaud': 590,
+  'Côte de la Croix de Pey': 591,
+}
+
+describe('points-config climb summit km vs GPX argmax', () => {
+  const track = buildTrack()
+
+  for (const climb of pointsConfig.climbs as Climb[]) {
+    if (climb.length_km == null) continue
+    const winLow = climb.km - climb.length_km
+    const winHigh = climb.km + UPPER_PAD_KM
+    const knownFailIssue = KNOWN_FAILING[climb.name]
+    const testFn = knownFailIssue ? it.skip : it
+    const titleSuffix = knownFailIssue ? ` [skipped: #${knownFailIssue}]` : ''
+    testFn(`${climb.name}: declared summit km ${climb.km} matches GPX argmax in [${winLow.toFixed(2)}, ${winHigh.toFixed(2)}] within ±${TOLERANCE_KM} km / ±${TOLERANCE_M} m${titleSuffix}`, () => {
+      let argmaxKm = climb.km
+      let argmaxElev = -Infinity
+      for (const [k, e] of track) {
+        if (k < winLow) continue
+        if (k > winHigh) break
+        if (e > argmaxElev) {
+          argmaxElev = e
+          argmaxKm = k
+        }
+      }
+      const declaredElev = elevationAt(track, climb.km)
+      const dKm = argmaxKm - climb.km
+      const dElev = argmaxElev - declaredElev
+
+      const message = `argmax ${argmaxKm.toFixed(2)} km / ${argmaxElev.toFixed(1)} m vs declared ${climb.km} km / ${declaredElev.toFixed(1)} m; Δkm ${dKm >= 0 ? '+' : ''}${dKm.toFixed(2)}, Δelev ${dElev >= 0 ? '+' : ''}${dElev.toFixed(1)}`
+
+      expect(Math.abs(dKm), `km drift: ${message}`).toBeLessThanOrEqual(TOLERANCE_KM)
+      expect(Math.abs(dElev), `elevation drift: ${message}`).toBeLessThanOrEqual(TOLERANCE_M)
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Adds `tests/utils/climb-summit-km.test.ts`: per-source-of-truth assertion that, for every climb in `points-config.json` with non-null `length_km`, the GPX elevation argmax in `[summit_km - length_km, summit_km + 1.5]` matches the declared summit within ±0.35 km and ±10 m. Catches the bug class PR #516 fixed for Naves (declared summit on a rising flank).

Closes #518. Milestone: [v1.4.19](https://github.com/gneeek/tdf26/milestone/52).

## Tolerance + window rationale

- **Sample resolution:** `data/elevation/segment-*.json` arrays have ~0.25–0.31 km spacing, which is a structural floor on km-tolerance. The 0.35 km threshold sits just above the floor.
- **Elevation tolerance:** 10 m, ~2× the typical peak-to-adjacent-sample drop at the climbs in this dataset.
- **Window design:** asymmetric upper pad of 1.5 km. Symmetric ±length_km was the initial choice but the by-hand diagnostic (per `feedback_assertion_bug_class.md`) showed climbs sit 5–20 km apart with length_km up to 7 km, so a symmetric window crosses into adjacent peaks. Concrete: at symmetric pad, Naves's argmax shifts to km 79.82 / 449 m — a separate, unrelated peak. The 1.5 km cap stays inside Naves's local terrain (the adjacent rise begins ~2 km past the post-fix summit) while catching Naves-class drift with margin.

Tolerance + window picked via AskUserQuestion checkpoint with the diagnostic table as evidence; choices documented inline in the test file.

## Red-green demonstration

**Green on current main:** all 6 non-skip-listed climbs pass; 3 skip-listed (see below).

**Red on temporary revert:** edited Naves `km` from 77.45 → 76.59 (pre-PR-#516 value). Assertion fires:

```
argmax 77.45 km / 422.0 m vs declared 76.59 km / 390.7 m;
Δkm +0.86, Δelev +31.3
expected 0.8599999999999994 to be less than or equal to 0.35
```

Matches the brief's diagnostic prediction exactly (+0.86 km, +30 m). Reverted before commit.

## Climbs passing / firing red

**Passing (6):** Puy Boubou, Côte de Miel, Côte de Naves (PR #516 fix verified), Suc au May, Mont Bessou, Côte des Gardes.

**Firing red (3), skip-listed pending follow-up data fixes:**

| Climb | Δkm | Δelev | Issue |
|---|---|---|---|
| Côte de Lagleygeolle | +1.41 | +27 m | #589 |
| Puy de Lachaud | +1.42 | +24 m | #590 |
| Côte de la Croix de Pey | +0.55 | +32 m | #591 |

Lachaud and Croix de Pey were named in the brief's v1.4.19 retro carry list. Lagleygeolle is a new finding surfaced by the assertion — same Naves-class drift signature.

Per the strand's scope discipline, data fixes are not part of this PR — each follow-up issue is resolved under separate scope, and the skip-list entry is removed when the corresponding fix lands.

## Files

- `tests/utils/_track.ts` (new) — shared loader: `loadElevation`, `buildTrack`, `elevationAt`. Extracted from `climb-gradient.test.ts` for reuse.
- `tests/utils/climb-summit-km.test.ts` (new) — the assertion.
- `tests/utils/climb-gradient.test.ts` (modified) — imports from `_track.ts` instead of duplicating helpers. No behavior change; existing test still asserts the same gradient × length × GPX-gain agreement.

## Test plan

- [x] `npm test` green (204 passed, 3 skipped, 0 failed)
- [x] `python3 processing/validate_points.py` green
- [x] `npm run build` green
- [x] Red demonstration via temporary `data/competition/points-config.json` edit; reverted before commit
- [x] Three follow-up issues filed: #589, #590, #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)