### PR TITLE
fix(attractions): Musée Chirac Wilmotte building opening date (closes #586)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -655,7 +655,7 @@
     "category": "museum",
     "lat": 45.44262,
     "lng": 1.91898,
-    "description": "Museum at Sarran, opened June 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). The Chirac family château (Château de Bity) is in the commune, and Bernadette Chirac was a Sarran municipal councillor; Chirac himself is buried at Cimetière du Montparnasse in Paris, with Sarran hosting the October 2019 memorial gathering rather than an interment. The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.",
+    "description": "Museum at Sarran, opened 15 December 2000, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). The Chirac family château (Château de Bity) is in the commune, and Bernadette Chirac was a Sarran municipal councillor; Chirac himself is buried at Cimetière du Montparnasse in Paris, with Sarran hosting the October 2019 memorial gathering rather than an interment. The route passes 3.2 km west of Sarran on the climb out of Saint-Augustin toward Chaumeil; not on-route but adjacent. Pairs with Ussel (seg 25-26), where Chirac began his political career as a municipal councillor in 1965.",
     "links": [
       {
         "url": "https://www.museepresidentjcchirac.fr/",


### PR DESCRIPTION
## Summary

Single-field fix to `data/attractions.json` — the Musée du Président Jacques Chirac entry said "opened June 2000" but the Jean-Michel Wilmotte-designed building opened on **15 December 2000**.

Sister to PR #585 (closes #564), same entry, different factual claim. Surfaced during the #564 strand execution and held back per single-entry-fix discipline; now resolved.

## Pre-fix description

> Museum at Sarran, opened **June 2000**, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). The Chirac family château (Château de Bity) is in the commune, …

## Post-fix description

> Museum at Sarran, opened **15 December 2000**, housing the official gifts received by Jacques Chirac during his presidency (1995-2007). The Chirac family château (Château de Bity) is in the commune, …

Rest of the description unchanged from the post-#585 state.

## Source verification

- English Wikipedia, [Musée du Président Jacques Chirac](https://en.wikipedia.org/wiki/Mus%C3%A9e_du_Pr%C3%A9sident_Jacques_Chirac): "It was opened on December 15, 2000 by Chirac. The building was designed by Jean-Michel Wilmotte."
- Web-search corroboration across multiple French museum directories agrees on 15 December 2000.
- The French Wikipedia URL given in the issue (`fr.wikipedia.org/wiki/Musée_du_président_Jacques-Chirac`) currently 404s for both the underscore and hyphen variants of the URL slug; the English Wikipedia article and the segs 14-16 block research dossier (`content/research/segs-14-16-block-research.md`, "Sarran adjacency") both name 15 December 2000, so the date is well-attested independent of the unreachable French page.
- Wilmotte's own project page (`wilmotte.com/projets/musee-president-chirac/`) lists "Année: 2006" — likely a later extension phase, not the original opening.

## Other entries spot-checked

None — strict single-entry-fix discipline per the strand brief. Any further data-correctness issues should be filed as separate issues.

## Test plan

- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green
- [x] `npm test` — 204 passed, 3 skipped (28 files)
- [x] `npm run build` — production build succeeded

Closes #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)