### PR TITLE
historical-context: darker subtitle, year fields, MFNA photo links on 1987 men's card

### DIFF
--- a/components/HistoricalContext.vue
+++ b/components/HistoricalContext.vue
@@ -5,7 +5,7 @@
       <div v-for="(event, idx) in events" :key="idx" class="border-l-4 border-correze-red pl-4">
         <div v-if="event.year" class="flex items-baseline gap-2 mb-1">
           <span class="font-mono font-bold text-correze-red">{{ event.year }}</span>
-          <span v-if="event.stage" class="text-sm text-stone-500">{{ event.stage }}</span>
+          <span v-if="event.stage" class="text-sm font-medium text-stone-700">{{ event.stage }}</span>
           <span v-if="event.route" class="text-sm text-stone-400">{{ event.route }}</span>
         </div>
         <p class="text-sm text-stone-600 leading-relaxed">{{ event.description }}</p>
@@ -16,6 +16,16 @@
           rel="noopener"
           class="text-sm text-correze-red hover:underline mt-1 inline-block"
         >▶ {{ event.videoTitle || 'Watch on YouTube' }}</a>
+        <div v-if="event.photos && event.photos.length" class="mt-1 flex flex-wrap gap-x-4">
+          <a
+            v-for="(photo, pIdx) in event.photos"
+            :key="pIdx"
+            :href="photo.url"
+            target="_blank"
+            rel="noopener"
+            class="text-sm text-correze-red hover:underline inline-block"
+          >📷 {{ photo.title }}</a>
+        </div>
       </div>
     </div>
   </div>

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -50,7 +50,11 @@
         "year": 1987,
         "stage": "Stage 11 (men's)",
         "route": "Poitiers to Chaumeil",
-        "description": "255 km finish at Chaumeil on Saturday 11 July 1987. Martial Gayant (Système U) won solo from a breakaway 13 km out, ahead of Laudelino Cubino and Kim Andersen. Charly Mottet, Gayant's Système U teammate, lost the yellow jersey on the same stage. The same day saw the women's Tour de France Féminin Stage 3 also finish in Chaumeil — the only year both editions of the Tour finished a stage in the village on the same day."
+        "description": "255 km finish at Chaumeil on Saturday 11 July 1987. Martial Gayant (Système U) won solo from a breakaway 13 km out, ahead of Laudelino Cubino and Kim Andersen. Charly Mottet, Gayant's Système U teammate, lost the yellow jersey on the same stage. The same day saw the women's Tour de France Féminin Stage 3 also finish in Chaumeil — the only year both editions of the Tour finished a stage in the village on the same day.",
+        "photos": [
+          { "url": "https://www.memoirefilmiquenouvelleaquitaine.fr/photos/tour-de-france-1987-36", "title": "Stage finish (L'Echo du Centre archive)" },
+          { "url": "https://www.memoirefilmiquenouvelleaquitaine.fr/photos/tour-de-france-1987-5", "title": "Podium with the Chiracs (L'Echo du Centre archive)" }
+        ]
       },
       {
         "year": 1987,
@@ -71,14 +75,14 @@
         "description": "First Tour de France appearance of the Suc au May. 218 km — the longest stage of the 2020 Tour — on Thursday 10 September 2020. Marc Hirschi (Sunweb) won solo, his winning move launched on the Suc au May descent. The stage was dedicated to Raymond Poulidor through Saint-Léonard-de-Noblat. The finish at Sarran (4 km off the Stage 9 route at km 99.7) was a tribute to the Chirac family home."
       },
       {
-        "year": null,
-        "stage": "Bol d'Or des Monédières (criterium series)",
+        "year": 1952,
+        "stage": "Bol d'Or des Monédières",
         "route": "Chaumeil",
         "description": "Post-Tour criterium founded in 1952 by Chaumeil-born accordionist Jean Ségurel and run on a circuit around Chaumeil. Held annually 1952–1967, then revived 1981–2002. Winners read like a roll-call of the post-war peloton: Coppi (1953), Anquetil (1955, 1962), Géminiani (1956–58), Poulidor (1963, 1967, with a 3rd place behind Gérard Saint and Ercole Baldini in 1959), Hinault (1982). The criterium is the reason the village punches well above its 350-resident weight in French cycling memory; the Côte des Géants (the climb the 2017 Tour du Limousin used as its finishing-circuit challenge) takes its name from these post-Tour exhibitions."
       },
       {
-        "year": null,
-        "stage": "Paris-Corrèze (2001–2012, final stages 2007–2012)",
+        "year": 2001,
+        "stage": "Paris-Corrèze",
         "route": "Final stages closing at Chaumeil",
         "description": "UCI 2.1 stage race created in 2001 by 1983/1984 Tour de France winner Laurent Fignon with Corrézien motorsport champion Max Mamers and the Conseil général de la Corrèze. From the 2005 edition onward, the final stage closed with five laps of the historic Bol d'Or des Monédières circuit at Chaumeil — explicitly preserving the legacy of the post-Tour criterium. Six confirmed Chaumeil finishes: 2007 (Vigeois → Chaumeil, won by Edvald Boasson Hagen at age 20), 2008 (Brive → Chaumeil), 2009 (Tulle → Chaumeil — the strongest single-stage corridor overlap), 2010, 2011 (Objat → Chaumeil), 2012 (Objat → Chaumeil, final edition). The race did not run in 2013 and has not been organised since. Re-keyed from segments [25, 26, 27] to [15] in seg 23-27 verification (#500) per the #502 tour-history dossier: every documented Paris-Corrèze finish was at Chaumeil (seg 15), not Ussel."
       }


### PR DESCRIPTION
## Summary

Two-part fix to the Tour de France History rendering surfaced during seg 15 drafting review:

- `data/historical-tdf.json`: add `year` (1952 / 2001) and clean stage subtitle on the Bol d'Or des Monédières and Paris-Corrèze entries (both were `year: null`, which the template hid entirely); add a `photos` array with two Mémoire Filmique Nouvelle-Aquitaine archive links on the 1987 men's Stage 11 card.
- `components/HistoricalContext.vue`: darken stage subtitle `text-stone-500` → `text-stone-700 font-medium`; add a photos rendering block parallel to the existing `videoUrl` link.

Closes #599.

## Before / After on the seg 15 history section

Before the data fix, the Bol d'Or and Paris-Corrèze entries rendered as a descriptionless paragraph below an empty card spine, because the template hid the year+subtitle+route header row on `v-if="event.year"`. After: every event has the same header shape, and the 1987 men's card carries two clickable period-photo links.

## Test plan

- [x] `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` green
- [x] Dev preview at `/entries/15-suc-au-may-the-fierce-one` shows all six seg 15 cards in the same shape, with the 1987 men's card carrying both `📷 Stage finish` and `📷 Podium with the Chiracs` links
- [x] Reviewer click-tests each MFNA link

🤖 Generated with [Claude Code](https://claude.com/claude-code)