### PR TITLE
feat(historical-tdf): corridor expansion from dossier carryforwards (closes #527)

### DIFF
--- a/content/research/tour-history-research.md
+++ b/content/research/tour-history-research.md
@@ -585,23 +585,23 @@ Each item below describes a gap (per `feedback_issues_describe_problems.md`). Th
 
 On-corridor events:
 
-- [ ] 1951 Stage 10: Clermont-Ferrand → Brive (men's TdF; seg 1; pairs with already-corpus 1951 Stage 11 Koblet solo). Source: https://www.bikeraceinfo.com/tdf/tdf1951.html
-- [ ] 1964 Stage 19: Bordeaux → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Anquetil-Poulidor Puy-de-Dôme launch pad). Source: https://www.bikeraceinfo.com/tdf/tdf1964.html
-- [ ] 1969 Stage 19: Libourne → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Hoban + Matignon underdog). Source: https://www.bikeraceinfo.com/tdf/tdf1969.html
-- [ ] 1973 Stage 17: Sainte-Foy-la-Grande → Brive + Stage 18: Brive → Puy-de-Dôme (men's TdF; seg 1; Ocaña era). Source: https://www.bikeraceinfo.com/tdf/tdf1973.html
-- [ ] 1976 Stage 19: Sainte-Foy-la-Grande → Tulle (men's TdF; seg 10; pairs with already-corpus 1976 Stage 20). Source: https://www.bikeraceinfo.com/tdf/tdf1976.html
-- [ ] 1987 Stage 12: Brive → Bordeaux (men's TdF; seg 1; Davis Phinney; pairs with #478's Chaumeil work). Source: https://www.bikeraceinfo.com/tdf/tdf1987.html
-- [ ] 1998 Stage 6: La Châtre → Brive (men's TdF; seg 1; Cipollini). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html
-- [ ] 1998 Stage 7 ITT: Meyrignac-l'Église → Corrèze town (men's TdF; mid-corridor segs 12-13 vicinity; Ullrich + Festina expulsion). Source: https://www.procyclingstats.com/race/tour-de-france/1998/stage-7
-- [ ] 1998 Stage 8: Brive → Montauban (men's TdF; seg 1; Jacky Durand). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html
-- [ ] 2001 Stage 17: Brive → Montluçon (men's TdF; seg 1; Serge Baguet). Source: https://www.bikeraceinfo.com/tdf/tdf2001.html
-- [ ] Tour du Limousin 1979 Stage 5: Tulle → Tulle (regional race; seg 10).
-- [ ] Tour du Limousin 1987 Stage 4: Tulle → Limoges (regional race; seg 10).
-- [ ] Tour du Limousin 1997 Stage 2: Le Moutier-d'Ahun → Tulle (regional race; seg 10).
-- [ ] Tour du Limousin 2009 Stage 1: Limoges → Ussel (regional race; seg 27 — same finish town as 2026 TdF Stage 9). Source: https://fr.wikipedia.org/wiki/Tour_du_Limousin_2009
-- [ ] Tour du Limousin 2024 Stage 3: La Rivière de Mansac → Argentat (regional race; near seg 1).
-- [ ] Tour du Limousin 2025 Stage 3: Saint-Jal → Masseret (regional race; corridor-adjacent north of seg 12-15).
-- [ ] Paris-Corrèze 2007 / 2008 / 2009 / 2010 / 2011 / 2012 final stages at Chaumeil (regional race; seg 15). The existing `[25, 26, 27]` keying is wrong (see #503 + dossier §Paris-Corrèze); recommendation is to re-key to `[15]` and consider per-edition entries surfacing the 2008 (Brive start) and 2009 (Tulle → Chaumeil corridor-spanning) editions.
+- [x] 1951 Stage 10: Clermont-Ferrand → Brive (men's TdF; seg 1; pairs with already-corpus 1951 Stage 11 Koblet solo). Source: https://www.bikeraceinfo.com/tdf/tdf1951.html — landed in PR #581 (session 3).
+- [x] 1964 Stage 19: Bordeaux → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Anquetil-Poulidor Puy-de-Dôme launch pad). Source: https://www.bikeraceinfo.com/tdf/tdf1964.html — both landed in PR #581 (session 3).
+- [x] 1969 Stage 19: Libourne → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Hoban + Matignon underdog). Source: https://www.bikeraceinfo.com/tdf/tdf1969.html — both landed in PR #581 (session 3).
+- [x] 1973 Stage 17: Sainte-Foy-la-Grande → Brive + Stage 18: Brive → Puy-de-Dôme (men's TdF; seg 1; Ocaña era). Source: https://www.bikeraceinfo.com/tdf/tdf1973.html — both landed in PR #581 (session 3).
+- [x] 1976 Stage 19: Sainte-Foy-la-Grande → Tulle (men's TdF; seg 10; pairs with already-corpus 1976 Stage 20). Source: https://www.bikeraceinfo.com/tdf/tdf1976.html — landed in PR #581 (session 3).
+- [x] 1987 Stage 12: Brive → Bordeaux (men's TdF; seg 1; Davis Phinney; pairs with #478's Chaumeil work). Source: https://www.bikeraceinfo.com/tdf/tdf1987.html — landed in PR #581 (session 3).
+- [x] 1998 Stage 6: La Châtre → Brive (men's TdF; seg 1; Cipollini). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #581 (session 3).
+- [x] 1998 Stage 7 ITT: Meyrignac-l'Église → Corrèze town (men's TdF; mid-corridor segs 12-13 vicinity; Ullrich + Festina expulsion). Source: https://www.procyclingstats.com/race/tour-de-france/1998/stage-7 — landed in PR #581 (session 3) as new group `[12, 13]`.
+- [x] 1998 Stage 8: Brive → Montauban (men's TdF; seg 1; Jacky Durand). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #581 (session 3).
+- [x] 2001 Stage 17: Brive → Montluçon (men's TdF; seg 1; Serge Baguet). Source: https://www.bikeraceinfo.com/tdf/tdf2001.html — landed in PR #581 (session 3).
+- [x] Tour du Limousin 1979 Stage 5: Tulle → Tulle (regional race; seg 10) — landed in PR #581 (session 3).
+- [x] Tour du Limousin 1987 Stage 4: Tulle → Limoges (regional race; seg 10) — landed in PR #581 (session 3).
+- [x] Tour du Limousin 1997 Stage 2: Le Moutier-d'Ahun → Tulle (regional race; seg 10) — landed in PR #581 (session 3).
+- [x] Tour du Limousin 2009 Stage 1: Limoges → Ussel (regional race; seg 27 — same finish town as 2026 TdF Stage 9). Source: https://fr.wikipedia.org/wiki/Tour_du_Limousin_2009 — landed in PR #581 (session 3) as new group `[27]`.
+- [x] Tour du Limousin 2024 Stage 3: La Rivière de Mansac → Argentat (regional race; near seg 1) — landed in PR #581 (session 3) as `[1, 2]` adjacent-context entry.
+- [x] Tour du Limousin 2025 Stage 3: Saint-Jal → Masseret (regional race; corridor-adjacent north of seg 12-15) — landed in PR #581 (session 3) as new group `[12]` adjacent-context entry.
+- [x] Paris-Corrèze 2007 / 2008 / 2009 / 2010 / 2011 / 2012 final stages at Chaumeil (regional race; seg 15). Re-keying landed earlier (in seg 23-27 verification PR #500) — entry already present in `[15]` group; PR #581 did not duplicate. Per-edition stage rows (2008 Brive start, 2009 Tulle → Chaumeil) deferred; not landed in session 3 because the consolidated `[15]` Paris-Corrèze entry already names them inline.
 
 Closes when each event has been added to `data/historical-tdf.json` with verified segment keying. The exact polyline-keying for each event is in the dossier's per-event corpus.
 
@@ -680,3 +680,30 @@ The four flaky URLs all have alternative coverage:
 - `Passage_Tour_de_France_2020.jpg`: CC BY-SA 4.0 (GAFUCRU, 2020-07-26). Verified.
 - `Les_Monédières.jpg`: Free Art License — copyleft, free for commercial + non-commercial (Phiffou, photographed 2004-11-19). Verified.
 - `Raymond_Poulidor_-_IMG_1906_(cropped)_(cropped).JPG`: CC BY-SA 3.0 (Poudou99, 2012-04-03). Verified.
+
+### Session 3 (corridor expansion landing, 2026-05-24)
+
+Session 3 was the data-population strand for #527 (PR #581). Moderate scope chosen at the AskUserQuestion checkpoint: land all dossier carryforwards that pass single-source verification.
+
+**Events landed in `data/historical-tdf.json`** (19 events across 4 commits, batches of 5/7/5/3):
+
+Seg [1, 2] additions (12 events): 1951 S10, 1964 S19, 1964 S20, 1969 S19, 1969 S20, 1973 S17, 1973 S18, 1987 S12, 1998 S6, 1998 S8, 2001 S17, Tour du Limousin 2024 S3 (adjacent).
+
+Seg [10] additions (4 events): 1976 S19, Tour du Limousin 1979 S5, Tour du Limousin 1987 S4, Tour du Limousin 1997 S2.
+
+New keying groups: `[12]` (Tour du Limousin 2025 S3, adjacent); `[12, 13]` (1998 Stage 7 ITT — Ullrich, first post-Festina stage); `[27]` (Tour du Limousin 2009 S1 Limoges → Ussel — the closest documented finish-line antecedent to the 2026 TdF Stage 9 finish).
+
+**Schema use:** existing shape (`segments` int[]; `events[].year` int|null, `stage` string, `route` string, `description` string, optional `videoUrl`/`videoTitle`). No new fields added; `description` carries inline source-attribution context where the link mattered (e.g., "see seg 15" cross-references; "verified during seg 23-27 verification #500" pointers retained from prior work).
+
+**Verification posture:** dossier-cited single-source claims were trusted for routine details (stage winner, year, route termini). Three substantive cross-checks during landing:
+
+- 1976 Stage 19 Bernard Thévenet abandonment: dossier places it on the 1976 Sainte-Foy-la-Grande → Tulle stage, not the 1973 Brive double-header — applied accordingly.
+- 1998 Festina expulsion timing: dossier framing "morning the Festina scandal broke" was tightened to "Festina had been expelled the previous evening" (the expulsion happened the night before Stage 7 ITT, not the morning of). Phrasing in the 1998 S7 ITT description corrected accordingly.
+- 1997 Tour du Limousin Stage 2 third-place rider: dossier says "Piziks"; resolved as Arvis Piziks (Latvian rider) in the description.
+
+**Not landed in session 3:**
+
+- Per-edition Paris-Corrèze stage rows (2008 Brive start, 2009 Tulle → Chaumeil corridor-spanning) — the consolidated `[15]` Paris-Corrèze entry from earlier work already names them inline; per-edition rows would duplicate without adding reader-facing information.
+- Backfill of thin existing entries (the 1996 Stage 14 Tulle entry's Hollande-anachronism point, etc.) — out of Moderate scope.
+
+**Surprises during session:** none material. The HistoricalContext.vue component renders plain text from `event.description` (mustache interpolation, no markdown), confirming that any inline asterisks/bolds would have rendered literally — no such markup was used.

--- a/content/research/tour-history-research.md
+++ b/content/research/tour-history-research.md
@@ -585,23 +585,23 @@ Each item below describes a gap (per `feedback_issues_describe_problems.md`). Th
 
 On-corridor events:
 
-- [x] 1951 Stage 10: Clermont-Ferrand → Brive (men's TdF; seg 1; pairs with already-corpus 1951 Stage 11 Koblet solo). Source: https://www.bikeraceinfo.com/tdf/tdf1951.html — landed in PR #581 (session 3).
-- [x] 1964 Stage 19: Bordeaux → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Anquetil-Poulidor Puy-de-Dôme launch pad). Source: https://www.bikeraceinfo.com/tdf/tdf1964.html — both landed in PR #581 (session 3).
-- [x] 1969 Stage 19: Libourne → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Hoban + Matignon underdog). Source: https://www.bikeraceinfo.com/tdf/tdf1969.html — both landed in PR #581 (session 3).
-- [x] 1973 Stage 17: Sainte-Foy-la-Grande → Brive + Stage 18: Brive → Puy-de-Dôme (men's TdF; seg 1; Ocaña era). Source: https://www.bikeraceinfo.com/tdf/tdf1973.html — both landed in PR #581 (session 3).
-- [x] 1976 Stage 19: Sainte-Foy-la-Grande → Tulle (men's TdF; seg 10; pairs with already-corpus 1976 Stage 20). Source: https://www.bikeraceinfo.com/tdf/tdf1976.html — landed in PR #581 (session 3).
-- [x] 1987 Stage 12: Brive → Bordeaux (men's TdF; seg 1; Davis Phinney; pairs with #478's Chaumeil work). Source: https://www.bikeraceinfo.com/tdf/tdf1987.html — landed in PR #581 (session 3).
-- [x] 1998 Stage 6: La Châtre → Brive (men's TdF; seg 1; Cipollini). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #581 (session 3).
-- [x] 1998 Stage 7 ITT: Meyrignac-l'Église → Corrèze town (men's TdF; mid-corridor segs 12-13 vicinity; Ullrich + Festina expulsion). Source: https://www.procyclingstats.com/race/tour-de-france/1998/stage-7 — landed in PR #581 (session 3) as new group `[12, 13]`.
-- [x] 1998 Stage 8: Brive → Montauban (men's TdF; seg 1; Jacky Durand). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #581 (session 3).
-- [x] 2001 Stage 17: Brive → Montluçon (men's TdF; seg 1; Serge Baguet). Source: https://www.bikeraceinfo.com/tdf/tdf2001.html — landed in PR #581 (session 3).
-- [x] Tour du Limousin 1979 Stage 5: Tulle → Tulle (regional race; seg 10) — landed in PR #581 (session 3).
-- [x] Tour du Limousin 1987 Stage 4: Tulle → Limoges (regional race; seg 10) — landed in PR #581 (session 3).
-- [x] Tour du Limousin 1997 Stage 2: Le Moutier-d'Ahun → Tulle (regional race; seg 10) — landed in PR #581 (session 3).
-- [x] Tour du Limousin 2009 Stage 1: Limoges → Ussel (regional race; seg 27 — same finish town as 2026 TdF Stage 9). Source: https://fr.wikipedia.org/wiki/Tour_du_Limousin_2009 — landed in PR #581 (session 3) as new group `[27]`.
-- [x] Tour du Limousin 2024 Stage 3: La Rivière de Mansac → Argentat (regional race; near seg 1) — landed in PR #581 (session 3) as `[1, 2]` adjacent-context entry.
-- [x] Tour du Limousin 2025 Stage 3: Saint-Jal → Masseret (regional race; corridor-adjacent north of seg 12-15) — landed in PR #581 (session 3) as new group `[12]` adjacent-context entry.
-- [x] Paris-Corrèze 2007 / 2008 / 2009 / 2010 / 2011 / 2012 final stages at Chaumeil (regional race; seg 15). Re-keying landed earlier (in seg 23-27 verification PR #500) — entry already present in `[15]` group; PR #581 did not duplicate. Per-edition stage rows (2008 Brive start, 2009 Tulle → Chaumeil) deferred; not landed in session 3 because the consolidated `[15]` Paris-Corrèze entry already names them inline.
+- [x] 1951 Stage 10: Clermont-Ferrand → Brive (men's TdF; seg 1; pairs with already-corpus 1951 Stage 11 Koblet solo). Source: https://www.bikeraceinfo.com/tdf/tdf1951.html — landed in PR #601 (session 3).
+- [x] 1964 Stage 19: Bordeaux → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Anquetil-Poulidor Puy-de-Dôme launch pad). Source: https://www.bikeraceinfo.com/tdf/tdf1964.html — both landed in PR #601 (session 3).
+- [x] 1969 Stage 19: Libourne → Brive + Stage 20: Brive → Puy-de-Dôme (men's TdF; seg 1; Hoban + Matignon underdog). Source: https://www.bikeraceinfo.com/tdf/tdf1969.html — both landed in PR #601 (session 3).
+- [x] 1973 Stage 17: Sainte-Foy-la-Grande → Brive + Stage 18: Brive → Puy-de-Dôme (men's TdF; seg 1; Ocaña era). Source: https://www.bikeraceinfo.com/tdf/tdf1973.html — both landed in PR #601 (session 3).
+- [x] 1976 Stage 19: Sainte-Foy-la-Grande → Tulle (men's TdF; seg 10; pairs with already-corpus 1976 Stage 20). Source: https://www.bikeraceinfo.com/tdf/tdf1976.html — landed in PR #601 (session 3).
+- [x] 1987 Stage 12: Brive → Bordeaux (men's TdF; seg 1; Davis Phinney; pairs with #478's Chaumeil work). Source: https://www.bikeraceinfo.com/tdf/tdf1987.html — landed in PR #601 (session 3).
+- [x] 1998 Stage 6: La Châtre → Brive (men's TdF; seg 1; Cipollini). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #601 (session 3).
+- [x] 1998 Stage 7 ITT: Meyrignac-l'Église → Corrèze town (men's TdF; mid-corridor segs 12-13 vicinity; Ullrich + Festina expulsion). Source: https://www.procyclingstats.com/race/tour-de-france/1998/stage-7 — landed in PR #601 (session 3) as new group `[12, 13]`.
+- [x] 1998 Stage 8: Brive → Montauban (men's TdF; seg 1; Jacky Durand). Source: https://www.bikeraceinfo.com/tdf/tdf1998.html — landed in PR #601 (session 3).
+- [x] 2001 Stage 17: Brive → Montluçon (men's TdF; seg 1; Serge Baguet). Source: https://www.bikeraceinfo.com/tdf/tdf2001.html — landed in PR #601 (session 3).
+- [x] Tour du Limousin 1979 Stage 5: Tulle → Tulle (regional race; seg 10) — landed in PR #601 (session 3).
+- [x] Tour du Limousin 1987 Stage 4: Tulle → Limoges (regional race; seg 10) — landed in PR #601 (session 3).
+- [x] Tour du Limousin 1997 Stage 2: Le Moutier-d'Ahun → Tulle (regional race; seg 10) — landed in PR #601 (session 3).
+- [x] Tour du Limousin 2009 Stage 1: Limoges → Ussel (regional race; seg 27 — same finish town as 2026 TdF Stage 9). Source: https://fr.wikipedia.org/wiki/Tour_du_Limousin_2009 — landed in PR #601 (session 3) as new group `[27]`.
+- [x] Tour du Limousin 2024 Stage 3: La Rivière de Mansac → Argentat (regional race; near seg 1) — landed in PR #601 (session 3) as `[1, 2]` adjacent-context entry.
+- [x] Tour du Limousin 2025 Stage 3: Saint-Jal → Masseret (regional race; corridor-adjacent north of seg 12-15) — landed in PR #601 (session 3) as new group `[12]` adjacent-context entry.
+- [x] Paris-Corrèze 2007 / 2008 / 2009 / 2010 / 2011 / 2012 final stages at Chaumeil (regional race; seg 15). Re-keying landed earlier (in seg 23-27 verification PR #500) — entry already present in `[15]` group; PR #601 did not duplicate. Per-edition stage rows (2008 Brive start, 2009 Tulle → Chaumeil) deferred; not landed in session 3 because the consolidated `[15]` Paris-Corrèze entry already names them inline.
 
 Closes when each event has been added to `data/historical-tdf.json` with verified segment keying. The exact polyline-keying for each event is in the dossier's per-event corpus.
 
@@ -683,7 +683,7 @@ The four flaky URLs all have alternative coverage:
 
 ### Session 3 (corridor expansion landing, 2026-05-24)
 
-Session 3 was the data-population strand for #527 (PR #581). Moderate scope chosen at the AskUserQuestion checkpoint: land all dossier carryforwards that pass single-source verification.
+Session 3 was the data-population strand for #527 (PR #601). Moderate scope chosen at the AskUserQuestion checkpoint: land all dossier carryforwards that pass single-source verification.
 
 **Events landed in `data/historical-tdf.json`** (19 events across 4 commits, batches of 5/7/5/3):
 

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -49,6 +49,42 @@
         "stage": "Stage 20",
         "route": "Brive to Puy-de-Dome",
         "description": "Pierre Matignon, the lanterne rouge of the race, attacked from a small group and held off the field for one of the most romantic stage wins in Tour history. Merckx held yellow. Brive was the launch pad for the underdog day."
+      },
+      {
+        "year": 1973,
+        "stage": "Stage 17",
+        "route": "Sainte-Foy-la-Grande to Brive",
+        "description": "Claude Tollet of France won the stage into Brive; Luis Ocana in yellow. The third Brive double-header in nine years — Ocana dominated the Massif Central transitions and won the next day's Stage 18 to the Puy-de-Dome, on his way to his only Tour victory."
+      },
+      {
+        "year": 1973,
+        "stage": "Stage 18",
+        "route": "Brive to Puy-de-Dome",
+        "description": "Luis Ocana of Spain won the mountaintop finish at the Puy-de-Dome, dominating the Massif Central transition en route to his only Tour win. Brive was the launch pad."
+      },
+      {
+        "year": 1987,
+        "stage": "Stage 12",
+        "route": "Brive to Bordeaux",
+        "description": "Davis Phinney of the USA (7-Eleven) won the sprint — a rare American sprint win of the 1980s. Martial Gayant in yellow. The previous day, Stage 11 had finished at Chaumeil with Gayant's Systeme U teammate Charly Mottet losing the jersey on the same day Gayant inherited it (see seg 15). The corridor finished the day at Chaumeil, slept in Brive, and departed for Bordeaux."
+      },
+      {
+        "year": 1998,
+        "stage": "Stage 6",
+        "route": "La Chatre to Brive",
+        "description": "Mario Cipollini of Italy won the sprint into Brive — his second consecutive stage win of the race. Stuart O'Grady in yellow. The first of three consecutive days the 1998 Tour spent in or around the Correze; the Festina doping scandal would break the next evening, on the eve of Stage 7."
+      },
+      {
+        "year": 1998,
+        "stage": "Stage 8",
+        "route": "Brive to Montauban",
+        "description": "Jacky Durand of France won from the breakaway as the Festina-less peloton left the corridor; Laurent Desbiens in yellow. The 1998 Tour had spent three full days in the Correze (Stage 6 finish at Brive, Stage 7 ITT around Tulle, Stage 8 departure from Brive) — the corridor was the geographic stage on which the Festina story broke (see seg 12-13 for Stage 7)."
+      },
+      {
+        "year": 2001,
+        "stage": "Stage 17",
+        "route": "Brive to Montlucon",
+        "description": "Serge Baguet of Belgium won the breakaway finish into Montlucon; Lance Armstrong in yellow (results subsequently annulled for doping). Brive's most recent Tour departure before 2012. The previous day's Stage 16 finish at Sarran — a presidential-courtesy stage town for then-sitting-President Jacques Chirac — was adjacent to the corridor (Sarran sits ~10 km north of seg 15)."
       }
     ]
   },

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -85,12 +85,24 @@
         "stage": "Stage 17",
         "route": "Brive to Montlucon",
         "description": "Serge Baguet of Belgium won the breakaway finish into Montlucon; Lance Armstrong in yellow (results subsequently annulled for doping). Brive's most recent Tour departure before 2012. The previous day's Stage 16 finish at Sarran — a presidential-courtesy stage town for then-sitting-President Jacques Chirac — was adjacent to the corridor (Sarran sits ~10 km north of seg 15)."
+      },
+      {
+        "year": 2024,
+        "stage": "Tour du Limousin Stage 3",
+        "route": "La Riviere-de-Mansac to Argentat-sur-Dordogne",
+        "description": "Adjacent context — the start at La Riviere-de-Mansac sits in the Brive agglomeration ~15 km west of Brive, and the stage ran south-east toward Argentat well off the Stage 9 polyline. Jefferson Cepeda soloed in from 10 km out; Alex Baudin won the GC. The Tour du Limousin is the corridor's regular pro race — the resident that the 2026 Tour visits as guest."
       }
     ]
   },
   {
     "segments": [10],
     "events": [
+      {
+        "year": 1976,
+        "stage": "Stage 19",
+        "route": "Sainte-Foy-la-Grande to Tulle",
+        "description": "Hubert Mathis of France won by 7 seconds from a 9-man breakaway; Italy's Enrico Paolini second. Lucien Van Impe held yellow. The previous year's winner Bernard Thevenet abandoned during this stage. The first half of a two-day Tulle visit — the next morning Stage 20 (Tulle to Puy-de-Dome) launched Van Impe toward his only Grand Tour victory (see the 1976 Stage 20 entry)."
+      },
       {
         "year": 1976,
         "stage": "Stage 20",
@@ -100,12 +112,30 @@
         "videoTitle": "TV broadcast (YouTube)"
       },
       {
+        "year": 1979,
+        "stage": "Tour du Limousin Stage 5",
+        "route": "Tulle to Tulle",
+        "description": "Final stage of the 1979 Tour du Limousin, a circuit race departing and finishing in Tulle — a full Correze loop on roads that overlap large parts of the Stage 9 corridor's mid-section."
+      },
+      {
+        "year": 1987,
+        "stage": "Tour du Limousin Stage 4",
+        "route": "Tulle to Limoges",
+        "description": "Final stage of the 1987 Tour du Limousin, departing from Tulle. Kim Andersen won the stage; Charly Mottet — the Systeme U rider who'd lost the Tour de France yellow jersey on the corridor's Chaumeil stage two weeks earlier (see seg 15) — won the GC."
+      },
+      {
         "year": 1996,
         "stage": "Stage 14",
         "route": "Besse-en-Chandesse to Tulle",
         "description": "Bastille Day stage into Tulle won in a sprint by Djamolidine Abdoujaparov, the Tashkent Terror. Bjarne Riis in yellow on his way to overall victory.",
         "videoUrl": "https://www.youtube.com/watch?v=3WUztWV7_tQ",
         "videoTitle": "TV broadcast (YouTube)"
+      },
+      {
+        "year": 1997,
+        "stage": "Tour du Limousin Stage 2",
+        "route": "Le Moutier-d'Ahun to Tulle",
+        "description": "Tulle finish. Frederic Guesdon won the stage ahead of Frederic Magnien and Arvis Piziks. Guesdon would go on to win Paris-Roubaix the following spring — his Tulle stage was a marker for the breakthrough year."
       }
     ]
   },

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -212,5 +212,38 @@
         "description": "The day after Stage 9, the peloton rides the adjacent Cantal roads from Aurillac to Le Lioran - the same finale where Vingegaard beat Pogacar in a photo finish in 2024. The 2026 Tour de France Stage 9 finish at Ussel is genuinely the town's first Tour stage appearance — Ussel has never been a Tour de France stage town in any prior edition (verified during seg 23-27 verification #500 via two independent ledicodutour sources). The earlier claim that Ussel had served as a Paris-Corrèze stage town was unverified for pre-2005 editions and contradicted for 2007–2012 (all of which finished at Chaumeil, seg 15); the Paris-Corrèze entry has been re-keyed to seg 15 accordingly."
       }
     ]
+  },
+  {
+    "segments": [12],
+    "events": [
+      {
+        "year": 2025,
+        "stage": "Tour du Limousin Stage 3",
+        "route": "Saint-Jal to Masseret",
+        "description": "Adjacent context — Saint-Jal sits ~12 km north of Tulle on the plateau between segs 12 and 15, off the Stage 9 polyline; Masseret is further north in Correze, also off-route. Paul Lapeira (Decathlon AG2R La Mondiale) won the stage; Ewen Costiou won the GC. The closest Tour du Limousin overlap of the corridor's mid-section in recent years."
+      }
+    ]
+  },
+  {
+    "segments": [12, 13],
+    "events": [
+      {
+        "year": 1998,
+        "stage": "Stage 7 ITT",
+        "route": "Meyrignac-l'Eglise to Correze",
+        "description": "Jan Ullrich won the 58 km individual time trial in 1h15:25, taking yellow. The ITT looped between two communes — Meyrignac-l'Eglise and the town of Correze, both north-east of Tulle on the plateau the Stage 9 corridor traverses in segs 12-13; the ITT route's exact relationship to the 2026 polyline is approximate. Festina had been expelled the previous evening for the doping scandal that would define the 1998 Tour, making this the first stage of the post-Festina race. The 1998 Tour spent three consecutive days in the Correze: Stage 6 finish at Brive, this ITT, and Stage 8 departure from Brive (see seg 1-2)."
+      }
+    ]
+  },
+  {
+    "segments": [27],
+    "events": [
+      {
+        "year": 2009,
+        "stage": "Tour du Limousin Stage 1",
+        "route": "Limoges to Ussel",
+        "description": "Borut Bozic (Vacansoleil) won the 159.6 km opening stage and took the leader's jersey; Mathieu Perget won the GC. The closest documented precedent for the 2026 Tour de France Stage 9 finish at Ussel — same finish town, 17 years earlier, in the smaller regional race. Per the seg 23-27 verification (#500) and the tour-history dossier (PR #526), Ussel had never hosted a Tour de France stage finish before 2026; this Tour du Limousin opener is the strongest documented finish-line antecedent."
+      }
+    ]
   }
 ]

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -19,6 +19,36 @@
         "stage": "Stage 15",
         "route": "Departure from Brive",
         "description": "The Tour departed from Brive-la-Gaillarde heading to Villeneuve-sur-Lot."
+      },
+      {
+        "year": 1951,
+        "stage": "Stage 10",
+        "route": "Clermont-Ferrand to Brive",
+        "description": "Bernardo Ruiz of Spain won the Massif Central stage into Brive; Roger Leveque held yellow. The first half of the only year Brive hosted both a finish and the next day's start — the following morning, Brive launched Stage 11 to Agen, on which Hugo Koblet rode his legendary 135 km solo (see the 1951 Stage 11 entry above)."
+      },
+      {
+        "year": 1964,
+        "stage": "Stage 19",
+        "route": "Bordeaux to Brive",
+        "description": "Edouard Sels of Belgium won the sprint into Brive; Jacques Anquetil in yellow. Brive was the launch pad for the next day's Stage 20 to the Puy-de-Dome — the day of the most-photographed duel in Tour history, Anquetil and Raymond Poulidor riding shoulder-to-shoulder up the volcanic plug."
+      },
+      {
+        "year": 1964,
+        "stage": "Stage 20",
+        "route": "Brive to Puy-de-Dome",
+        "description": "Julio Jimenez of Spain won the mountaintop finish at the Puy-de-Dome; Anquetil held yellow to the line after the shoulder-to-shoulder duel with Poulidor on the volcanic plug. Anquetil lost seconds on the climb but kept the jersey by 14 seconds on the final podium — his fifth and last Tour win."
+      },
+      {
+        "year": 1969,
+        "stage": "Stage 19",
+        "route": "Libourne to Brive",
+        "description": "Barry Hoban of Great Britain won the sprint into Brive; Eddy Merckx in yellow on his way to the first of his five Tour wins. Hoban was Britain's most prolific Tour stage winner of the 1960s and 70s — eight career stages."
+      },
+      {
+        "year": 1969,
+        "stage": "Stage 20",
+        "route": "Brive to Puy-de-Dome",
+        "description": "Pierre Matignon, the lanterne rouge of the race, attacked from a small group and held off the field for one of the most romantic stage wins in Tour history. Merckx held yellow. Brive was the launch pad for the underdog day."
       }
     ]
   },


### PR DESCRIPTION
## Summary

Data-population strand expanding `data/historical-tdf.json` with the corridor-relevant Tour de France events the tour-history research dossier (PR #526) surfaced but did not action. Closes the gap between research (done) and reader-facing data realisation.

**Scope chosen at the AskUserQuestion checkpoint:** Moderate — land all dossier carryforwards that pass single-source verification.

**Events landed:** 19 across 4 commits (batches of 5/7/5/3):

Seg `[1, 2]` (12 new events): 1951 Stage 10 Brive finish, 1964 Stages 19/20 (Anquetil-Poulidor Puy-de-Dôme launch pad), 1969 Stages 19/20 (Hoban + Matignon underdog), 1973 Stages 17/18 (Tollet + Ocaña), 1987 Stage 12 (Davis Phinney pairing with the seg 15 Chaumeil work), 1998 Stages 6 + 8 (Cipollini + Durand bookending the Festina-week Corrèze residency), 2001 Stage 17 (Baguet breakaway), Tour du Limousin 2024 Stage 3 (adjacent-context entry for the Brive agglomeration start).

Seg `[10]` (4 new events): 1976 Stage 19 Mathis (pairing with the existing 1976 Stage 20), Tour du Limousin 1979 Stage 5 (Tulle circuit), Tour du Limousin 1987 Stage 4 (Andersen + Mottet GC pairing with seg 15's 1987 Chaumeil work), Tour du Limousin 1997 Stage 2 (Guesdon pre-Roubaix).

New groups: `[12]` (Tour du Limousin 2025 Stage 3, adjacent), `[12, 13]` (1998 Stage 7 ITT — Ullrich, first stage of the post-Festina race), `[27]` (Tour du Limousin 2009 Stage 1 Limoges → Ussel — the closest documented finish-line antecedent to the 2026 Tour de France Stage 9 finish).

**Dossier (append-only) updates:**

- All 17 dossier-checklist carryforwards marked as landed in this PR.
- Session-3 verification log entry appended: scope chosen, schema notes, three substantive cross-checks (Thévenet 1976 not 1973, Festina expulsion timing, Arvis Piziks identity), what was deliberately not landed in Moderate scope.

**Verification:**

- JSON parses (`python3 -c "import json; json.load(...)"`).
- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green.
- `npm test` — 198 tests / 27 files passing.
- `npm run build` — green.
- `npx nuxt generate` — 53 routes prerendered.
- Spot-check: rendered `01-malemort-departure/index.html` and `02-south-of-brive/index.html` both contain the new 1969 Matignon event content.

Closes #527

## Test plan

- [x] JSON parses
- [x] `validate_entries.py` green
- [x] `npm test` green (27 files / 198 tests)
- [x] `npm run build` green
- [x] `npx nuxt generate` succeeds (53 routes)
- [x] Spot-check: rendered seg-1 and seg-2 pages contain new historical event content

🤖 Generated with [Claude Code](https://claude.com/claude-code)