### PR TITLE
seg 27: move publishDate from 2026-07-09 to 2026-07-03

### DIFF
--- a/content/entries/27-place-voltaire-the-finish-line.md
+++ b/content/entries/27-place-voltaire-the-finish-line.md
@@ -2,7 +2,7 @@
 segment: 27
 title: "Place Voltaire - The Finish Line"
 subtitle: "Km 182-184.8: The final sprint into Ussel"
-publishDate: 2026-07-09
+publishDate: 2026-07-03
 kmStart: 182
 kmEnd: 184.8
 gpxFile: /gpx/segment-27.gpx


### PR DESCRIPTION
Schedule reshuffle decided during the seg-16 drafting session (2026-05-27), parked in `project_next_planning_notes.md` as a pending repo edit until now.

## Why

The new run-in to the race:

```
Wed 2026-07-01  seg 26 (Canada Day, unchanged)
Thu 2026-07-02  Tour-history special publication
Fri 2026-07-03  seg 27 (this PR)
Sat 2026-07-04  Grand Départ, Barcelona TTT
Sun 2026-07-12  Stage 9 (the race)
```

Walker arithmetic checks out: 185 km at the 2 km/day cap from the 2026-04-01 start finishes **2026-07-02** best-case, so seg 27 can land on 2026-07-03 with the walking ledger plausibly complete.

## What this PR does

- One line change in `content/entries/27-place-voltaire-the-finish-line.md`: `publishDate: 2026-07-09` → `publishDate: 2026-07-03`
- Validators green

## Out of scope

- **Tour-history special publication** (Jul 2) is a separate content piece — research lives in `content/research/tour-history-research.md` already, format decision parked for the next planning session
- **`data/riders/rider-config.json` startDate vs CLAUDE.md doc drift** (config says 2026-04-01, CLAUDE.md says 04-02) — separate cleanup