### PR TITLE
docs/planning: 2026-05-28 session — close v1.4.19, scope v1.4.20, run-in strand briefs

### DIFF
--- a/docs/planning/2026-05-28-archive.md
+++ b/docs/planning/2026-05-28-archive.md
@@ -1,0 +1,776 @@
+# Planning-notes archive — 2026-05-28
+
+Archived at the close of the 2026-05-28 planning session (v1.4.19 close + v1.4.20 themed as Publish-pipeline hardening). Preserves the strand close-out inputs (2026-05-12 through 2026-05-28 seg-16 publish) that this session swept, plus the prior NEXT.md handoff content, for retro and audit reference. The live memory file was rewritten thin; forward-looking carryforwards live in docs/planning/NEXT.md.
+
+---
+
+---
+name: Next planning session inputs
+description: Running list of items surfaced since the last planning session that should be raised at the next one. Piers and Tully add items during retros and in-progress work; publisher consults and clears at planning time.
+type: project
+originSessionId: 560f0d5d-2b96-4c74-a7e3-4336cf65d0e8
+---
+
+Items to raise at the next planning session. Added during retrospectives, during in-progress work, or when Piers and Tully notice something worth remembering for later. Per the project's convention, the retrospective itself is pure reflection; deciding what to carry forward is a planning activity, not a retro activity. This file is the handoff surface between the two.
+
+**Pre-2026-05-12 historical sections archived** to `docs/planning/2026-05-12-archive.md`. The 2026-05-12 planning session executed the file's "Who clears" rule against everything older than today; archive preserves the originals for retro and audit reference.
+
+## State at handoff to next planning (2026-05-12 evening — after planning session close)
+
+Planning session 2026-05-12 closed all decision-actionable Retro v1.4.17 and v1.4.18 carryforwards. Headlines:
+
+- **v1.4.18 milestone closed.** All 9 lingering open issues reassigned: 5 to v1.4.19 (#328, #476, #479, #486, #487), 1 to v1.6.0 (#468), 2 to v1.4.20 (#322, #480), 1 fixed inline + closed (#510 via PR #543). The W19-seg11 tag was the v1.4.18 artifact; milestone-as-issue-bag now matches.
+- **v1.4.19 grew to 16 open issues** (added #328, #476, #479, #486, #487, #541). Seg 12+13 drafting work and verify-strands #498/#499/#500 land under this milestone before tagging.
+- **Seg 12 publishes Wed 2026-05-13** under tag `W20-seg12` (second publication under date-based scheme). Drafting strand spawn instructions issued during this session; publisher to run in a fresh Claude Code session.
+- **Seg 13 publishes Sun 2026-05-17** under tag `W20-seg13`. Drafting strand spawns Thu 2026-05-14 after seg 12 ships, publisher-paced.
+- **Three verify-strands** (#498/#499/#500) to run in parallel, auto-mode, this week. Briefs ready at `docs/strands/`.
+
+Next retro fires after seg 12 production deploy on Wed 2026-05-13 (production-deploy-bounded per Topic 9c). Retro v1.4.18 was the first under the date-based tag scheme; Retro v1.4.18+W20-seg12 will be the second.
+
+### Decisions recorded today (Retro v1.4.18 close-out)
+
+- **1a — Fail-fast pattern promoted to heavy-tier unfold.** Filed [unfold#45](https://github.com/gneeek/unfold/issues/45). Two clean instances (publish.sh halts in v1.4.17 + rider-stats time-of-day in v1.4.18), cross-surface (script + data display), retro evidence not from inside the experiment that ran it.
+- **1b + 1d — Three-workflow triad and post-publish hotfix mini-playbook → How-We-Work wiki.** New section "Publication workflow shapes" names pre-publish PR / publish.sh session / post-publish hotfix; hotfix mini-playbook captured as a sub-section. v1.4.19 deliverable (no separate issue; recorded in milestone-scope file).
+- **1c — MDC pre-render validator → extend `validate_entries.py`.** One-line regex to count `::name{...}` opens against `::` closes per file. Single source of truth; runs in CI + publish.sh path. v1.4.19 deliverable.
+- **1e — Gitignore audit for write-once files deferred to second instance.** Memory rule captured: "if a file is named by a published segment and is canonical at publish time, it probably wants tracking." Re-evaluate on next instance.
+- **1f — #541 folded with broader consistency-assertion scope.** Fix the time-of-day bug AND add unit-test-shaped consistency assertion ("if displayed days = N, displayed date = asOf + N") in the same PR. Milestoned v1.4.19.
+- **Topic 9 strand-brief template §10 retro-flavored close-out.** PR #544 adds mandatory "Retro inputs" sub-bullet: decision-actionable items + light-tier pattern observations + observable numeric stats (files-touched, commits, AskUserQuestion count, wall-clock) written to this file at strand close. Codifies the v1.4.17-v1.4.18 voluntary practice.
+- **Slip-rate tally artifact landed.** [Slip-rate tally](https://github.com/gneeek/tdf26/wiki/Slip-rate-tally) wiki page created; referenced from Retrospectives page. Four retros of "carrying without writing" was the gate.
+- **Chore-deploy script wrapper parked.** Three-step manual recipe accepted; revisit on next chore-only deploy if friction is concretely felt. Off the carryforward list.
+- **suggest_images.py noise filed as [#545](https://github.com/gneeek/tdf26/issues/545).** Light-tier enhancement, no milestone, opportunistic.
+- **tls-essay atmospheric detail memory extension.** `feedback_pre_publish_scrutiny.md` grew a new paragraph: novelistic specifics that sound real often verify true; prefer adding citations to removing the detail.
+
+### New artifacts on `main` and the wiki
+
+- PRs open: [#543](https://github.com/gneeek/tdf26/pull/543) (template path fix, closes #510), [#544](https://github.com/gneeek/tdf26/pull/544) (template §10 Retro inputs sub-bullet).
+- Wiki: [Slip-rate tally](https://github.com/gneeek/tdf26/wiki/Slip-rate-tally), [Retrospectives](https://github.com/gneeek/tdf26/wiki/Retrospectives) updated.
+- Issues filed: tdf26#545, unfold#45.
+- Issues milestone-reassigned: tdf26 #328, #476, #479, #486, #487 → v1.4.19; #468 → v1.6.0; #322, #480 → v1.4.20; #541 → v1.4.19.
+- Milestone-scope file `docs/planning/v1.4.19-scope.md` (Topic 9b first instance) — to be written at session close.
+- Planning-notes archive `docs/planning/2026-05-12-archive.md` — pre-2026-05-12 content preserved for retro reference.
+
+## Carryforwards for the next planning session
+
+None substantive at session close. Topic 8 settled the slip-rate tally and chore-deploy wrapper; Topic 9 settled the strand-brief template §10 question; Topics 1+5+6+7 settled retro outputs and strand cadence; Topic 11 swept seg 11 pre-publish observations.
+
+**Active threads to monitor** (not decision-pending, but watch for changes):
+
+- **Recommended-option calibration** — 100% acceptance rate held through the v1.4.18 cycle; Topic 8c on 2026-05-07 reframed as well-calibrated. Re-flag if rubber-stamping appears.
+- **Tully/Piers explainer pages** — [unfold#44](https://github.com/gneeek/unfold/issues/44) blocks tdf26#529. Re-evaluate when unfold#44 lands.
+- **Existing milestone names under date-based scheme** — future-only migration settled 2026-05-07; the first new milestone created after v1.4.20 will be the first non-semver name. Decide its naming form at creation time.
+- **Voices design session** — brief authored at `docs/strands/strand-voices-design-session.md`; spawn whenever the publisher schedules it. Separate cadence from release work.
+- **Strand-as-first-class unfold candidate** — re-evaluate after v1.4.19 ships under multi-strand cadence (3 verify + seg 12 + seg 13 + content lints possible).
+- **NearbyAttractions backward-tolerance leak** — surfaced during seg 12 pre-publish: Tintignac (km 77.66) and Chateau de Bach (km 77.92) repeated in seg 12's "Nearby attractions" sidebar even though both are seg 11 attractions, because `NearbyAttractions.vue` uses a symmetric `TOLERANCE_KM = 0.5` (the tolerance exists for Collonges-la-Rouge-style forward-leak from seg 3 to seg 4, but applies symmetrically). Publisher explicitly deferred fixing pre-publish to avoid touching the rendering layer the day before deploy. **Follow-up: file an issue post-deploy** describing the problem (per `feedback_issues_describe_problems.md`); proposed mechanism was a per-attraction `hideFromSegments: [N]` override field + filter check, but the issue should describe the problem only, not prescribe the solution.
+
+## Stats and observations for the next retro (2026-05-12 evening close)
+
+The next retro fires after the seg 12 production deploy on Wed 2026-05-13 (production-deploy-bounded per Topic 9c). Inputs from this planning session:
+
+### Counts
+
+- **PRs opened this session: 2** (#543 template path fix; #544 template §10 Retro inputs).
+- **Issues filed this session: 2** (tdf26#545 suggest_images.py noise; unfold#45 fail-fast heavy-tier).
+- **Issues milestone-reassigned: 9** (5 to v1.4.19; 1 to v1.6.0; 2 to v1.4.20; #541 to v1.4.19).
+- **Issues closed via inline fix: 1** (#510 closes when #543 merges).
+- **Milestones closed: 1** (v1.4.18).
+- **Wiki pages added/edited: 2** (Slip-rate-tally created; Retrospectives updated).
+- **Memory entries edited: 1** (`feedback_pre_publish_scrutiny.md` — atmospheric-detail paragraph added).
+- **AskUserQuestion checkpoints fired: 8** (1a/b+d/c; 1e/1f/#541-milestone; seg-12-spawn pacing/depth; seg-13-cadence/verify-cadence; §10-shape; slip-rate/chore-deploy; suggest_images-issue/tls-essay-memory; ).
+- **Planning-notes archive size: 683 lines** moved out of the live memory file.
+
+### Pattern observations worth a retro line
+
+- **First planning session under the §10 Retro-inputs rule.** This session's own retro inputs land in this file at close; the rule we just wrote applies retroactively to ourselves. Worth a retro line on whether the planning-session pre-condition (publisher present, conversation thread bounded) makes the close-out cheaper than for a strand session.
+- **Heavy archive + thin live file as a planning-notes shape.** First time we moved >600 lines out of the live notes file in one sweep. The decision was "light sweep, confirm decided, remove" but the cumulative effect of 5+ weeks of carryforwards meant the sweep was big. Worth a retro line on whether the sweep should be a regular ceremony (e.g. once per retro) rather than a once-per-major-session ceremony.
+- **Slip-rate tally artifact promoted via planning session, not strand.** Four retros of carrying-without-doing; the breakthrough was a 10-minute commit during this session. Pattern: some artifacts that look strand-shaped are actually planning-session-shaped, because the slot they need is "10 minutes of cross-context committed time," which is more available during planning than during scoped strand execution.
+- **Two PRs for template fixes in one planning session.** PR #543 (path fix) and PR #544 (§10 addition) both touch `docs/strands/STRAND-BRIEF-TEMPLATE.md`. Kept separate because one is a bug fix and one is a policy addition; the precedent from 2026-05-07 ("planning-session infrastructure PRs are routine, not exceptional") covered this. Worth a retro check whether splitting was the right call vs. one bundled PR.
+- **Wiki edits without PR review.** Slip-rate-tally page pushed directly to wiki master with publisher pre-authorization at the AskUserQuestion checkpoint. Pattern consistent with the 2026-05-07 How-We-Work edit; worth naming once at retro as the standing pattern (planning decides + AskUserQuestion confirms → direct wiki push is OK).
+
+## Retro inputs from strand close-outs
+
+Strand close-outs land observable counts and pattern observations here per the §10 Retro inputs rule (PR #544). The next retro reads this section as one of its inputs.
+
+### Seg 12 drafting strand (2026-05-12 close, PR #548 merged)
+
+Counts:
+
+- **PR opened: 1** ([#548](https://github.com/gneeek/tdf26/pull/548), merged 2026-05-12).
+- **Issues filed: 1** ([#547](https://github.com/gneeek/tdf26/issues/547) attractions.json Saint-Augustin Duhamel divergence).
+- **Files written: 1** entry (`content/entries/12-naves-coming-home.md`, renamed from placeholder via `git mv`).
+- **Word count:** 1,162 (within 800–1,200 target).
+- **Footnotes:** 1 expanded (Berque + Donadieu + Hippolyte/Bossis/Burel ONCFS-Rennes I bocage study) tightening the Barthes seg-6 plant.
+- **MDC directives:** 2 `::press-card{...}` opens / 2 closes (manual grep matched).
+- **Em-dashes / exclamation marks:** 0 / 0.
+- **Publisher checkpoint cycles fired: 3** (voice register; arc agreement; first-draft review). Each batched 1–4 questions; total ~10 question-units across the cycles.
+- **Wall-clock from spawn to PR open:** ~3 hours over 4 agent invocations (orchestrator session held the publisher loop because the agent harness did not surface AskUserQuestion to spawned agents — see pattern observation below).
+- **Cleanup:** worktree removed at PR merge per `feedback_strand_session_self_cleanup.md`.
+
+Pattern observations worth a retro line:
+
+- **Unverified-claims list at session close fired its first instance and caught a real bug.** Retro v1.4.18 surfaced four errors in seg 11 the drafting strand missed; the seg 12 brief added "claims-I-did-not-verify list at session close" as a stopgap. The list converted Mérimée verification from "thing the agent might do" into "publisher-selected target" — and verification immediately surfaced the wrong PA notice + wrong inscription date in `data/attractions.json`, leading to #547. Pattern: lightweight session-close enumeration of unverified inputs is cheap and fires real bugs.
+- **Mérimée verification flipped a load-bearing claim mid-revision (cheap because in-strand).** The Duhamel foreshadow line was approved at the arc-agreement checkpoint as a feature; verification at first-draft-review revision time showed the source was wrong; line dropped + issue filed in the same agent invocation. Reinforces `feedback_pre_publish_scrutiny.md` and `feedback_brief_content_is_carryforward.md`. Cost: a few minutes mid-strand. Cost if caught post-publish: retroactive constraint per `feedback_content_change_rule.md` plus possible seg 14 redirect.
+- **MDC validator commitment held by manual discipline.** Retro v1.4.18 decision-actionable item (extend `validate_entries.py` with `::name{...}` ↔ `::` balance check) is open. The seg 12 brief carried "manual grep before PR" as a stopgap; it worked (2/2 balanced). Suggests "manual-discipline-as-backstop-while-validator-pending" is viable for low-frequency strands but starts to bite as the count of strands per cycle grows.
+- **Placeholder-title over-anchoring.** The seg 12 file shipped at planning time as `12-puy-de-lachaud.md`, but the climb summits in seg 13 — the actual seg 12 content was village-anchored (Naves). The arc-agreement checkpoint drove the rename. Pattern: planning-time placeholder titles tend to over-anchor on geographic features at the segment's end (climbs, towns approached) rather than the segment's interior. Worth a retro line on whether seg 13+ placeholders should be deliberately neutral (e.g. `13-segment-13.md`) until the drafter picks the anchor.
+- **Agent harness did not surface AskUserQuestion to spawned agents.** All three checkpoint cycles fired as the agent's final tool-call output (prose), with the orchestrator session collecting answers and re-spawning. Worked but added orchestrator overhead and meant the spawned-agent context window was discarded between cycles. Worth a retro check whether this is harness limitation or strand-spawn shape — and whether `feedback_multi_strand_session_checkpoints.md` should sharpen on what "publisher-paced" means under this constraint.
+
+### Seg 12 pre-publish session (2026-05-12 evening, PR #558 open)
+
+Counts:
+
+- **PRs opened: 2** ([#557](https://github.com/gneeek/tdf26/pull/557) close-out artifacts; [#558](https://github.com/gneeek/tdf26/pull/558) pre-publish corrections).
+- **Files written: 1** (`content/entries/12-naves-coming-home.md`).
+- **Footnotes added: 1** (`[^remembrement]`) + 1 renamed/rewritten (`[^naves-reading]`, replacing `[^naves-bocage-as-argument]`).
+- **MDC directives added: 2** (`::inline-figure{...}` for the Cummins retable, `::street-view-embed{...}` at the descent bottom) + 1 (`::video-embed{...}` for the Viaduc du Pays de Tulle drone view).
+- **Images sourced: 6 candidates → 5 gallery + 1 inline.** All CC-licensed, all Naves (Corrèze) confirmed (publisher-flagged two wrong-Naves source URLs that were Ardèche, not Corrèze; both caught at review).
+- **Embeds added: 3** (1 street-view, 1 YouTube video, 1 inline figure).
+
+Pattern observations worth a retro line:
+
+- **`ajv-formats` local dep mismatch surfaced during pre-publish validators.** `npm test` failed to load `tests/data/schemas.test.ts` because `ajv-formats` (listed in `package.json` at `^3.0.1`) was missing from `node_modules`. The 144 actual tests still passed, but the suite-load failure reads as a CI red light. Root cause: `node_modules` had drifted out of sync with `package-lock.json`, likely from prior agent work that left the local install partial (no dep change was made in this session — the dev server kept running fine because it loaded `ajv` proper, not `ajv-formats`). Fix was a single `npm install` (added 34, removed 35, changed 105 packages) and the suite returned 208 passing. Worth a retro line on whether the pre-publish validator chain should pre-flight a lockfile/install check (e.g. `npm ci --dry-run` or equivalent), so the next publisher does not waste a moment doubting their content before they realise the failure is environment-state, not entry-state.
+- **Wrong-Naves disambiguation took two surprise iterations.** Two of the publisher's candidate sources (one tourism URL, one YouTube video) were about Naves in Ardèche, not Naves in Corrèze. The disambiguation cost was small per instance (a single WebFetch confirming "Cévennes" / "Ardèche" in the title) but compounded: the publisher came back twice with Ardèche-Naves material before reaching a Corrèze-Naves video. Worth a retro line on whether segment briefs should pre-emptively flag commune-name collisions (other Naves, other Beynat, other Tulle, etc.) so the publisher's source-hunt narrows from the start.
+- **Streetview + video embeds were tractable inside the pre-publish window.** Both `::street-view-embed` and `::video-embed` directives already exist in the codebase (used in seg 5-11). The publisher pasted raw iframe markup; converting to the MDC directive shape was a one-edit pattern-match. Reinforces: embed infrastructure does its job; the bottleneck is sourcing, not implementation.
+- **Inline-figure-out-of-gallery move was a clean publisher-driven editorial step.** Publisher asked late in the session to promote one of two retable images from the gallery into an inline figure beside the retable paragraph. The pattern (remove from images JSON array, add `::inline-figure{...}` with full attribution, leave the alternate retable image in the gallery) was mechanical once decided. Worth a retro line on whether the strand-brief template should mention "inline-figure-vs-gallery placement" as an editorial decision class so it surfaces at first-draft-review rather than at pre-publish.
+
+### Seg 23-27 verification strand (#500 close, PR #556 open 2026-05-12)
+
+Counts:
+
+- **PR opened: 1** ([#556](https://github.com/gneeek/tdf26/pull/556) — closes #500; also closes #503 inline via the Paris-Corrèze re-key).
+- **Issues filed: 3** ([#553](https://github.com/gneeek/tdf26/issues/553) CLAUDE.md staleness — 26-seg claim + Meymac/Ussel area-section seg numbers; [#554](https://github.com/gneeek/tdf26/issues/554) GPX polyline ends 216 m short of Place Voltaire; [#555](https://github.com/gneeek/tdf26/issues/555) Côte des Gardes — fourth instance of "declared summit km past actual GPX peak" class).
+- **Claims audited:** ~20 (GPX integrity ×5, Meymac seg, Abbaye Saint-André seg, Côte des Gardes gradient + actual elevation peak, Côte des Gardes town-coords coord, Saint-Angel proximity + priory MH, La Feuillade/L'Empereur rejection, Ussel coord + town-positions km, Avenue Thiers bounds, Place Voltaire OSM, four Ussel attractions cluster, Paris-Corrèze re-key, 2026 Stage 10 keying, Ussel never a TdF stage town, Mont Bessou cross-check).
+- **Bugs found: 12.** Landed: 9 (Côte des Gardes coord 814 m off, Aigle Romaine coord ~400 m off, Musée du Pays d'Ussel coord, Chapelle des Pénitents coord, Marché d'Ussel km/distance drift, Ussel coord = route-entry not centre, Saint-Angel village absent, Saint-Angel priory absent, Paris-Corrèze keyed to wrong segments). Filed (3): #553, #554, #555.
+- **Files written: 5** (`data/attractions.json`, `data/historical-tdf.json`, `data/segments.json`, `data/town-coords.json`, `data/town-positions.ts`) + 2 memory files (`project_meymac_voice.md` retargeted seg 24 → seg 25, `MEMORY.md` index entry).
+- **External sources cited: ~10** (OSM Nominatim ×6: Place Voltaire, Musée, Chapelle, Avenue Thiers, Saint-Martin, Saint-Angel; Wikipédia ×2: Saint-Angel commune, Place Voltaire context; Overpass API; cyclingstage.com 2026 Stage 9 finish; the #502 tour-history-research.md dossier).
+- **AskUserQuestion checkpoints fired: 1** (bundled two questions: scope expansion to seg 27 + Côte des Gardes coord write-set fit; both publisher-recommended options accepted).
+- **Brief errata caught mid-strand: 2** (§1 "26 segments" — publisher caught and pushed a mid-strand correction; §5 step 3 "Côte des Gardes seg 24" — caught by reading source-of-truth before acting).
+- **Scope expansion mid-strand: +1 segment** (seg 27, Ussel finish, originally not in brief).
+- **Wall-clock:** ~2 hours from spawn to PR open.
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-verify-500` to be removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+Pattern observations worth a retro line:
+
+- **Fourth instance of the climb-coord-vs-points-config-summit-km bug class.** Lachaud (#477) + Naves (#490/#515) + Mont Bessou (#499) + Gardes (#500). The #499 retro line proposed a per-source-of-truth assertion for this class (`feedback_parallel_source_of_truth_detector.md`); after four instances in a row, that proposal has moved from "candidate v1.4.20 work" to "clearly worth filing as a real assertion". Worth a retro line on whether four-in-a-row is enough to promote the assertion-write into v1.4.19 (rather than v1.4.20 deferral). #555 specifically covers Côte des Gardes; a separate v1.4.19 issue for the assertion would carry the cross-instance argument.
+- **Brief-content-as-carryforward fired twice in one strand — once caught by the publisher mid-strand, once caught by the agent before acting.** `feedback_brief_content_is_carryforward.md` predicted this; the two instances were the strand's two largest factual errata. Worth a retro line on whether brief authors should run the audit script against the in-scope segs as a brief-prep step — the segment-count and seg-24-vs-25 errors would have been caught in 30 seconds at brief-write time.
+- **Town-coords convention (= town centre) was invisible until the audit script's drift report exposed it.** The convention is only documented per-entry in source-note strings (e.g. Saint-Augustin "Coord = bourg centre per OSM"); there's no file-level header explaining it. The Ussel entry violated the convention silently (coord was the route-entry point) until town-positions.ts km vs town-coords coord disagreed. Worth a retro line on documenting `data/town-coords.json` schema conventions in a file header, similar to how `data/town-positions.ts` already does.
+- **"Cluster of attractions sharing one wrong coord" is a new bug shape.** Four Ussel attractions originally shared the same coord ~(45.548, 2.311); three of four were OSM-correctable individually. The cluster pattern means single-attraction audits miss the systemic question — the audit-script's per-row drift report catches each entry independently but doesn't notice the shared-coord smell. Worth a retro line on whether to add a clustering check ("flag if N attractions share a coord within X m, especially if they describe distinct buildings").
+- **Strand brief contained a stale segments.json segment count, but CLAUDE.md had the same staleness — and the staleness has been there since commit 4a6bdaf ("Fix odd/even segment lengths - odd=8km, even=6km (#249)")**. The brief was a downstream symptom of an unsurfaced upstream drift. #553 filed against CLAUDE.md specifically. Worth a retro line on whether CLAUDE.md should be subject to a periodic narrative-vs-data drift check (e.g. once-per-milestone grep for "26 segments", segment-number references, etc.).
+- **Audit-script's pre-existing finding handed to the right strand cleanly.** Mont Bessou drift on seg 23 was present in this strand's audit, but the fix was already in flight on PR #550 (#499 strand). Pattern: cross-strand pre-existing findings can be left as a no-op with a PR-body cross-reference, rather than re-filing or re-fixing. Worth a retro line on documenting this cross-strand-coordination pattern as a default (vs. the temptation to re-touch the file).
+- **Scope-expansion mid-strand was clean.** Publisher's directive to ask, agent's bundled-question AskUserQuestion, both options recommended-and-accepted. The seg 27 work added ~25 % to the strand load but produced six of the strand's nine landed bugs (Ussel cluster + Place Voltaire endpoint). If the original brief's scope (segs 23-26 only) had held, those bugs would have been deferred to a follow-up; the integrated audit caught more drift than two separate strands likely would have. Worth a retro line on the scope-expansion-when-cheap heuristic and whether it's strong enough to put in the strand-brief template §7.
+
+### Seg 20-22 verification strand (#499 close, PR #550 open 2026-05-12)
+
+Counts:
+
+- **PR opened: 1** ([#550](https://github.com/gneeek/tdf26/pull/550) — closes #499).
+- **Issues filed: 1** ([#549](https://github.com/gneeek/tdf26/issues/549) Sprint - Bugeat km/seg drift in points-config).
+- **Claims audited:** ~15 (GPX polyline integrity ×3, elevation extents ×3, Mont Bessou summit km, Mont Bessou gradient, Mont Bessou town-coords coord, Bugeat keying, 2024 TdF Stage 11 re-keying check, Les Cars wiki link, Stele des Maquisards proximity, Tourbière de Longeyroux, Plateau attractions density, notable_points convention, Sprint - Bugeat keying).
+- **Bugs found: 3.** Landed: 2 (Mont Bessou coord 8.91 km off → realigned to points-config km 152.31; Les Cars wiki slug `Tours_de_Bonneval` → `Ruines_gallo-romaines_des_Cars`). Filed: 1 (#549, out of write set).
+- **Files written: 2** (`data/town-coords.json`, `data/attractions.json`). 4 lines changed total.
+- **External sources cited: 4** (Wikipédia ×2, Tourisme Corrèze, Pérols-sur-Vézère commune site).
+- **AskUserQuestion checkpoints fired: 1** (orchestrator routing decision after sub-agent's permissions narrowed mid-session — see pattern below; 0 inside the spawned agent).
+- **Wall-clock:** ~9 min sub-agent (read-only audit pass) + ~10 min orchestrator (verification of proposed fix, edits, validators, tests, build, PR open) = ~19 min.
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-verify-499` to be removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+Pattern observations worth a retro line:
+
+- **Sub-agent harness permissions narrowed mid-session (new shape of harness instability).** The spawned agent completed a thorough read-only audit pass (Read, Python, WebFetch, `git status` all worked) and then was denied Edit, Write, npm, node, `git commit`, `gh pr create` partway through. Different shape from the seg-12 strand's "AskUserQuestion not surfaced to spawned agents" but same family: harness instability inside long-running spawned strands. The agent recognized the block and stopped cleanly, encoding all findings in a structured handoff that the orchestrator session could land in ~10 min. Pattern: **read-only verification handoff with corrections-as-text** is a viable failure mode when write capability is intermittent — but it depends on the agent recognizing the block rather than retrying. Worth a retro line on whether strand briefs should explicitly name this failure shape ("if you lose write capability mid-strand, stop and produce a structured handoff").
+- **Third instance of the "climb coord ≠ points-config summit km" bug class.** Puy de Lachaud (#477, May 2026) → Naves (#516, May 2026) → Mont Bessou (#499, this strand). Candidate per-source-of-truth assertion (`feedback_parallel_source_of_truth_detector.md`): for every climb in `points-config.json`, the corresponding `town-coords.json` entry's lat/lng should sit within some tolerance (50m?) of the polyline at the points-config summit km. A red-on-broken / green-on-fix test that catches the class instead of one-instance-at-a-time. Worth filing as v1.4.20 candidate.
+- **"Verified empty" pattern held cleanly on Plateau de Millevaches.** The brief anticipated sparse attraction density; the audit confirmed `attractions.json` km 134-154 holds 2 entries plus 1 just outside seg 22 (Tourbière de Longeyroux, km 154.4, keyed to seg 23). The Parc itself is the attraction. Pattern: when the brief names "verified empty" as a valid finding shape ahead of time, the strand doesn't drift into "let me find more attractions to keep busy." Worth a retro line on whether to promote "verified empty as a brief-time anticipated outcome" into STRAND-BRIEF-TEMPLATE.md §5 explicitly.
+- **Cross-check that PR #514 re-keying held.** 2024 TdF Stage 11 was re-keyed from segs 14-16 to seg 22 (Mont Bessou as altitude parallel for Puy Mary). This strand verified the re-keying held cleanly and surfaced no leak-back. Pattern: when a prior PR re-keys data, the next verify-strand in the affected range is the natural verification point. Worth a retro line on whether re-keying PRs should explicitly name "verified next by strand X" in their bodies so the chain is legible.
+- **Audit-script Sprints section has a structural blind spot.** `audit_segment_data.py` Sprints section caught nothing on Sprint - Bugeat because it only checks km-vs-stored-segment internal consistency — both are consistent (km 130 falls in seg 19). The audit has no geometric check that the sprint's name matches a nearby landmark. Filed as part of #549. Per `feedback_assertion_bug_class.md`: before writing an assertion, compute its diagnostic for the bug by hand. The Sprints assertion was written for a different bug class than the one #549 represents.
+
+### Seg 13 drafting strand (2026-05-12 close, PR #560 merged + sibling PR #559 merged)
+
+Counts:
+
+- **PRs opened: 2** ([#560](https://github.com/gneeek/tdf26/pull/560) seg 13 draft, merged 2026-05-12; [#559](https://github.com/gneeek/tdf26/pull/559) sibling polka-dot reword on seg 12, merged 2026-05-12).
+- **Files written: 1 entry** (`content/entries/13-puy-de-lachaud-uncounted.md`, renamed from placeholder via `git mv`) + 1 prose-only edit on seg 12 (`content/entries/12-naves-coming-home.md`).
+- **Word count:** 829 (within 800-1200 target).
+- **MDC directives:** 1 `::press-card{...}` open / 1 close (manual grep matched).
+- **Em-dashes / exclamation marks:** 0 / 0.
+- **Publisher checkpoint cycles fired: 5** (voice register × 2 — initial AskUserQuestion was rejected with "different voice", second round presented edinburgh-review vs tls-essay comparison; arc agreement; mid-draft pattern catches × 4: "X the Y will not Z" shape, internal-data citations in Sources, "the day's" double-use, "hardest climbing" antecedent).
+- **Memory entries added: 4** (`feedback_will_not_shape.md`, `feedback_sources_no_internal.md`, `feedback_interpolated_pr_pattern.md`, `feedback_voice_checkpoint_prep.md`).
+- **Wall-clock from worktree creation to second PR merge:** ~1.5 hours, single orchestrator session (publisher-paced, no spawned sub-agents — the previous strand's harness-instability finding informed this choice).
+- **Cleanup:** both worktrees (`tdf26-seg-13`, `tdf26-seg-12-reword`) removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+Pattern observations worth a retro line:
+
+- **The "X the Y will not Z" shape ran for six entries before publisher caught it.** Seg 6 first instance ("Our four riders will not see Beynat"), then seg 7 (twice), seg 8 subtitle, seg 10, seg 11, seg 12 (twice). The catch fired *mid-seg-13-drafting*, not pre-publish, because the seg 13 strand was about to echo the shape forward. Worth a retro line on whether *cross-entry pattern grep* (run after every entry merges, not just pre-publish) should become a publisher- or agent-side ritual. The grep itself is one line; the value depends on noticing the shape *as* it accumulates, before it becomes a tic.
+- **Five publisher checkpoints fired mid-draft, four were pattern catches the agent had not flagged.** Voice register, arc agreement (the two planned checkpoints) ran predictably. The four pattern catches (shape echo, internal sources, "the day's" repetition, "hardest climbing" ambiguity) were each publisher-side reads that the agent's self-checks did not catch. Worth a retro line on whether the tls-essay self-check list (or a tdf26 project-level self-check list) should grow to include the cross-entry shape grep, an internal-data-citation check, and adjacent-sentence repetition scan. The four catches were cheap to fire mid-draft but would have been four pre-publish iterations if missed.
+- **Sibling-PR pattern (interpolated PR) worked cleanly.** The seg 12 polka-dot reword was authorised mid-strand, opened as a separate branch+worktree off main (`tdf26-seg-12-reword`), validated and merged independently of the strand PR. Memory `feedback_interpolated_pr_pattern.md` captures the pattern. Worth a retro line on whether the pattern should be named in the strand-brief template §7 ("what this strand may NOT touch — *unless authorised as a sibling PR per [pattern]*") so future strands surface the option explicitly when something comes up.
+- **Rebase conflict resolution under substantial main-side evolution had a non-obvious shape.** PR #558 (seg 12 pre-publish, merged before #559) had *kept* the polka-dot sentence but *extended its paragraph* with new content (panneau sentence + street-view embed). The auto-merge produced a conflict that left my entire (now-stale) replacement paragraph as the "incoming" side while main's new context was on HEAD. Correct resolution was to keep main's structure and re-apply the *single-sentence reword* to the surviving polka-dot sentence, not to accept either side of the conflict block verbatim. Worth a retro line on the heuristic: "when rebasing onto evolved main, treat the conflict as 'what was my intent' not 'which side to keep'." Also worth flagging that auto-merge tooling can produce conflicts that misrepresent the actual change set — the agent has to read both sides as a unit.
+- **Voice-register checkpoint required reading register SKILL.md briefs mid-discussion.** Publisher rejected both pre-loaded register options ("different voice"). The agent had not pre-read edinburgh-review/SKILL.md (the only other candidate); a side-by-side comparison required pausing to read both briefs at discussion time. Memory `feedback_voice_checkpoint_prep.md` captures the lesson. Worth a retro line on whether voice-register checkpoints should be reframed as "voice exploration" rather than "voice selection" — survey first, then ask.
+- **GPX upstream source citation surfaced as an unresolved convention question.** The Sources section needed a citation for route geometry / climb metrics that had previously been attributed to internal data files. The agent picked `cyclingstage.com` on the seg-08 precedent; the alternative (letour.fr official route) is also plausible. Worth a retro line on whether to standardise the GPX/route-data source citation across entries — pick one canonical URL, name it in CLAUDE.md or a memory, and apply consistently going forward.
+- **Single-strand publisher-paced mode (no sub-agent spawning) avoided the seg-12 strand's harness-instability findings.** The seg-12 drafting strand's retro line flagged "agent harness did not surface AskUserQuestion to spawned agents" as a friction point. This strand ran entirely in the orchestrator session, no sub-agent spawning, and all five AskUserQuestion checkpoints fired cleanly. Worth a retro line on whether *single-strand drafting* should default to orchestrator-session-only (no spawn), with sub-agent spawning reserved for parallel verification strands where the harness's read-only audit shape is fine.
+
+### Seg 17-19 verification strand (#498 close, PR #552 open 2026-05-12)
+
+Counts:
+
+- **PR opened: 1** ([#552](https://github.com/gneeek/tdf26/pull/552) — closes #498).
+- **Issues filed: 1** ([#551](https://github.com/gneeek/tdf26/issues/551) Côte de la Croix de Pey length/gradient drift, sister of #513 and #549's family).
+- **Claims audited:** ~18 (GPX polyline integrity ×3, km boundaries ×3, elevation extents ×3, Treignac town keying, Madranges on-route position [NEW], Lestards on-route position [NEW], Côte de la Croix de Pey coord vs points-config km, Croix de Pey length/gradient cross-source, attractions ×5 verified clean, Sprint - Bugeat, 2020 TdF Stage 12 corridor crossing, Treignac "Plus Beaux Villages" carryforward claim, 2017 Tour du Limousin Stage 3 Côte de Lestards mention).
+- **Bugs found: 4.** Landed: 3 (Madranges added as on-route town in seg 17, Lestards added as on-route town in seg 19, Côte de la Croix de Pey coord realigned from km 131.83 → km 128.99 / 2.84 km divergence closed). Filed: 1 (#551, out of write set). Corrections: 1 (Treignac is **not** in Les Plus Beaux Villages de France — the carryforward suggesting otherwise was wrong; Treignac is in Petites Cités de Caractère).
+- **Files written: 4** (`data/town-coords.json`, `data/town-positions.ts`, `data/segments.json`, `data/historical-tdf.json`). 34 insertions, 4 deletions.
+- **External sources cited: 8** (Wikipedia EN ×3 — Madranges, Lestards, Treignac; Les Plus Beaux Villages de France official directory; Petites Cités de Caractère official page; mycols.app; correze-decouverte.fr for Croix du Pey heritage cross; cyclingstage.com for 2020 TdF Stage 12 categorisation).
+- **AskUserQuestion checkpoints fired: 0** (auto-mode; no material disagreements rose above the strand's scope-discipline bar — coord-realignment precedent from #477/#490 was decisive, town adds mirrored Saint-Augustin pattern from PR #514).
+- **Wall-clock:** ~1.5 hours total (worktree creation ~17:08, PR open ~17:14 — wall clock — but most of that was research; about 30 min of audit + 30 min of research + 30 min of edit/validate/PR).
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-verify-498` to be removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+Pattern observations worth a retro line:
+
+- **Fourth instance of the "climb coord ≠ points-config summit km" bug class.** Puy de Lachaud (#477) → Naves (#516) → Mont Bessou (#499/PR #550) → Côte de la Croix de Pey (#498/PR #552). The per-source-of-truth assertion candidate from the seg 20-22 strand's retro lines is now four instances strong. Same fix shape every time: realign coord to polyline at points-config summit km. The assertion this is missing would compare `town-coords[climb].lat/lng` closest-approach km to `points-config.climbs[climb].km` within tolerance — drift is the bug. Worth elevating from "v1.4.20 candidate" (seg 20-22's framing) to "filed as v1.4.20 must-have" — the seg 23-26 verification strand (#500) is the fifth opportunity to surface this same bug class, and the cycle should fix the class before the next instance lands.
+- **Carryforward facts in CLAUDE.md are not just stale, they are wrong.** The brief said "verify Treignac as 'medieval bridge, granite town' per CLAUDE.md content notes" — verification confirmed those *narrative* facts but caught a separate carryforward (Treignac as a *Plus Beaux Villages*) that was floating in earlier search results and would have made it into a seg 18 draft if not flagged. Pattern: even when CLAUDE.md is silent on a claim, carryforward facts attached to the *type* of village (medieval, scenic, Corrèze) leak in via web searches. `feedback_brief_content_is_carryforward.md` covers strand-brief specifically; this is a generalization — the *web's* carryforward about a town can be wrong too. Worth a retro line on whether the seg drafting strand should have a "check official designations against the canonical association directory" step alongside the Mérimée check from seg 12.
+- **Re-keying-PR cross-check pattern held cleanly (instance 2).** PR #514 re-keyed 2024 TdF Stage 11 to seg 22; the seg 20-22 strand verified that re-keying. This strand's analog: PR #514 keyed 2020 TdF Stage 12 to seg 15 (Suc au May framing); this strand added a separate `[17, 18, 19]` grouping for the same stage with a Croix du Pey framing. Pattern: when one PR keys a multi-corridor stage to one segment, the next verify-strand in an adjacent corridor benefits from a parallel keying with a different framing rather than re-keying the original entry. Avoids stepping on prior PR's groupings while still surfacing the stage to readers on the new segments.
+- **"Verified empty" pattern held on seg 19 attractions; seg 17 too.** The Plateau de Millevaches gateway was anticipated as sparse per #514's pattern; the audit confirmed seg 19 has zero attractions (the Croix du Pey heritage cross at 620m off-route on a forest path was the marginal candidate, deliberately not added per scope discipline) and seg 17 has zero attractions (Suc au May → Treignac descent corridor of farmland and forest). Third explicit "verified empty" finding (after seg 14-16's Plateau approach and seg 20-22's Plateau proper). Re-elevating seg 20-22 strand's retro-line suggestion: promote "verified empty as a brief-time anticipated outcome" into STRAND-BRIEF-TEMPLATE.md §5 explicitly.
+- **Brief reference to v1.4.20 milestone now stale.** The strand brief at `docs/strands/strand-498-verify-segs-17-19.md` says "Milestone: v1.4.20 (subject to renumbering per Topic 9a)"; the user's spawn prompt corrected this to v1.4.19. Same shape as `feedback_brief_content_is_carryforward.md` — briefs are scaffolding, not bedrock; verify milestone keying against the current state. Low-stakes here (cosmetic), but worth a retro line on whether briefs that reference future milestones should have a "verified against current milestone state on spawn day" note.
+
+## Forward-looking content-prep notes
+
+These are not pending planning decisions — they are content threads for future segment drafting, kept here so the next drafter doesn't have to re-discover them.
+
+### Music threads by segment (originally surfaced 2026-04-26 during seg 7 research)
+
+- **Brassens, "Hécatombe" (1952)** — about a riot at the Brive marché. Brive market hall was renamed "Halle Georges Brassens" because of the song. Best home: any future Brive-flashback in segs 7-onward, or save as canon-knowledge for the stage-finish reflective notes. Segs 1-2 already published (content-change rule blocks retroactive insertion).
+- **Maugein Accordéons, Tulle** — used in seg 10 entry. Logged here for reference. Liquidation September 2024, reopened by an ex-employee March 2025.
+- **Bourrée limousine and "Bourrée des Monédières"** — the bourrée is the regional folk dance form; the Monédières range has a named variant. *Boreïa de las botelhas* / La Bourrée des Bouteilles composed 1950 by accordionist René Lafeuille. Best home: **seg 14 or 15** (route enters Monédières).
+- **Patrick Sébastien** — born Brive 14 Nov 1953, populist TV-singer register. Less literary fit for the project's voice; flag for awareness, not adoption.
+- **Late-19th-c Limousin folk corpus** — e.g. *Sauto tredjo*, *Adiou paure Carnaval*, *Cornovar* (Tulle/Brive 1898 collection). Texture material; no single song specifically marks any segment.
+
+### Geological-transition story deferred from seg 11 (added 2026-05-10)
+
+Seg 11 originally framed the Côte de Naves as the lithological boundary between the Brive sedimentary basin and the Variscan granite of the Limousin basement. Pre-publish scrutiny showed this is wrong: the Brive basin is confined to ~600 km² in southwestern Corrèze, with its boundary fault running through the southwestern corner of the Tulle map sheet — well south of Tulle. The route has been on Massif Central basement since roughly Beynat (seg 5/6); the Côte de Naves is a **topographic** threshold (river valley → plateau), not a lithological one.
+
+Per `feedback_content_change_rule.md`, this is forward-only: do not retroactively place the geology in segs 5/6. Pick the geological-boundary narrative up in a later segment where the geology actually changes — natural homes: a **Plateau de Millevaches segment (18-20)** or **Mont Bessou (seg 22)**.
+
+Sources to reuse for the future drafter:
+- [BRGM Tulle 761 notice](http://ficheinfoterre.brgm.fr/Notices/0761N.pdf)
+- [Bassin sédimentaire de Brive (Université de Limoges)](https://www.unilim.fr/musee_geologique_de_plein_air/geologie-du-limousin/le-bassin-sedimentaire-de-brive/)
+- [Géologie du Limousin (FR Wikipédia)](https://fr.wikipedia.org/wiki/G%C3%A9ologie_du_Limousin)
+
+### Saint-Augustin retable / Duhamel foreshadow gating (added 2026-05-12 from seg 12 strand)
+
+[#547](https://github.com/gneeek/tdf26/issues/547) records a `data/attractions.json` divergence at Saint-Augustin (km 94.52, seg 14): the row claims Pierre Duhamel of Tulle carved a 17th-century retable and cites Mérimée notice PA00099811 (which is actually Château de Ventadour) plus inscription date "28 December 1929" (actual: 25 September 1929). The correct Mérimée notice for the church (PA00099839) mentions neither retable nor Duhamel. Seg 12 originally planned to foreshadow this; the line was dropped at revision time once Mérimée verification flipped the source.
+
+For **seg 14 drafting**: do not assume any Saint-Augustin retable / Duhamel claim until #547 resolves. If #547 confirms a primary-source attribution (different brother, workshop-only, or different artisan entirely), seg 14 picks the thread up directly. If #547 closes by removing the unsupported claim from attractions.json, seg 14 reaches for a different cultural anchor at km 94.52.
+
+Per `feedback_content_change_rule.md`, no retroactive seg 12 edits regardless of #547's outcome.
+
+### Monédières plant landed in seg 13 (added 2026-05-12 from seg 13 strand)
+
+Seg 13 (`content/entries/13-puy-de-lachaud-uncounted.md`, PR #560 merged) plants the Monédières range in two short sentences at the crest of Puy de Lachaud: *The ridges are the Monédières. The stage's hardest climbing is inside them.* Visibility from the upper plateau is named; the range is named; the foreshadow that the stage's hardest climbing lies inside is named.
+
+For **seg 14 drafting**: the Monédières framing work (Bourrée des Monédières, Léon Dautrement's *morceau de Monédières perdu dans le bas Limousin*, Sainte-Fortunade, regional folk-culture beat) remains reserved per dossier — seg 13 deliberately did not do that work. Seg 14 has clean room to develop the framing without coordinating back, and can rely on seg 13 having already (a) named the range, (b) established that "the stage's hardest climbing" is inside it, and (c) handed off the road descending toward the next commune line. The visibility-from-Puy-de-Lachaud-plateau beat is spent and should not be re-planted.
+
+Also reserved for seg 14-16 (per dossier carryforwards, unchanged by seg 13's plant): Sainte-Fortunade by name, the Bourrée des Monédières, Léon Dautrement, the *Bol d'Or des Monédières* criterium, the 2017 Tour du Limousin Stage 3 Chaumeil finish (anchored to seg 14 per dossier), and the Suc au May framing in its climb-specific application (anchored to seg 15).
+
+### Pair-writing disclosure: frontmatter+template approach (deferred 2026-05-07)
+
+Carryforward question deferred at 2026-05-07 Topic 11: should the per-entry pair-writing/voice-register disclosure move from markdown body footer to a frontmatter field rendered by the entry template? Allows consistent styling across entries and decouples disclosure from prose flow. Small Vue layout change.
+
+Decision at 2026-05-07: **forwards-keep, frontmatter-drop** for now — the current body-footer approach works, the frontmatter rewrite is a v1.4.21+ candidate. Logged here for the next time the entry-template area gets touched (e.g. seg 14+ reader-uplift work in v1.4.19).
+
+## Items surfaced during mdc-validator strand execution (2026-05-13)
+
+Strand: `docs/strands/strand-mdc-validator.md`. PR [#563](https://github.com/gneeek/tdf26/pull/563) opened against `main`, closes [#561](https://github.com/gneeek/tdf26/issues/561). One commit on `feature/mdc-validator`.
+
+### Decision-actionable observations
+
+- **No production entries flagged.** Survey across `content/entries/*.md` found 8 entries with MDC blocks (segs 05, 06, 07, 08, 09, 10, 11, 12), all balanced (31 paired blocks total). The validator ships as a forward-trap, not a hotfix for an existing bug. No content edits needed.
+- **Brief named a label that does not exist.** Brief §4 said `infra`; repo has no `infra` label. Filed #561 with `process` + `python` instead. Either add an `infra` label and recategorise process-y issues, or update the strand-brief template / future briefs to use existing labels. Worth a one-line decision at planning.
+- **Existing MDC usage is single-line-attribute shape only.** All current `::name{...}` blocks have all attributes on the opener line and an empty body — `::inline-figure`, `::press-card`, `::street-view-embed`, `::video-embed`. If future entries adopt multi-line block content with slot syntax (`#slotname`), this validator still works for balance but won't validate slot pairing. Out of scope for this strand; flag if/when first multi-line MDC block appears.
+
+### Light-tier pattern observations
+
+- **Parser-extension candidates parked.** Inline-form `:name{...}` validation (attribute syntax, required-attr enforcement) deliberately out of scope per brief §8. The fixtures dir `processing/tests/fixtures/mdc-*` is set up for reuse if a future strand wants inline-form or attribute checks. No issue filed; document the shape exists if/when a maintainability case appears.
+- **Brief-template gap caught in flight.** Brief said "label `infra`" without verifying the label exists. Consider a brief-pre-flight item: "labels named in brief exist in the repo". Pairs with the existing `feedback_brief_content_is_carryforward.md` memory rule.
+- **Validator extends existing CLI cleanly.** No CLI surface change; `scripts/publish.sh` invocation unchanged. The "fail-fast at the front of `main()`" wiring matches the pattern Retro v1.4.18 promoted to heavy-tier unfold (item 1a above). One more instance of the fail-fast pattern, this time pre-render.
+
+### Numeric stats
+
+- Files touched: 4 (`processing/validate_entries.py` +94/-3, `processing/tests/test_validate_entries.py` +139/-0, 2 new fixture files +38/-0). `git diff --stat main..HEAD`: 270 insertions, 3 deletions.
+- Commits on branch: 1.
+- AskUserQuestion checkpoints fired: 0 (auto-mode, no material disagreement).
+- Wall-clock: ~30 minutes from brief read to PR open.
+- Tests: 200 Python (+11 new), 198 JS — all green. Ruff clean.
+
+## Items surfaced during segs-14-16-content-research strand execution (2026-05-13)
+
+Auto-mode strand. PR #565; tracking issue #562. Dossier at `content/research/segs-14-16-block-research.md`.
+
+### Decision-actionable observations
+
+- **#564 filed against `data/attractions.json`.** Musée Chirac description says Chirac is buried in Sarran communal cemetery; he is buried at Cimetière du Montparnasse. Already on v1.4.19; needs a data-strand pickup or inline fix before any seg 14 / seg 15 prose can lean on Sarran adjacency.
+- **Léon Dautrement Sainte-Fortunade quote — verification failed online.** The strand owned the verification; Dautrement himself is well-sourced (Maitron biographical record, SSHAC president 1963-1979) but the specific "morceau de Monédières perdu dans le bas Limousin" quote is not in any web-indexed source. **Recommendation for the publisher: reframe the quote as a seg 9-10 (Sainte-Fortunade-as-geography) carryforward** if and when SSHAC archives or the Tulle BFM library surface a primary citation. Geography-wise the quote belongs to seg 9-10, not segs 14-16; this strand's Monédières block does not need it.
+- **Maquis Roland ground-truth needed.** The seg 14 `Maquis de Chaumeil Memorial` (km 96.76) is almost certainly the Camp Roland stele commemorating Auguste Vangierdegom (first FTP killed in Corrèze, 13-14 July 1943). A ground-truth photo of the stele's dedication is the missing piece before any seg 14 prose names a specific fighter/unit. Worth a publisher visit before seg 14 publish, or a phone call to the Egletons OT.
+- **Anchor allocation recommendation logged in the dossier (open question 9).** Seg 14: Saint-Augustin, Duhamel retable pair with seg 12 Naves, Maquis Roland, massif becoming visible. Seg 15: Chaumeil + Ségurel + Bol d'Or + Bourrée + Suc au May + Jouvenel seg 4 callback. Seg 16: descent + Lestards (if on-route) + 2020 directional inversion. Drafting strands need to confirm/diverge.
+- **Suc au May highest-peak framing must be corrected at draft time.** Suc au May (908 m) is not the highest peak in the Monédières (Puy de la Monédière 922 m), and never was the highest point in Corrèze (Mont Bessou 977 m). Drafters: do not write Suc au May as "highest." Frame as most-named / most-photographed / most-fierce.
+- **Local media tier-1 finding to elevate.** La Vie Corrézienne was founded 1944 by Edmond Michelet (the Brive Resistance figure already in seg 1 corridor material) — a verified cross-corridor callback the seg 14-16 drafters can lean on. Office de Tourisme Ventadour-Egletons-Monédières is the most corridor-specific tourism source. Worth raising at planning whether the local-media-tier-1 finding should be surfaced more durably in CLAUDE.md or unfold.
+
+### Light-tier pattern observations
+
+- **Dossier-shape findings (now that two block dossiers exist — segs 11-13 and segs 14-16).** The dossiers self-stabilise on a shape: cross-segment threads → per-segment → sources → carryforwards → open questions. The seg 11-13 dossier put cross-segment threads at the top *after* the segment sections; this seg 14-16 dossier put them at the very top. Both work; the up-front placement reads better for a drafting strand picking up only its own segment. Worth a planning conversation on whether this is the default shape.
+- **Publisher-added research topic ("local media candidates") integrated mid-prompt.** The user added a new research topic ("look for local newspapers or radio stations or websites … local colour") after the strand had spawned the subagent prompt. The pattern of integrating mid-flight by appending a section to the existing subagent's research scope (rather than spawning a second agent) worked cleanly — the topic landed as section E with its own tier-1/2/3/4 structure. Worth surfacing the pattern: "mid-flight research-scope additions can be appended to the existing single subagent's findings list rather than triggering a parallel call."
+- **Subagent surfaced four corrections to repo / brief assumptions** (Monédières geology, highest-peak attribution, Chirac burial, Bruyères corréziennes year). The "tell the subagent the bedrock and let it correct around it" framing pays off: the corrections came as part of the routine work, not as a separate verification pass.
+- **Brief-template gap caught in flight.** The brief §4 step 2 listed "famous local people" as one bullet across the block. The subagent treated this seriously enough to surface both real candidates (Bergounioux, Roux, Dautrement) *and* tempting confusions (Antonin Malroux is Cantal; Bertrand Levergeois is unverified). Worth adding to the brief template: "expect the subagent to surface candidates that look right but are not corridor — request explicit drop/keep verdicts."
+- **Carryforward issue filed mid-strand** (#564, the Chirac burial in `data/attractions.json`) — the strand-brief scope rule ("if research surfaces a contradiction … file a new issue") fired exactly once during this run. The pattern is cleanly separated: dossier surfaces, separate issue tracks, neither blocks the other.
+
+### Numeric stats
+
+- Files touched: 1 (`content/research/segs-14-16-block-research.md` +330/-0). `git diff --stat main..HEAD`: 330 insertions, 0 deletions.
+- Commits on branch: 1.
+- AskUserQuestion checkpoints fired: 0 (auto-mode, no material disagreement; publisher injected one extra research topic mid-flight which was incorporated without checkpointing).
+- Issues filed during strand: 2 — #562 (tracking, closed by PR), #564 (data carryforward against attractions.json).
+- Wall-clock: ~45 minutes from brief read to PR open.
+- Subagent run: ~11 minutes wall-clock, 61 tool calls, 116k total tokens.
+- Tests: 198 JS pass. `validate_entries.py` + `validate_points.py` pass. No new entries or data touched.
+
+## Items surfaced during 563-mdc-validator-review strand execution (2026-05-13)
+
+Strand: `docs/strands/strand-563-mdc-validator-review.md`. **First dedicated code-review strand** at tdf26. Read-only review of PR [#563](https://github.com/gneeek/tdf26/pull/563) ahead of seg 12 publish. Output: one PR review comment (COMMENTED state, not approve/request-changes) at https://github.com/gneeek/tdf26/pull/563#pullrequestreview-4279742614. **Verdict: SAFE TO MERGE TODAY.**
+
+### Decision-actionable observations
+
+- **Verdict given to publisher.** Risk pass clean on all 8 risks. Documentation drift surfaced: PR body claims `^::[A-Za-z]` regex, actual is `^(::+)[A-Za-z]` (more permissive, accepts multi-colon openers); PR body claims 31 paired blocks, my count is 29 (58 `::`-lines / 2). Neither affects safety; both are PR-body fixes the author can apply or skip.
+- **Three follow-up issues worth filing if the publisher cares** (none required for merge):
+  (a) Tilde-fence (`~~~`) and multi-colon-opener (`:::`) tests — current tests only cover backtick fence and double-colon openers. Current content uses only these forms, so no silent-miss risk today; gap only matters if future content adopts the uncovered shapes.
+  (b) PR body documentation alignment with the actual regex.
+  (c) `scripts/publish.sh:258-259` calls `validate_entries.py` without `--non-interactive`, despite `reference_validate_entries_invocation.md` suggesting it should. Pre-existing, not introduced by #563; a separate cleanup if the publisher wants the publish path strictly non-interactive.
+- **Behavioral expansion worth surfacing in PR description.** The new MDC check runs over **all** non-draft entries every invocation, not just today's. Any unbalanced MDC anywhere blocks the publish, not just in the segment being published. This is correct and intentional, but a future publisher hitting an unexpected halt should know.
+
+### Light-tier pattern observations (first review strand shape)
+
+- **Defensive-review brief shape worked.** The 8-risk explicit list with risks 2 and 3 pre-flagged as "immediate NO-GO if..." gave clear structure for both walking the diff and assembling the verdict comment. The verdict-line-at-top convention reads well — the publisher gets the answer in one line and can drill down into reasoning if they want.
+- **Detached worktree was the right posture.** Read-only review with no write surface; cleanup is one command. Brief's "operate from main checkout OR detached worktree" optionality was useful — the detached worktree let me run the validator against the PR's code without affecting the main checkout's state. Worth promoting "detached worktree for read-only review" into the strand-brief template's filesystem-posture section.
+- **PR-body verification caught real drift.** Per `feedback_brief_content_is_carryforward.md` (PR descriptions are scaffolding), verifying every PR-body claim against running code surfaced two minor inaccuracies (regex shape, pair count). Neither was a blocker, but the practice paid off — would have missed both reading the PR body alone.
+- **Adversarial case enumeration before verdict.** Walking through nested blocks, multi-colon openers, code-fence-protected markers, embedded braces, and multi-line attributes before saying "safe" felt like the load-bearing risk-4 work. Brief's "compute the diagnostic by hand against adversarial inputs" (`feedback_assertion_bug_class.md`) is the operative memory here. Worth keeping in the review-strand template.
+- **Verdict comment, not approve/request-changes.** Brief's explicit "do NOT use `--approve` or `--request-changes`" framing meant the comment landed as advisory; the publisher decides. This separation read clean and respected the publisher's authority over the merge gate.
+- **Brief template gap (review-strand shape):** the existing template assumes implementation strands. The §5 "Workflow" section worked for review with the 8-risk explicit list, but the §10 "Stop when" check should explicitly include "review comment is COMMENTED state, not APPROVED/CHANGES_REQUESTED" if review strands become a regular pattern. Worth a planning decision on whether to add a review-strand variant to STRAND-BRIEF-TEMPLATE.md or to extend the existing template with a posture flag.
+
+### Numeric stats
+
+- Files touched in repo: 0 (read-only review, by design).
+- Output artifacts: 1 PR review comment (~3.5KB), 1 update to this file.
+- AskUserQuestion checkpoints fired: 0 (auto-mode, brief explicit "the verdict itself is the synchronization point").
+- Commands run against PR branch: ~12 (gh pr view/diff, validator runs against 3 dirs, pytest, grep, fixture inspection, seg 12 cross-branch checks).
+- Wall-clock: ~25 minutes from brief read to comment posted.
+- Tests: 20 validate_entries + 200 full Python suite — all green. npm test not run (PR touches only Python; no JS surface affected).
+
+## Items surfaced during 541-328-stats-temporal-coupling strand execution (2026-05-13)
+
+Auto-mode code strand. PR [#566](https://github.com/gneeek/tdf26/pull/566); Closes #541, #328. Cut-over: held until publisher reviews (publisher's call per §5 step 1 checkpoint).
+
+### Decision-actionable observations
+
+- **Brief misstated the rounding rule.** Strand brief §8 said "banker's-up via `round_half_up` is the standard expectation, matches the seg 11 hotfix." Verified by hand against snapshot-11.json: the hotfix values (Nan/Wally 53/2026-07-03 from a raw 53.5) only match `math.floor`, NOT `round_half_up(53.5)=54`. Picked `floor` and documented the discrepancy in the PR body. A clean instance of `feedback_brief_content_is_carryforward.md` — verifying the brief's load-bearing factual claim against source data caught it. Worth raising whether the brief author's intuition was wrong (i.e. should the rule have been round_half_up and the hotfix re-done?) or whether the brief slipped (hotfix is right, brief wrong) — currently I assumed the latter.
+- **Live `stats.json` / `points.json` now respect dataCutoff.** Before this fix, publish.sh ran stats.py and calculate_points.py uncapped (no dataCutoff), then snapshot_stats.py re-ran them with the cutoff for the snapshot only. Pages that consume the live (non-snapshot) artifacts may show different numbers post-merge — possibly the rider dashboard on the homepage. **Worth a planning check before merge:** confirm which UI surfaces read `data/riders/stats.json` directly vs. `data/riders/snapshots/snapshot-NN.json`, and whether the live artifacts agreeing with the snapshot is the desired behaviour. If consumers expect "live = current state including post-publish days," this is a behaviour change.
+- **publish.sh dataCutoff resolution moved earlier.** Was between Step 2 (points) and Step 3 (snapshot); now happens before Step 1 (stats). Mechanical move within "wiring is in scope, reshape is not" — the TTY prompt and frontmatter-write logic are preserved verbatim. Surfacing in case it changes anyone's mental model of the script.
+- **snapshot_stats fail-loud is a behaviour change at the API.** Calling `create_snapshot(..., data_cutoff="...")` without `rider_config_path` now raises. Existing test suite was already passing both, and publish.sh passes both, so no in-tree callers break — but any out-of-tree call site (cron job, ad-hoc script) that relied on the silent fallback will fail loudly on first run after merge. That is exactly the desired outcome per #328 acceptance criteria, but worth knowing in case the planning session has a sense of out-of-tree callers.
+
+### Light-tier pattern observations
+
+- **Snapshot-as-regression-fixture pattern.** The seg 11 snapshot's frozen `log` field (now in git via PR #542) was used as literal input to a regression test that re-runs the stats pipeline and asserts byte-equal output to the snapshot's own stats/points. This is a tidy pattern for the stats pipeline specifically — the snapshot is both the assertion target and the input fixture, no separate fixture file needed. Worth noting as a candidate pattern for future stats-pipeline regressions and possibly other "publish-frozen output" surfaces.
+- **Parallel-source-of-truth detector landed concrete instance.** Per `feedback_parallel_source_of_truth_detector.md`, the carry-over capping logic was duplicated between `rider_stats.py` and `calculate_points.py`. Resolved by extracting `capped_daily_distances()` into rider_stats and importing it from calculate_points. Both #448 (per-source assertion) and #516 (existing instance) are named in the memory; this is the third named instance and the resolution shape (extract + import) was clean. Worth mentioning at planning whether the memory should grow to list these resolutions explicitly.
+- **Test config gap.** `processing/tests/` requires `PYTHONPATH=.` to import `processing.*`, but no conftest.py or pyproject.toml `testpaths` entry sets it. The parent worktree's `nohup`/CI runs presumably set it elsewhere. Not a blocker, but a fresh worktree needs to know — worth adding a `[tool.pytest.ini_options]` block to pyproject.toml or a conftest.py that adjusts sys.path. Low-priority cleanup.
+- **node_modules / .venv symlinks in fresh worktrees.** Bringing up the worktree required symlinking node_modules and processing/.venv from the parent. This is mentioned in `feedback_ci_seed_ordering.md` for `data/riders/*.json`, but the node_modules + .venv recipe isn't documented anywhere I can find. Worth adding to the strand-brief template's filesystem-posture section, or extending `feedback_strand_worktree_path.md`.
+
+### Numeric stats
+
+- Files touched: 6. `processing/rider_stats.py` (+62/-15), `processing/calculate_points.py` (+25/-11), `processing/snapshot_stats.py` (+44/-7), `processing/tests/test_rider_stats_temporal.py` (+178/-0, new), `processing/tests/test_snapshot_stats.py` (+34/-0), `scripts/publish.sh` (+33/-18). Total: 376 insertions, 51 deletions.
+- Commits on branch: 1.
+- AskUserQuestion checkpoints fired: 1 (the mandatory cut-over checkpoint at strand start, per §5 step 1).
+- Wall-clock: ~50 minutes from brief read to PR open.
+- Tests: 196 Python pass (+7 new — 5 temporal + 2 snapshot fail-loud), 198 vitest pass, `validate_points.py` + `validate_entries.py` clean.
+
+## Items surfaced during seg-13 pre-publish + publish work (2026-05-17)
+
+Publisher-paced session, single continuous conversation. Branch `feature/seg-13-pre-publish` merged as PR [#572](https://github.com/gneeek/tdf26/pull/572) → squash `46ab916`; publish.sh frontmatter merged as PR [#573](https://github.com/gneeek/tdf26/pull/573) → `98e1841`; release `W20-seg13` tagged at 16:42Z, deployed to OVH. Substantively reshaped the entry's opening with publisher photographs and a Paris-meta editorial section.
+
+### Decision-actionable observations
+
+- **Seg 13 forecloses a Paris-19th editorial aside in seg 14.** The seg 13 entry's editorial opening (Bassin de la Villette banner, OSFS aside locating the conference inside la Rotonde de la Villette, paragraph on la Rotonde / Mur des Fermiers généraux / 19e history) closes with a foreshadow promising more Paris-19th content (photographs, notes) in segment 14, on the basis that the publisher is in Paris for the whole OSFS week. The seg 14 drafting strand brief (`docs/strands/strand-seg-14-drafting.md`) does not currently anticipate this; the opening editorial section is pre-committed by the seg 13 promise. The brief should be updated before spawn — or the spawning session told at brief time — so the seg 14 strand knows what the foreshadow obliges. Promise is intentionally open-ended ("more photographs, more notes"), so the strand still has latitude on specifics.
+
+- **Editorial colour about real places needs ground-truth, not vibe.** Mid-session I introduced the phrase "in a quiet annex of the same city" to locate the OSFS; the publisher caught it: "is 'quiet annex' the right framing for the 19th arrondissement?" The 19th is one of the most densely lived-in arrondissements (working-class, multicultural, the Bassin de la Villette as active public space) and "quiet annex" was just wrong. The publisher's checkpoint shape — "I am not saying it is not, I am genuinely unsure" — was useful: it forced a substantive answer rather than a defence or capitulation. Pattern worth a memory: editorial colour claims about real-world places should be ground-truthed; when ground-truth is uncertain, hedge or omit.
+
+- **Cross-segment foreshadow is a new coupling shape.** The seg 13 editorial section makes a forward-looking promise about seg 14 content. Strand briefs currently model what an entry _owns_ and _reserves_; they do not model what an entry _promises_ for the next. The promise creates an obligation the next strand has to discover by reading the previous entry, which is fragile. Worth a planning conversation about whether the strand-brief template should grow a "promises inherited from earlier entries" section that the spawning script populates.
+
+- **Publisher-supplied local photos worked first-time with existing components.** Seg 13 was the first entry to ship photos from `public/images/segment-NN/` rather than Wikimedia URLs (four Paris photos taken by Justin). Both `::inline-figure` and `ImageGallery.vue` handled local paths transparently; the convention sketched in CLAUDE.md works in practice. New pattern likely to recur — implications for the publish workflow (image-rights checks for self-hosted vs upstream-attributed shift) and for the project's CC BY-SA 4.0 content license, which the photos inherit by virtue of being committed to the content repo.
+
+### Light-tier pattern observations
+
+- **Wikimedia geosearch is ineffective for sparsely-photographed corridors.** Seg 13 covers upper-Naves climb into the granite-plateau approach — no architecturally-named on-route site. Coordinate-based geosearch returned mostly off-route content (Corrèze village 5 km east, Bar hydroelectric plant, Saint-Salvadour church). The on-route candidates surfaced from text-search on named features (Monédières, Vimbelle, "Chamboulive paysage") and from sibling-commune categories. `processing/suggest_images.py` currently only does geosearch; text-search supplementation would help for segments without a named site.
+
+- **Banner-via-inline-figure pattern.** The project has no `banner` frontmatter field; `::inline-figure` immediately after the H1 functions as one. Used by seg 9 (Tulle_banner.JPG) and now seg 13 (canal-bassin-villette.jpg). Stable convention; possibly worth documenting in the entry-format section of CLAUDE.md so future strands stop asking for a banner field.
+
+- **`## Back to <region>` H2 as register-shift demarcator.** Publisher-suggested header (`## Back to Corrèze`) to mark the boundary between the Paris-meta italic editorial opening and the body's tls-essay scholarly voice. Effective and reusable — if the meta-opening pattern recurs in segs 14-15, the equivalent H2 should mark the body's start there too.
+
+- **Disclosure footer can carry a register-shift sub-clause.** When an entry has mixed register (italic editorial aside + body), the disclosure footer line grew a sub-clause flagging "the editorial opening above the first body paragraph is in a personal-aside register, outside the body's voice." Small evolution of the disclosure practice from `project_disclosure_practice.md`; the terminology there was already flagged as provisional.
+
+- **Sources section absorbed the Paris claims without restructuring.** Added one consolidated bullet listing four `fr.wikipedia` references (la Rotonde / Mur des Fermiers généraux / 19e / Bassin de la Villette) alongside the existing Corrèze bullets. The single-bulleted-cluster format (one bullet per topic, multiple URLs inside) holds at this density; no need for sub-headings yet.
+
+### Numeric stats
+
+- Files touched: 5 tracked (content/entries/13-puy-de-lachaud-uncounted.md plus 4 image files in public/images/segment-13/). ~22 insertions, 4 deletions in the markdown source.
+- Commits on the pre-publish branch: 7 (consolidated as squash `46ab916`). publish.sh added 1 more (`98e1841`).
+- AskUserQuestion checkpoints fired: 0. Session ran conversationally; the publisher drove every editorial decision directly.
+- Wall-clock: ~4 hours across one continuous session.
+- Tests at close: `validate_entries.py` green, MDC blocks balanced, 51 routes prerendered, deploy + tag + release all 0-exit.
+
+## Items surfaced during 564-chirac-burial strand execution (2026-05-24)
+
+Auto-mode small data-correctness strand. Brief at `docs/strands/strand-564-chirac-burial-fix.md`. PR [#585](https://github.com/gneeek/tdf26/pull/585) merged 2026-05-24 (merge commit a332cba). Closes #564.
+
+### Decision-actionable observations
+
+- **Sister factual issue surfaced and filed as [#586](https://github.com/gneeek/tdf26/issues/586).** The Musée Chirac entry also says "opened June 2000" but the segs 14-16 dossier and fr.wikipedia.org/wiki/Musée_du_président_Jacques-Chirac agree the Wilmotte building opened **15 December 2000**. Kept out of #585's scope per the single-entry-fix discipline; filed as a sibling issue describing the problem only. Worth a planning decision on whether to bundle #586 with #476 (audit-trail metadata) since both touch the same row, or run #586 as its own small fix.
+- **Same dossier-flagged-error workflow shape held a second time.** The seg 14-16 dossier (#562 strand) flagged the Sarran-burial error, filed #564, and this strand resolved #564 cleanly with the dossier-prescribed framing. The dossier-as-issue-source pipeline is now two instances clean (#564 fixed, #586 filed). If a similar pipeline runs on later dossiers (segs 17-19, 20-22, 23-26), worth naming the shape explicitly in the strand-brief template's §7 cross-strand section.
+- **No audit-trail metadata exists on attractions entries.** Brief §5 step 4 anticipated `verified` / `lastVerified` / `source` fields per #476 conventions. The Chirac entry has only a `source` field (free-form string already pointing at Wikipédia + a 2026-05-07 verification date). I did not update the source string ad-hoc per the brief's guidance — but the next time a strand touches an attraction, #476's design will need to decide whether to overwrite the free-form `source` string or supplement it with structured fields. Worth surfacing at planning when #476 spawns.
+
+### Light-tier pattern observations
+
+- **Single-clause-correction strand is a clean shape.** No checkpoints, ~30 min wall-clock, one-line diff. The brief's "recommended-fix language is in the issue body and is mechanical to apply" framing held literally — the only judgment call was prose length (current was 71 words, my replacement is 95 words; +28% but the disambiguation of the October 2019 ceremony was load-bearing for reader comprehension). Worth naming "single-clause-correction" as a strand shape distinct from "single-entry-fix" in the brief template if more of these recur.
+- **Prose-length budget can be overrun for disambiguation cost.** Brief said "do not lengthen materially"; I exceeded the implicit budget because the correction has to (a) replace the assertion, (b) add the actual burial location, and (c) explain the 2019-ceremony confusion that readers familiar with the funeral coverage would otherwise wonder about. Reader-comprehension argument trumped tight-length argument. Worth a retro line on whether brief authors should size length budgets to "minimum-coherent" rather than "near-original" for correction strands.
+- **Production-build-bundle grep is a cheaper reader-surface spot-check than booting dev.** Brief §6 called for a dev-server spot-check across seg 13/14/15 pages. The build had already been run for verification; grepping `.output/public/_nuxt/*.js` confirmed the new "Cimetière du Montparnasse" text was in the shipped bundle and "Sarran communal cemetery" count was 0 — equivalent evidence in seconds. The dev-server boot attempt errored on pkill timing anyway. Worth a retro line on promoting "production-bundle grep as reader-surface confirmation" into the strand-brief template's §6 verification section as a substitute for dev-server boot on data-only changes.
+- **Branch verification ritual held with no surprises.** Per `feedback_shared_tree_branch_verification.md`, ran `git branch --show-current` immediately before commit. Branch was `feature/564-chirac-burial` as expected. No drift surfaced — but the ritual is cheap and would have caught a shared-tree leak.
+
+### Numeric stats
+
+- Files touched: 1 (`data/attractions.json` +1/-1).
+- Commits on branch: 1.
+- AskUserQuestion checkpoints fired: 0 (auto-mode, brief explicit "no checkpoints — apply mechanically").
+- Issues filed during strand: 1 ([#586](https://github.com/gneeek/tdf26/issues/586) sister factual issue).
+- Wall-clock: ~35 minutes from worktree creation to PR open; PR merged within ~30 minutes after.
+- Tests at close: `validate_entries.py` green, 198 vitest tests passing, `npm run build` green, production bundle contains corrected text.
+- External sources verified: 1 (fr.wikipedia.org/wiki/Jacques_Chirac — Sépulture infobox + biographical body for Bity / Bernadette councillor).
+
+## Items surfaced during 535-entry-card-thumbnails strand execution (2026-05-24)
+
+Publisher-paced reader-uplift strand. Brief at `docs/strands/strand-535-entry-card-thumbnails.md`. PR [#587](https://github.com/gneeek/tdf26/pull/587). Closes #535.
+
+### Decision-actionable observations
+
+- **AskUserQuestion option-rejection signal.** The visual-review checkpoint was rejected with "user wants to clarify" rather than answered. The publisher's clarification (carnyx for seg 11, drop archive density) was substantive but did not fit any of the four prepared options — it was a combined override+layout call. Worth a feedback memory: when a checkpoint's option set fails to admit the publisher's actual answer, that's evidence the options were too binary, not that the publisher is being awkward. Re-fire with a different shape rather than asking what to clarify.
+- **Manifest manual-override pattern is reusable.** The `"manual": true` flag on a manifest entry preserves it across script re-runs. Same shape would work for any auto-generated-with-overrides data file (rider-stats edge cases, points-config category overrides, etc.). Worth naming as a pattern in a planning conversation if a second instance appears.
+- **Build-time heuristic is heavier than the design checkpoint suggested.** The option description said "no author burden, but heuristic correctness is a moving target." The reality also included: new Python deps (Pillow, requests, PyYAML — all already on system but newly required in requirements.txt), Wikimedia Commons API integration with batching and rate limiting (initial naive download approach got 429'd on every request), and a portrait-vs-landscape rejection rule that surfaced after the first run picked a portrait sign for seg 4. Worth a feedback memory: when presenting design options in a checkpoint, include the hidden complexity (network dependencies, API limits, dep additions) not just the visible cost (lines of code). My initial sketch undersold the build-time-heuristic option by ~3x in implementation effort.
+- **Panorama images are systematically rejected by the 3:2 target.** Seg 14 has a "Saint-Augustin Panorama" image at ratio 2.04 that lost to a 1.51-ratio château because the heuristic targets exactly 3:2. The publisher accepted the pick, but this is a heuristic-tuning question worth a planning conversation: should the cost function be `abs(ratio - 1.5)` (current, biased against panoramas) or a sigmoid that accepts wider ratios up to ~2.5 with equal weight? Or should the manual-override path handle panoramas explicitly? Files: `processing/pick_entry_thumbnails.py` line 90 (TARGET_RATIO).
+
+### Light-tier pattern observations
+
+- **Square cards penalize landscape images.** The card surface is a `w-20 h-20` square; `object-cover` center-crops landscape images, losing ~33% of width for a 3:2 image and ~67% for a 3:1 panorama. The "most landscape" heuristic is therefore optimizing for "least content lost in square crop" implicitly. Worth a retro line on whether the card aspect should change (rectangular cards would let panoramas shine and reduce the heuristic's tradeoff).
+- **Wikimedia 429 surfaced as 100% of fetches failing after the first.** Initial naive `requests.get` for each image URL got rate-limited immediately. Switching to the MediaWiki imageinfo API (batched up to 50 titles per call, with a 1s inter-batch sleep) succeeded entirely. Pattern for any future Commons-dimension work: use the API, not direct file fetches. Worth caching as a reference memory.
+- **Strand brief's "publisher-paced cadence" works well for reader-uplift strands.** Two AskUserQuestion checkpoints (design + visual review) gave the publisher real control without slowing the work between them. The brief's framing — "design checkpoint and visual review checkpoint; implementation steps in between are not checkpointed" — was correct; mid-implementation surprises (Wikimedia 429, portrait bug, panorama tradeoff) were narrated as text rather than checkpointed, which preserved publisher visibility without stalling.
+- **Manifest-with-objectPosition-pass-through composes cleanly.** PR #540's `objectPosition` per-image field worked transparently with the new manifest lookup — when the manifest picks an image with `objectPosition` set (e.g., seg 11 carnyx), the cropping signal flows through to the rendered card unchanged. No code changes needed to preserve the PR #540 feature; the brief's §3 guidance ("compose with `objectPosition`, not replace it") was satisfied by the manifest pointing at the existing image rather than copying its fields.
+
+### Numeric stats
+
+- Files touched: 6 (2 new — `processing/pick_entry_thumbnails.py` + `data/entry-thumbnails.json`; 4 modified — `components/EntryCard.vue`, `pages/entries/index.vue`, `processing/requirements.txt`, `.gitignore`). 330 insertions, 4 deletions.
+- Commits on branch: 1 (single squashed commit).
+- AskUserQuestion checkpoints fired: 2 prepared (design + visual review); 1 cleanly answered (design = heuristic); 1 rejected-then-answered-conversationally (visual review).
+- Wikimedia API calls: 1 batched query of 50 image titles, returning dimensions for ~32 unique Wikimedia images across 13 entries.
+- Wall-clock: ~90 minutes from worktree creation to PR open.
+- Tests at close: 198 vitest tests passing, `validate_entries.py` green, `npm run build` succeeded, dev preview confirmed by publisher.
+
+## Items surfaced during 513-suc-au-may-points-config strand execution (2026-05-24)
+
+Strand: `docs/strands/strand-513-suc-au-may-points-config.md`. PR [#592](https://github.com/gneeek/tdf26/pull/592) opened against `main`, closes [#513](https://github.com/gneeek/tdf26/issues/513). Auto-mode, one publisher checkpoint fired (bundled category + gradient).
+
+### Decision-actionable observations
+
+- **Fifth instance of "data fix invisible to readers because parallel rendering source exists" pattern.** Filed [#588](https://github.com/gneeek/tdf26/issues/588) — `components/StageDetails.vue` has a hand-coded `CLIMB_DETAILS` lookup with `length` + `gradient` for every categorised climb, disagreeing with `data/competition/points-config.json` on every climb's gradient (and Côte de Miel's length is off by 4.2 km). The seg 15 entry page still displays "7.7%" after this strand's data fix because the rendering reads from `StageDetails.vue`, not from `points-config.json`. Worth planning-time discussion on whether #588 is v1.4.19 or v1.4.20 — the data-vs-display divergence undermines the value of data-correctness strands generally.
+- **Brief contained a wrong canonical fact (points scale).** Strand §3 cited the official polka-dot scale (`Cat 2: [5,3,2,1]`, etc.) as the constraint on the points array, but the project actually uses its own custom 4-position rider-competition scale (`Cat 2: [6,4,2,1]`, derived by formula rank-1 = 2 × (5 − category)). The brief's polka-dot scale would have over-corrected; the strand caught the discrepancy by reading existing climbs before applying the fix. Another fresh instance of `feedback_brief_content_is_carryforward.md`. Worth a retro line on whether brief authors should grep existing data before citing a "scale" or "convention" as canonical.
+- **Issue body misquoted its primary source.** #513's body said "Tourisme Corrèze (official 2026 Stage 9 announcement) | Cat 4 (or Cat 3)". WebFetch of that page found the page explicitly says **Cat 2**. The misquote propagated to the brief's option set. Worth a retro line on whether issue bodies that cite external sources should require a verbatim quote (not a paraphrase) so the misquote risk is structurally lower.
+- **Publisher's gradient choice (7.7%) was vetoed by a pre-existing project invariant.** `tests/utils/climb-gradient.test.ts` enforces ±0.3pp absolute between declared gradient and GPX-derived gradient over the declared span. 7.7% vs GPX 7.07% = +0.63pp, fails. Reverted to 7.1% (unchanged from pre-fix). The publisher's editorial preference (7.7% per CLAUDE.md narrative) is preserved in the published intro entry's prose, but not in the data layer. Worth a planning-time check on whether the data layer and narrative layer should both carry 7.7% (requires also touching `length_km` or loosening the invariant) or whether the split (data=7.1, narrative=7.7) is acceptable.
+
+### Light-tier pattern observations
+
+- **Category↔points scale assertion has a known blind spot — the original bug.** New `validate_category_points_scale()` enforces field-pair consistency, but the pre-fix Suc au May (`HC + [10,8,6,4]`) was internally consistent under the project's extrapolated HC scale, so the assertion would not have caught the original bug. The bug class the assertion targets is "future drift when someone changes one field without the other"; the bug class that needed catching (wrong category label on a self-consistent pair) requires an external authority (ASO categorisation). Documented in the new test class docstring. Per `feedback_assertion_bug_class.md`, working the diagnostic out before writing the test prevented an "assertion that passes against the bug it was written to catch."
+- **The brief's red-green expectation in §6 ("demonstrate it fires red against the pre-fix [10, 8, 6, 4] + HC state") was unmeetable because of the diagnostic gap above.** Worth a retro line on whether brief-writers should think about "what scale defines drift here?" before naming the red-green expectation. Briefs that demand red-on-pre-fix tend to drive towards the polka-dot scale even when it would over-correct existing data.
+- **Project's custom scale was discoverable by grep across existing data in ~30s.** No code defined the scale; it was implicit in 9 hand-edited climb entries. The discovery would have moved the brief into a more accurate framing. Worth a retro line on whether briefs that touch a "scale" or "convention" should include the grep result in §3 (source-of-truth posture) as evidence.
+- **The interpolated-PR-pattern decision was easy because the cost was low.** StageDetails.vue is one file with one lookup; expanding scope would have meant 9 climb entries and risked rendering regressions on every published entry. Following `feedback_interpolated_pr_pattern.md` was straightforward. Worth a retro check on whether scope-discipline cost is predictably low when the parallel source is internal-only (no reader-facing prose change).
+
+### Numeric stats
+
+- **Files touched: 3** (`data/competition/points-config.json` +3/-3; `processing/validate_points.py` +37/-0; `processing/tests/test_validate_points.py` +58/-0). Total diff: 98 insertions / 2 deletions.
+- **Commits on branch: 1.**
+- **AskUserQuestion checkpoints fired: 1** (bundled 2 questions: category + gradient).
+- **Issues filed: 1** (#588 StageDetails parallel-source).
+- **External sources fetched: 4** (Tourisme Corrèze official page, Le Dico du Tour Suc au May col page, Actus Limousin Stage 9 announcement, Le Dico du Tour 2026 stage 9 page; one WebSearch + four WebFetch).
+- **Wall-clock from worktree creation to PR open: ~50 min.**
+- **Tests at close:** 213 Python (+5 new), 198 vitest, ruff clean, `npm run build` succeeded. Dev spot-check confirmed (and surfaced #588).
+- **Brief errata caught mid-strand: 2** (polka-dot scale wrong; #513 body misquoted Tourisme Corrèze category).
+
+## Items surfaced during 518-summit-km-assertion strand execution (2026-05-24)
+
+Auto-mode code/test strand. Brief at `docs/strands/strand-518-climb-summit-km-assertion.md`. PR [#594](https://github.com/gneeek/tdf26/pull/594) opened against `main`, closes [#518](https://github.com/gneeek/tdf26/issues/518). Two AskUserQuestion checkpoints fired (initial tolerance choice + diagnostic-informed window refinement).
+
+### Decision-actionable observations
+
+- **Of the five named carry climbs, 2 fire red at the chosen tolerance/window** — Puy de Lachaud (#590) and Côte de la Croix de Pey (#591). Naves passes cleanly, confirming PR #516. Two others (Mont Bessou, Côte des Gardes) pass below the 10m / 0.35km threshold (Mont Bessou +0.21km/+0.2m; Côte des Gardes -0.25km/+0.3m). The v1.4.19 retro's "five-instance carry" framing overstates the count at this tolerance; the actual data-fix backlog from this assertion is 3 climbs, not 5.
+- **A sixth, previously-unnamed climb fires red: Côte de Lagleygeolle (#589).** Same Naves-class drift signature (Δkm +1.41, Δelev +27m). Not flagged in any prior retro or planning session; surfaced only because the assertion ran across all spanning climbs uniformly. Reinforces the parallel-source-of-truth detector pattern's value — assertions catch instances the human survey missed.
+- **Tolerance + window precedent set for future assertions of the same shape:** km-tolerance 0.35 (just above the 0.31km sample-resolution floor on `data/elevation/segment-*.json`), elevation-tolerance 10m, asymmetric window `[summit-length_km, summit+1.5]`. The asymmetric upper-pad was the load-bearing design decision — the diagnostic-by-hand exercise (per `feedback_assertion_bug_class.md`) showed symmetric ±length_km windows cross into adjacent terrain on this stage (climbs 5-20km apart, length_km up to 7km). Worth referencing if a future assertion checks summit km on another data layer (e.g. town-coord vs polyline-closest-approach, the v1.4.20 candidate from the seg 17-19 and 20-22 retros).
+- **Three follow-up issues filed: #589 (Lagleygeolle), #590 (Lachaud), #591 (Croix de Pey).** All skip-listed in `tests/utils/climb-summit-km.test.ts` with TODO refs in the test title; remove from `KNOWN_FAILING` map when each fix lands. Worth scheduling these into v1.4.19 closeout or v1.4.20 at planning.
+
+### Light-tier pattern observations
+
+- **By-hand diagnostic before writing the assertion caught the window-design blind spot.** The brief's initial pseudocode used `[summit-length_km, summit+tolerance_km]` (narrow asymmetric, padding = the assertion's tolerance). My first AskUserQuestion presented "Moderate symmetric ±length_km" as the recommended option — symmetric was structurally wrong for this terrain, but I would not have caught it from the brief alone. Running a throwaway diagnostic script against current data surfaced the blind spot in ~5 minutes. `feedback_assertion_bug_class.md` was the operative memory here; the cost of catching late (a wrong design merged) was avoided cheaply. Worth keeping the by-hand-diagnostic-before-checkpoint discipline.
+- **AskUserQuestion fired twice — initial tolerance, then a refinement after diagnostic.** The brief's §8 said "AskUserQuestion fires at tolerance + only re-fires if step 6 hits a red climb." My second fire was about window-design *and* red-climb handling bundled — partly within scope (red climbs), partly a deviation (window-design framing critique). Worth a retro line on whether "diagnostic surfaced a framing critique on the original checkpoint" should be an explicit re-fire trigger in the brief template, alongside red-climb encounters.
+- **Test-file factoring: extracted shared helpers to a new `tests/utils/_track.ts`** with leading-underscore convention to keep vitest from treating it as a test file (the include pattern is `tests/**/*.test.ts`). Reused by `climb-gradient.test.ts` (existing) and `climb-summit-km.test.ts` (new). Worth naming as a convention if more shared test helpers appear.
+- **Skip-list with TODO refs is a reusable pattern for "assertion lands first, data fixes follow" sequencing.** New `KNOWN_FAILING` map in the test file routes failing climbs to `it.skip` with the follow-up issue number in the test title. Each follow-up PR removes its entry. Same shape would work for any per-source-of-truth assertion that ships ahead of its data backlog.
+- **Red-demo via temporary points-config edit + revert worked cleanly.** Naves's km reverted to pre-fix 76.59, assertion fired with the exact predicted diagnostic ("Δkm +0.86, Δelev +31.3"), reverted before commit (`git diff` confirmed empty). Worth keeping as the standard red-green demonstration shape for data-vs-derivation assertions.
+
+### Numeric stats
+
+- **Files touched: 3** (`tests/utils/_track.ts` +47/-0 new; `tests/utils/climb-summit-km.test.ts` +75/-0 new; `tests/utils/climb-gradient.test.ts` +15/-48 refactor). Total diff: 137 insertions / 48 deletions.
+- **Commits on branch: 1.**
+- **AskUserQuestion checkpoints fired: 2** (tolerance choice + diagnostic-informed window refinement bundled with red-climb handling).
+- **Issues filed during strand: 3** (#589 Lagleygeolle, #590 Lachaud, #591 Croix de Pey).
+- **Wall-clock:** ~50 minutes from worktree creation to PR open.
+- **Tests at close:** 204 vitest pass + 3 skipped; `python3 processing/validate_points.py` green; `npm run build` green.
+- **Brief errata caught mid-strand: 1** (the §5 pseudocode's narrow-asymmetric framing — corrected to symmetric initially in the first checkpoint, then refined to asymmetric-upper-pad-1.5km via diagnostic in the second).
+
+## Items surfaced during dependabot-sweep strand execution (2026-05-24)
+
+Auto-mode strand. Brief at `docs/strands/strand-dependabot-sweep.md`. Eight PRs in scope at spawn (#574, #567, #579, #581, #582, #575, #576, #583); seven merged (5 singletons + Nuxt pair landed via combined PR #575 + regenerated bundle PR #595), two closed-redundant (#576 subsumed by the #575 combine; #583 auto-closed when `@dependabot rebase` triggered recreate as #595 minus the redundant nuxt bump). Zero held. One new dependabot PR opened during the sweep — **#593 (ws + engine.io-client paired bump)** — was scope-expanded in-session by publisher direction at the close-out report and merged (lockfile-only, CI green, no local re-test needed; same singleton rubric as #574/#567/#579/#581/#582). Eight total merged, zero open dependabot PRs post-sweep.
+
+### Decision-actionable observations
+
+- **Paired-dep cascade resolution required local combine — `@dependabot rebase` and `@dependabot recreate` both failed on the nuxt 4.4.4 → 4.4.6 cluster.** Root cause: nuxt 4.4.6 pulls `commander@13.1.0` transitively but `@nuxt/nitro-server@4.4.4` in main still pinned `commander@11.1.0`. Rebase/recreate operate on the original package update set in isolation, so neither could pull in the sibling nitro-server bump. Brief §5 step 6 bucket (c) is the correct triage for this shape; the local-combine remedy worked in one shot (run `npm install` with the head's package.json bumps, push the regenerated lockfile back to the dependabot branch, CI green on next run, squash-merge resolves both PRs). Worth a retro line on whether bucket (c) is a *common-enough* shape for nuxt-class ecosystem bumps to be the **first** thing tried on any nuxt PR with red CI (skipping the cheap rebase/recreate dance). Hypothesis: yes, because nuxt and `@nuxt/nitro-server` bump in lockstep upstream every release.
+- **Dependabot auto-regenerates the bundle PR when `@dependabot rebase` is invoked after a sibling singleton lands that overlaps a bundle entry.** Asking #583 to rebase (post nuxt-pair merge) closed #583 and opened #595 with 5 packages instead of 6 (nuxt bump dropped because main already had 4.4.6). Brief §5 step 4 anticipated this in principle ("dependabot should auto-rebase to remove the duplicate bump") but did not anticipate the *new-PR-number* mechanism. Worth a brief-template update: §10 stop conditions and §5 checkpoint wording should account for "the bundle PR may be recreated with a new number" so the publisher checkpoint references the *current* PR rather than the spawn-time number.
+- **better-sqlite3 12.10.0 postinstall (the PR #446 retire-Module-did-not-self-register rebuild) worked cleanly on the combined bundle.** No issue to file. Confirms the postinstall rebuild step is robust across patch-level better-sqlite3 bumps.
+- **@nuxt/content 3.14.0 is purely additive (new `useSearchCollection` FTS5 composable; new `NOT IN` SQLOperator type; custom-properties on `ContentConfig`).** Existing project usage (`queryCollectionSearchSections`, content fs-watcher) unchanged. No breaking-change pattern to surface.
+
+### Light-tier pattern observations
+
+- **Manual cost was *not* low on this sweep — the routine-vs-manual decision input shifts.** The v1.4.10-retro question was "if manual cost stays low, recurring routine is overhead." This sweep was 2h wall-clock with one paired-dep cascade requiring a local combine + push, one bundle auto-regeneration into a new PR number, one AskUserQuestion checkpoint, and one drift-induced rebase loop on #575. None of those are routine-automatable shapes — they need adjudication. The case for routine-promotion *weakens* here, not strengthens. The shape worth promoting (if any) is a *pre-flight* that flags Nuxt-class paired-dep PRs and recommends a local combine before trying rebase/recreate; the merging itself stays manual.
+- **Sibling strands' merges visibly moved main mid-sweep.** Between merging singletons and the Nuxt pair, sibling strands #513 (PR #592) and #564 (PR #585) landed; #518 (PR #594) and #535 (PR #587) landed before the bundle checkpoint. Each main move forced a dependabot rebase on the next-in-queue PR. Pattern: the sweep's serial-merge pacing absorbed sibling-strand drift cleanly because each PR was small and lockfile-only — but if a sibling strand had touched `package.json` or `package-lock.json`, this sweep would have hit cross-strand collisions. Brief §7 was right to mark dependabot as the sole writer of those files for the sweep's window; worth keeping that invariant as a planning-time scheduling constraint when dep-sweeps run alongside content/data strands.
+- **Fresh worktree missing rider-seed data caught at `npm run build`, not earlier.** `feedback_ci_seed_ordering.md` predicted this exactly; the seed step (`cp data/riders/*.example.json data/riders/*.json`) is now part of the dep-sweep workflow's local-build verification. Worth promoting into the strand-brief template §2 or §6 as a *fresh-worktree pre-flight* line so future strands that hit `npm run build` don't surface the same trip-step.
+- **Production-preview gotcha hit on the seg-15 spot-check.** Running `node .output/server/index.mjs` (SSR runtime) failed with `ERR_MODULE_NOT_FOUND: vue/index.mjs` per the known nitro packaging path issue; switching to `nuxt generate` worked cleanly. `feedback_production_preview.md` already documents this; the dep-sweep flow should default to `nuxt generate` for any post-merge build spot-check rather than reaching for the SSR runtime first.
+- **Seg-15 spot-check substituted with seg-14 because seg-15 is `draft: true`.** Static generation filters drafts; the spot-check's intent (confirm Nuxt Content 3.14 still renders) was satisfied by the most-recent-published entry instead. Worth a brief-template note: post-merge spot-checks should target *the most recent published entry*, not a specific segment number, to avoid hitting draft-filter surprises.
+- **Post-report publisher scope-expansion to #593 was zero-friction.** The brief's "no scope expansion" rule (§8) was right as a default — it kept the strand bounded — but the close-out report's "flagged for next planning" line gave the publisher a natural decision point with full context (PR title, type, sweep-state). Choosing to merge in-session cost one additional minute (CI check + diff inspection + merge) and saved a planning-session cycle. Worth a retro line on whether "report scope-adjacent candidates at close-out, let publisher choose" should be promoted from accidental practice to brief-template §8 default — turns scope discipline into a *bounded* default with a structured escape valve.
+
+### Numeric stats
+
+- **PRs merged: 8** (#574, #567, #579, #581, #582, #575 [combined with #576 via local lockfile regen], #595 [regenerated from #583], #593 [scope-expanded post-report, lockfile-only paired bump]).
+- **PRs closed-redundant: 2** (#576 subsumed by combined #575; #583 auto-closed by dependabot when it recreated as #595).
+- **PRs held: 0.**
+- **Open dependabot PRs post-sweep: 0.**
+- **AskUserQuestion checkpoints fired: 1** (bundle #595 review). Publisher-directed scope expansion to #593 fired outside the brief's checkpoint set (handled inline at close-out report).
+- **@dependabot commands issued: 3** (rebase ×2 on #575 and #583; recreate ×1 on #575).
+- **Local commits pushed to dependabot branch: 1** (lockfile regeneration on #575 to resolve commander cascade).
+- **Wall-clock: ~2 hours** from worktree creation (10:00 UTC) to post-sweep build complete (~12:05 UTC).
+- **Local validations at close:** `npm ci` clean (1208 packages), `npm test` 204 pass + 3 skipped, `npm run build` green (81.1MB / 22.9MB gzip output), `nuxt generate` prerendered 53 routes, `validate_entries.py` green, `validate_points.py` green, seg-14 static render 61KB with correct title + h1.
+
+## Items surfaced during segs-17-19-content-research strand execution (2026-05-24)
+
+Auto-mode strand. Dossier at `content/research/segs-17-19-block-research.md`. Mirrors the shape of the seg 11-13 (PR #501) and seg 14-16 (PR #559) precedents.
+
+### Decision-actionable observations
+
+- **Seg 19 stub title "Bugeat — Gateway to Millevaches" is a threshold-framing title, not a literal-location title.** Bugeat town centre is 8086 m off the seg-19 polyline at the seg-19/20 boundary, then 3245 m off at the seg-20/21 boundary, then **24 m off at the seg-21 polyline at km ~144**. Bugeat is therefore properly a seg 21 town. The drafter for seg 19 must know this — Lestards (12 m off polyline at km 131.6, thatched-roof church of Saint-Martial) is the dominant on-route landmark; Bugeat is the foreshadow. Either keep the threshold-framing title (preferred by the dossier) or revise the stub at planning.
+- **"Sprint - Bugeat" at km 130 in `data/competition/points-config.json` sits ~16 km before Bugeat town centre.** Either (a) align with the "Sprint - Before Tulle" naming precedent (sprints can be named for upcoming towns), or (b) rename to "Sprint - Lestards" since the route is 12 m off Lestards at km 130. **Recommended issue title:** *Sprint name "Sprint - Bugeat" in points-config sits 16 km before Bugeat town centre; clarify naming convention*. Not yet filed (publisher to decide framing).
+- **`data/attractions.json` "Pont de la Tourmente" at Treignac is not a documented bridge name.** Wikipedia / Monumentum / Mairie de Treignac document Vieux Pont (1285), Pont Finot (1822-24), Pont Bargy (1840). "Pont de la Tourmente" did not surface in any consulted source. **Recommended issue title:** *attractions.json: Pont de la Tourmente at Treignac is not a documented bridge name; verify or revise*. Not yet filed.
+- **Treignac Plus Beaux Villages status is historical, not current.** Treignac joined PBVF 1989, **lost the label 2008**, currently holds the **Petite Cité de Caractère®** label. **Recommended issue title:** *If attractions.json references Treignac as Plus Beau Village, correct to Petite Cité de Caractère (label lost 2008)*. Not yet filed (publisher to verify whether the data references the wrong label).
+- **`data/historical-tdf.json` — 2017 Tour du Limousin Stage 3 should also key to seg 18 and 19.** Currently keyed only to seg 15 (Chaumeil finish). The same stage climbed "Côte de Lestards" en route — the same climb as 2026's Côte de la Croix de Pey (Inner Ring 2020 preview is explicit: "Côte de la Croix de Pey is 98% of the Col de Lestards"). **Recommended issue title:** *historical-tdf.json: 2017 Tour du Limousin Stage 3 keyed only to seg 15; also crossed segs 18-19 via Côte de Lestards*. Not yet filed.
+- **`data/attractions.json` optional addition for seg 17 drafter consideration: Madranges Protestant temple (1900).** Small but real Wikipedia-FR-documented feature; an upland Corrèze Protestant temple inaugurated 11 March 1900, designed by Adolphe Augustin Rey (Paris-trained, social-housing architect). Optional.
+- **Croix de Pey climb drift — alignment, no new issue.** Three readings surface as expected: points-config 7.0 km @ 4.4% (Cat 3); mycols 6.4 km @ 5.1%; 2020 ASO 3.8 km @ 6.1%. Already covered by **#551** (length/gradient drift) and **#591** (summit-km drift). Both open; drafter writes climb on its road shape, not on a categorisation figure. No new issue.
+- **Lestards-vs-seg-16-vs-seg-19 question — closed.** Lestards is firmly seg 19 (12 m off polyline at km 131.6). The seg 16 dossier's "borderline" flag was a working hypothesis that is now resolved. `town-coords.json` carries the verified position (updated 2026-05-12 under #498).
+- **Treignac Maquis specific-fighter / stèle attribution unresolved.** Treignac sits inside the **Maquis du Limousin** operational area (Guingouin/Royer command) and the **Treignac–La Celle camp-organising sector** is documented for May 1943 (Wikipedia EN, *Maquis du Limousin*). No specific named fighter or stèle on the seg 18 polyline surfaced in the dossier round. Drafter for seg 18 writes the corridor identity without poaching the Bugeat-specific names that anchor seg 21.
+- **Anchor allocation recommendation (logged in dossier's open-questions section 12).** Seg 17: Madranges-as-upland-Protestant-outlier + Treignac approach + Vézère catchment threshold. Seg 18: Treignac medieval bourg + Lachaud-Sangnier-Tapissier triple-anchor + Vieux Pont 1285 + clocher tors + 2020 directional inversion + kayak heritage + "Granite and Water" frame. Seg 19: thatched-roof Saint-Martial de Lestards + Plateau threshold + cuisine shift + "Côte de Lestards" naming-history beat + Bugeat as foreshadow. Drafters confirm or diverge.
+
+### Light-tier pattern observations
+
+- **Third instance of the block-research-then-N-drafts technique.** Segs 8-10 (v1.4.10), segs 11-13 (PR #501), segs 14-16 (PR #559), now segs 17-19. The shape is stabilising: cross-segment threads at top → per-segment sections with six fixed headers → data reconciliations → carryforwards → sources → open questions. Worth a planning conversation on whether this is now the **default** shape for block research dossiers (and whether the §10 stop conditions in the strand template should bake in the open-questions section, which has emerged as voluntary practice across all three dossiers).
+- **The dossier surfaced a content-and-data finding inside the same pass.** The Bugeat town-centre / seg-21-not-seg-19 finding came out of the verification step before the subagent spawned (my own GPX polyline check), and re-anchored the dossier's framing of seg 19. The pattern: verification of brief-reported facts at strand start can change the framing the subagent works from. The brief's "verify which side of km 134 the Bugeat town centre sits" question turned out to be 16 km off, not a few hundred metres.
+- **Subagent surfaced major figures the brief did not name.** Edmond Tapissier (Treignac-born painter-decorator, 1861-1943), Charles Lachaud (Treignac advocate of the Lafarge affair, buried Treignac), Marc Sangnier (Treignac family-house and burial). The "tell the subagent the bedrock and let it correct around it" framing continues to pay off; the brief did not name any of these and they are the segments' three best famous-people anchors.
+- **Two same-climb-different-name confirmations landed in one round.** "Côte de Lestards" and "Côte de la Croix de Pey" confirmed as the same climb via Inner Ring 2020 preview. Useful for both historical-tdf.json housekeeping (the 2017 TdL Stage 3 cross-reference) and as a writable naming-history beat for the drafter.
+- **Source URL spot-check found one transient 503** (monumentum.fr/...PA00099910). Cited URL flagged inline; not removed. The dossier follows the convention from `feedback_sources_section.md` — list it, flag the failure, let the drafter re-check.
+- **No AskUserQuestion fired.** Auto-mode held cleanly; no material disagreement surfaced that required publisher arbitration.
+
+### Numeric stats
+
+- Files touched: 1 (`content/research/segs-17-19-block-research.md`, 301 lines, +0/-0 modifications).
+- Commits on branch: 1.
+- AskUserQuestion checkpoints fired: 0.
+- Issues filed during strand: 0 (recommended issue titles captured in the dossier's "Data reconciliations" section and above; planning files them).
+- Subagent run: ~23 minutes wall-clock (`duration_ms: 1401920`), 42 tool calls, 139k total tokens. Above the seg 14-16 dossier's 11 minutes / 116k tokens — the corridor's depth (Treignac's multi-anchor cultural set + climb naming history + Bugeat town-centre verification) drove a longer run.
+- Wall-clock from brief read to PR open: ~50 minutes.
+- Tests: `validate_entries.py` green (research dossier doesn't touch entries). `npm test` not run (no `node_modules` in research worktree; dossier-only branch, no JS or data changes). Source URL spot-check: 9/10 reachable, 1 transient 503 flagged inline.
+
+## Items surfaced during tour-history-corridor-expansion strand execution (2026-05-24)
+
+Auto-mode data-population strand. PR [#601](https://github.com/gneeek/tdf26/pull/601); closes #527. Branch `feature/527-tour-history-corridor` (worktree `/home/jhs/code/tdf26-tour-history-2`). Strand brief at `docs/strands/strand-tour-history-corridor-expansion.md`.
+
+### Decision-actionable observations
+
+- **HistoricalContext schema has no `source` field.** The component (`components/HistoricalContext.vue`) renders `year`, `stage`, `route`, `description` (+ optional `videoUrl`/`videoTitle`) — `description` is plain-text mustache interpolation. Per `feedback_sources_no_internal.md` the dossier-cited external URLs do not live in the data file; they live in the dossier and the PR commits. The strand made that explicit. Worth a planning line on whether to add a `source` field to the schema (one canonical external URL per event, displayed as a small "source" link below the description) so the reader can verify a claim without leaving the page. Low-stakes but real.
+- **Two existing entries had ad-hoc "re-keyed from X to Y in PR #N" prose embedded in the description string.** The Paris-Corrèze entry (re-keyed [25,26,27]→[15] in #500) and the 2024 Stage 11 entry (re-keyed segs 14-16→[22] in #478) both carry their re-key audit trail inline in the description that the reader sees. That trail is useful internally (it's how I knew not to duplicate Paris-Corrèze in this strand) but reads as agent-debug content to a non-developer. Worth a planning line on whether to either (a) lift the audit-trail prose into a structured `notes` or `_provenance` field that's hidden from rendering, or (b) accept it as small-cost internal documentation that future readers will skim past.
+- **No `data/schemas/` dir exists yet.** The strand brief's §6 named optional schema validation (`jsonschema -i data/historical-tdf.json data/schemas/historical-tdf.schema.json`) — that file does not exist. Per #561 / PR #563's MDC-validator precedent, a JSON Schema for `historical-tdf.json` would catch a future contributor (or AI strand) adding entries with the wrong shape. Worth a planning line on whether this is worth a strand or just a 30-minute commit during a future planning session (per the slip-rate-tally pattern from 2026-05-12).
+
+### Light-tier pattern observations
+
+- **First dossier-to-data-file workflow instance.** Research strand (#502 / PR #526) → carryforward checklist in dossier + umbrella tracker issue (#527) → data-population strand (this one, #601). Cleanly separated: research was creative, this was mechanical. The umbrella tracker's checkbox list was the directly-usable input — no re-discovery needed. The dossier's Verification log + Carryforwards section made it trivial to know what was verified (skip) vs what needed re-verification (cross-check). The handoff shape worked. Pattern: research strand should always carry forward an explicit checklist + verification log so the data-population strand can be auto-mode and short.
+- **Moderate-scope checkpoint pre-loaded the right defaults.** The brief said "Default recommendation: Moderate" with a concrete entry count ("~15-25 entries"). The publisher accepted Recommended; the strand landed 19. The pre-loaded default removed the need for a multi-question deliberation. Pattern: scope-ceiling checkpoints work best when the brief author has already counted the candidate set and the recommendation matches it.
+- **Three substantive cross-checks vs the dossier landed during writing.** Bernard Thévenet's abandonment year (dossier had it right but easy to misplace into the 1973 stage), Festina expulsion timing ("the morning of the ITT" → "the previous evening" per known 1998 history), Arvis Piziks identity (dossier said "Piziks" only). None of these were dossier errors — they were precision-tightenings that fired because writing the reader-facing prose forced specificity the dossier did not. Pattern: reader-facing-prose-as-verification-pass is its own verification mode that the dossier-write step does not produce.
+- **Commit-batching to "5-10 entries per commit" worked.** Four data commits (5/7/5/3 entries) plus two dossier commits (session-3 log + PR-number fix). Each commit is reviewable as a scan-the-diff exercise. Pattern: numerical commit batching ("N entries") works as a brief-time discipline; the resulting diffs are reviewable without summary.
+- **PR number forward-reference fired again.** Brief §10's retro inputs section said to write the PR number into `project_next_planning_notes.md` at close — and the session-3 dossier log also referenced a PR number. I had to guess the PR number (used `#581` as placeholder) and fix it in a follow-up commit once the actual number (`#601`) landed. Pattern: any artifact written before PR-open that references the PR number needs a fix-up commit after `gh pr create`. Worth a one-line discipline note in the strand-brief template §5: "if you write artifact text referencing this PR's number before `gh pr create`, queue a sed/fix commit after the PR opens." (Alternative: write the placeholder as `PR #TBD` and grep before commit to confirm zero remaining instances — possibly cleaner than guessing a near-future number.)
+
+### Numeric stats
+
+- **PR opened: 1** ([#601](https://github.com/gneeek/tdf26/pull/601)).
+- **Files written: 2** (`data/historical-tdf.json` +129/-1; `content/research/tour-history-research.md` +44/-17 across two commits).
+- **Entries landed in `historical-tdf.json`: 19.** Across 3 existing groups (extended) + 3 new groups (created). Total events in file before: 14; after: 33.
+- **Commits on branch: 6** (4 data + 2 dossier — one log-append + one PR-number fix).
+- **AskUserQuestion checkpoints fired: 1** (scope-ceiling; publisher selected Recommended).
+- **External cross-checks during writing: 3** (Thévenet abandonment year, Festina expulsion timing, Arvis Piziks identity). All from general knowledge / dossier re-read, no external WebFetch needed.
+- **Validators run:** `validate_entries.py` green; `npm test` 27 files / 198 tests green; `npm run build` green; `npx nuxt generate` 53 routes; spot-check rendering confirmed via grep on prerendered HTML (seg-1 + seg-2 pages contain new 1969 Matignon entry).
+- **Wall-clock:** ~50 minutes from worktree spawn to PR open.
+- **Entries landed per hour:** ~23 (19 entries over ~50 min) — useful baseline for future research-then-realise pairs.
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-tour-history-2` to be removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+## Items surfaced during 586-chirac-museum-date strand execution (2026-05-24)
+
+Auto-mode small data-correctness strand. PR [#605](https://github.com/gneeek/tdf26/pull/605); closes #586. Branch `feature/586-chirac-museum-date` (worktree `/home/jhs/code/tdf26-586`). Strand brief at `docs/strands/strand-586-chirac-museum-date.md`. Sister to #564 (PR #585) — same Musée Chirac entry, different factual claim.
+
+### Decision-actionable observations
+
+- **French Wikipedia URL named in the issue + the brief 404s.** Both `fr.wikipedia.org/wiki/Musée_du_président_Jacques-Chirac` (hyphen) and `..._Jacques_Chirac` (underscore) returned 404 from `WebFetch`. The English Wikipedia article and the segs 14-16 research dossier both independently name 15 December 2000, so the date is well-attested, but the canonical-source URL we keep citing in `data/attractions.json`'s `links` array and source notes may be stale. Worth a planning line on whether to audit `data/attractions.json` for dead Wikipedia URLs — the `links` array for this same entry still points at `fr.wikipedia.org/wiki/Musée_du_président_Jacques-Chirac` which currently 404s. Could be a one-off (FR Wikipedia renamed the article) or a wider symptom.
+- **Sister-fix pattern landed cleanly twice in one day.** #564 (PR #585, this morning) + #586 (PR #605, this afternoon) — same entry, two separate single-clause fixes, opened as sequential strands rather than bundled. Strict single-entry-fix discipline held both times. Worth a planning line on whether this two-strand approach is the right default for "fix-the-museum-entry" work, or whether the second strand should have been folded into the first under a "while-we're-here" exception. The strands cost ~15 min each; the discipline gain (clean separation, reviewable diffs, atomic closure) is real but small.
+
+### Light-tier pattern observations
+
+- **Sub-15-minute audit-and-fix wall clock, mostly env setup.** Strand brief read → file edit → tests → PR open: ~15 min total (most of which was `npm ci` + `npm test` + `npm run build`). The actual edit was one line; verification was the bulk. Pattern: small-data-fix strands are environment-setup-bound, not edit-bound. The fresh `tdf26-586` worktree had no `node_modules` and needed `npm ci` (~20s, 1208 packages) + seed-rider-data step before `npm test` and `npm run build` could run. Per `feedback_ci_seed_ordering.md`, the seed-rider-data step has to come after `npm ci`. Worth a one-line discipline note: small-data-fix strands should pre-flight the env setup at the top of the work, not interleave it with the audit.
+- **Stale local-main bit me at the source-of-truth read step.** The strand worktree was created from `tdf26`'s `main` which was 4 commits behind `origin/main` (including merged PR #585). Reading `data/attractions.json` from the pre-rebase state showed the *pre-#585* burial line ("Sarran communal cemetery") rather than the post-#585 corrected text the brief assumed. I caught it by checking `git log --oneline -20 data/attractions.json` for PR #585 and seeing it absent — then `git fetch origin main && git rebase origin/main`. Pattern: when a strand brief says "verify post-PR-#N state" and the source-of-truth read disagrees, the first hypothesis should be "local main is stale," not "the brief is wrong." Worth a one-line discipline note: sibling/sister strands should rebase on `origin/main` before reading the source-of-truth file.
+- **One-conditional-checkpoint design held — the checkpoint did not fire.** Strand brief §5 step 2 allowed one AskUserQuestion if sources disagreed on the opening date. Sources (English Wikipedia, issue body, segs 14-16 dossier) all converged on 15 December 2000; no checkpoint fired. Pattern: explicit single-conditional checkpoints in otherwise-auto strands are cheap to specify in the brief and often go unused — they exist to keep the strand from stalling without publisher input when contention surfaces, not because contention is expected.
+- **Wilmotte project page (`wilmotte.com/projets/musee-president-chirac/`) says "Année: 2006".** Did not contradict the 15 December 2000 opening — likely refers to a later extension or expansion phase. Flagged in PR body for transparency. Pattern: architect-firm project pages tend to date their own engagement, not the building's first opening; cross-check against museum/Wikipedia for the inauguration date specifically.
+
+### Numeric stats
+
+- **Files touched: 1** (`data/attractions.json`, +1/-1, single sentence).
+- **Commits on branch: 1.**
+- **AskUserQuestion checkpoints fired: 0** (auto-mode, sources converged).
+- **External sources cited: 3** (English Wikipedia, Wilmotte project page, segs 14-16 research dossier).
+- **Validators run:** `validate_entries.py` green; `npm test` 28 files / 204 passed + 3 skipped; `npm run build` green (production output 81.1 MB / 23 MB gzip).
+- **Wall-clock from brief read to PR open: ~15 min** (including `npm ci` + `npm test` + `npm run build`).
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-586` to be removed post-merge per `feedback_strand_session_self_cleanup.md`.
+
+## Items surfaced during seg-16-drafting strand execution (2026-05-24)
+
+Strand spawned but held immediately. Publisher decision: hold and close out, resume after seg 15 lands. Findings posted as comment on tracking issue [#596](https://github.com/gneeek/tdf26/issues/596).
+
+### Before spawning the next seg-16 session
+
+Two prerequisites must both be true before the next seg-16 session is launched. The session itself cannot satisfy them — they sit at the planning/spawning layer.
+
+1. **Revise `docs/strands/strand-seg-16-drafting.md` to drop the Lestards-as-central-anchor framing.** The brief currently lives in the planning session's worktree as an untracked file. §3 ("Source-of-truth posture") and §1 ("Goal") name Lestards / the Lestards thatched-roof church as the segment's main concrete anchor; the verified data has Lestards on seg 19. The brief should also be checked for the Treignac-as-seg-17 misattribution (brief §3 paragraph beginning "Seg 17 owns Treignac itself..."). Without this revision the next session will hit the same blocker and either repeat this verification cycle or — worse — trust the brief and write a Lestards-centred draft. The corrected framing is in the [#596 close-out comment](https://github.com/gneeek/tdf26/issues/596#issuecomment-4528970848) and the new session's brief should reflect it before the session reads it.
+2. **Confirm seg 15 has actually merged (not just spawned).** Check `gh pr list --search "seg 15" --state merged --json number,title,mergedAt` and confirm a merged PR with a recent `mergedAt` exists before spawning. The first attempt at this strand was launched while the seg 15 worktree existed but had zero commits — the brief's "after seg 15 has merged" prerequisite was checked as "seg 15 strand exists" rather than "seg 15 PR is merged," and the prerequisite was not actually met. Verify the merged-PR state, not the worktree-exists state.
+
+### Decision-actionable observations
+
+- **Brief carryforward error: Lestards-as-seg-16-anchor.** The brief's central anchor for seg 16 was the Lestards thatched-roof church. Verified against `data/town-coords.json` (which was corrected during PR #498 / issue #498) — Lestards is on the **seg 19** polyline at km 130.39 (12 m off), not seg 16. The dossier (`content/research/segs-14-16-block-research.md` line 128, 133) actually hedged on this with explicit "verify against the segment-16 GPX before any seg 16 prose names a specific commune"; the brief converted the hedge into stated fact. Strong `feedback_brief_content_is_carryforward.md` instance. **Implication for next session:** the seg 16 brief §3 paragraph on Lestards needs revising before the next session reads it. Posted to #596 comment as inheritance surface.
+- **Brief secondary error: Treignac-as-seg-17.** The brief states "Seg 17 owns Treignac itself (km 112–120, town = Treignac)" — the verified data has Treignac in seg 18 (22 m off polyline at km ~122), and seg 17's `towns: ["Madranges"]` is correct. The dossier line 125 also misnamed the segment for Treignac (correctly named the km position but wrong segment). **Implication:** corridor-wide brief-vocab cleanup, not just seg 16. The next seg 17 / seg 18 / seg 19 drafting strands should each verify their brief's segment/town assignments against `data/town-coords.json` before they trust the prose framing.
+- **Seg 16 is genuinely thin.** With Lestards removed, seg 16's on-route inventory is: zero towns, zero climbs, zero historical-TdF events, one attraction barely on the segment boundary (Suc au May table d'orientation at km 105.48, 442 m off, really a seg 15 anchor). Honest framing options: the descent itself; Monédières receding to the east; the Vézère watershed crossing (needs Sandre/Géoportail verification); the 2020 Hirschi solo as opposite-direction callback; forward foreshadow toward Madranges/Treignac. **The publisher should be prepared for an outcome where seg 16 is the shortest entry of the corridor.** Worth a planning line on whether shorter-than-target entry length is acceptable when the data genuinely supports it, or whether seg 16 should pick up corridor-level material to fill standard-length expectations.
+- **Strand-spawn-too-eager pattern.** This strand was spawned with explicit "after seg 15 has merged" prerequisite in the brief — at spawn time the seg 15 worktree existed but had **zero commits.** The seg 16 session started by checking and immediately blocked. Pattern: strand briefs that say "spawn after X merges" should be **gated at the planning layer** (don't spawn the session until the prerequisite PR appears in `gh pr list --state merged`), not gated at the strand-execution layer (where the only available outcomes are wait or close out). Worth a one-line discipline note in the strand-spawning playbook.
+
+### Light-tier pattern observations
+
+- **Source-of-truth verification at strand-start caught the brief error before any prose was written.** The cost of running `python3 -c "<haversine GPX vs town-coords>"` at the top of the strand was <5 minutes; the cost if I'd trusted the brief and written ~800 words of prose around the Lestards church would have been an entire draft thrown away. Pattern: per `feedback_brief_content_is_carryforward.md`, the "verify central anchors before drafting" step pays for itself even on briefs that look thorough. Worth folding into the strand-brief template §5 step 1 as an explicit "verify named on-route anchors against `data/town-coords.json` + GPX polyline" sub-step.
+- **Two checkpoints fired before §5 step 3 (voice) — both warranted.** The brief's checkpoint plan was voice → arc → first-draft-review. The strand actually fired one checkpoint at strand-start, combining strand-posture and data-follow-up into a single AskUserQuestion. Pattern: when verification at §5 step 1 surfaces brief errors, an unscheduled "strand reset" checkpoint before voice/arc is the right move. The brief's checkpoint plan is the steady-state path, not the only path.
+- **Worktree spin-up was cheap.** `git worktree add -b feature/seg-16-draft /home/jhs/code/tdf26-seg-16 main` + `git branch --show-current` confirm + zero commits = essentially free strand state. Closing the worktree without a PR cost roughly the same. Pattern: held-strand close-out is not expensive; preferring "spawn early and close-out-cheap if blocked" over "delay spawning" is the right discipline as long as the close-out artifacts (issue comment + retro notes) are produced.
+
+### Numeric stats
+
+- **Files written in worktree: 0.** Brief itself lives in planning session's worktree (untracked), not this one.
+- **Commits on branch: 0.** Worktree branched from main 1f9391f, no work committed.
+- **AskUserQuestion checkpoints fired: 1** (combined strand-posture + data-follow-up).
+- **External cross-checks: 1 GPX-polyline-vs-town-coords proximity check** (haversine against 3 candidate towns × 5 segments).
+- **Validators run: 0** (no prose written).
+- **PR opened: 0.** Tracking issue [#596](https://github.com/gneeek/tdf26/issues/596) filed and held open for next session; close-out comment posted.
+- **Wall-clock from spawn to close-out: ~12 min.**
+- **Cleanup:** worktree at `/home/jhs/code/tdf26-seg-16` removed at strand close per `feedback_strand_session_self_cleanup.md`.
+
+## Items surfaced during seg-15-drafting strand execution (2026-05-24)
+
+Publisher-paced single-strand drafting of `content/entries/15-suc-au-may-the-fierce-one.md` for the 2026-05-24 publish slot. Tracking issue [#584](https://github.com/gneeek/tdf26/issues/584); PR [#608](https://github.com/gneeek/tdf26/pull/608) (merged). Sibling PRs surfaced mid-strand: [#606](https://github.com/gneeek/tdf26/pull/606) (HistoricalContext rendering — darker subtitle, year fields, photos block; closes #599) and [#607](https://github.com/gneeek/tdf26/pull/607) (card-link refinements + em-dash/segment-meta cleanup). All three merged in-session.
+
+### Decision-actionable observations
+
+- **Suc au May aerial video parked.** Publisher asked early to consider `youtube.com/watch?v=ZXQasOzc9zg` (channel "CAM ON BIG AIR", likely paragliding from the summit). I confirmed title-and-channel via oEmbed but the publisher never eyeballed content. Not embedded. Worth a planning line: confirm fit (paragliding-from-summit complements the Jouvenel/table-d'orientation beat) or drop.
+- **L'Équipe / Presse Sports archive URL search failed.** Publisher asked for "a card with a link to L'Équipe photos for 1987." `site:lequipe.fr` returned no 1987 Chaumeil results; `pressesports.com/reportage/77/145574/cyclisme-1987-tour-de-france-feminin-1987/1` was the closest Google match but 404'd in both server-side fetch and publisher's browser. Fell back to two Mémoire Filmique Nouvelle-Aquitaine (MFNA) photos from L'Echo du Centre archive on the men's 1987 card; no link on the women's card. Worth a planning line on whether to commission a contact-Tulle-Cyclisme-Compétition outreach for archive photos (per segs-14-16 dossier recommendation), or accept that 1987 cycling photos are L'Équipe-archived under all-rights-reserved.
+- **Bol d'Or des Monédières Cinémathèque dossier linked via `photos[]` field.** The 1952 Bol d'Or card now links to `memoirefilmiquenouvelleaquitaine.fr/dossiers/le-bol-d-or-des-monedieres-2` via the `photos[]` array added in #606. Semantically rough — the linked target is a text-heavy dossier with embedded photos, not a photo gallery; the 📷 icon and `photos` field name overstate. Worth a planning line on whether to extend `HistoricalContext.vue` with a generic `links[]` or `dossierUrl` field that can carry non-photo references with appropriate iconography.
+- **27-segment re-split landed mid-strand and required prose fix.** Background PR (not surfaced into this session's branch list) re-split the route from 26 to 27 segments. Collonges-la-Rouge moved from seg 4 (km_end 28) to seg 3 (km_end 22), invalidating the prose's "eleven segments back at kilometre twenty-eight" callback. Caught after fetching origin/main and reviewing the updated `segments.json`; fixed inline. Worth a planning line on whether drafting strands should pin the segment count at brief time and rebase explicitly if it changes — or whether the current rebase-on-origin/main-before-commit discipline is enough.
+
+### Light-tier pattern observations
+
+- **TLS-essay continuity gave seg 14 + seg 15 as one extended essay.** Voice checkpoint presented three substantive registers (TLS-essay continuity, Edinburgh-Review essay, Madrid-Review place-essay); publisher chose continuity. The summit beat reads as the seg 14 essay's payoff rather than a register break. Pattern: when seg N is a Barthes-arc "develops" beat coming off a seg N-1 "tightens", voice continuity is the conservative-but-coherent default; register breaks land bigger meaning but cost cohesion.
+- **Lead-anchor multi-select checkpoint with 4 options narrowed cleanly to 3.** Publisher picked 1987 double-finish + Bourrée + Jouvenel; dropped the Ségurel + Bol d'Or roll-call (which would have duplicated cycling-history weight with the 1987 finish). Ségurel rode inside the Bourrée beat as the canonical recorder rather than via the criterium founding. Pattern: when two candidates carry similar weight, letting the publisher cull is the right move rather than the drafter pre-cutting.
+- **Mid-strand authorised edits cleanly surfaced as sibling PRs.** Three sibling PRs (#606, #607 across two commits) opened in separate branch+worktree pairs off `main`, mirroring preview-only into the seg-15 worktree so the publisher saw everything at one dev URL. The `feedback_interpolated_pr_pattern.md` discipline scaled to three concurrent sibling PRs without confusion. Pattern: the sibling-PR pattern is durable under publisher pressure to "merge all the work in this session" — open the small PRs as they're authorised, sequence the merge by dependency (component changes before data additions before strand content).
+- **Duplication-audit pass at session close found significant slack.** Prose / footnotes / Sources triple-duplicated multiple facts (Jouvenel + Colette + Maison de la Sirène; Ségurel 600k copies; Chaumeil commune fundamentals; Suc au May summit details). One audit pass saved ~250 words across footnotes + Sources without touching body prose. Pattern: a dedicated "fact-duplication audit" pass right before sign-off is high-value, and worth codifying as a checkpoint in the strand-brief template §5 between revisions and Sources/disclosure.
+- **Banner-image research surfaced palette after first banner pick.** Publisher chose banner image first (Babsy's "Le sud des Monédières vers Chaumeil") via direct file URL, then asked for "other images" research as a separate batched pass. The research-then-pick batch turned up four strong beat-aligned candidates (Ségurel monument, Musée Jean Ségurel interior, table d'orientation, church square); publisher selected three (museum + table + square; omitted monument). Pattern: image research as a discrete batched pass after the banner is set works well — banner is one decision (visual establishing), gallery is several (beat-aligned support).
+- **Reading candidate voice SKILL briefs before the checkpoint paid off again.** Per `feedback_voice_checkpoint_prep.md`, read Edinburgh-Review and Madrid-Review SKILL.md briefs (skipped Saintsbury per the seg-24 reservation) before firing the voice checkpoint. The three-option presentation with one-line trade-offs landed cleanly; no follow-up "what's the difference between these" question fired. Pattern continues to hold from prior strands.
+- **Constructed Google Maps embed URL worked first-try.** Publisher's `maps.app.goo.gl` share URL wasn't iframe-embeddable; I extracted panorama parameters (panoid, viewpoint lat/lng, heading, tilt) from the resolved URL and substituted into the `https://www.google.com/maps/embed?pb=...` template with a guessed `4v[timestamp]` and `4f[tilt-sign]`. Publisher confirmed the iframe rendered correctly post-strand (2026-05-24). Pattern: when share URLs aren't iframe-embeddable, parameter extraction from the resolved URL + template substitution is a viable fallback to asking for the canonical Share → Embed URL.
+
+### Numeric stats
+
+- **PRs opened: 3** — [#606](https://github.com/gneeek/tdf26/pull/606) (hist-fmt rendering, closes #599), [#607](https://github.com/gneeek/tdf26/pull/607) (card-link refinements + em-dash/segment-meta cleanup), [#608](https://github.com/gneeek/tdf26/pull/608) (seg 15 draft, closes #584). All three merged in-session.
+- **Worktrees spawned: 3** — `tdf26-seg-15`, `tdf26-hist-fmt`, `tdf26-card-links`. All cleaned post-merge.
+- **Files written across the session: 3** — `content/entries/15-suc-au-may-the-fierce-one.md`, `data/historical-tdf.json`, `components/HistoricalContext.vue`.
+- **Commits across all three branches: 5** — seg-15: 2 (initial draft + duplication trim); hist-fmt: 1; card-links: 2 (initial + em-dash/segment-meta trim).
+- **AskUserQuestion checkpoints fired: 2 batches** — voice register (single-select, 3 options); arc agreement + Bessou foreshadow (multi-select + single-select in one batch).
+- **Other publisher review prompts: ~15** — banner image, gallery image picks, 2020 inline-figure, Bourrée video, 1987 video, L'Équipe card URL request, duplication reduction, MFNA links for men's 1987, women's photo link add-then-remove, 2020/1952 card links, Paris-Corrèze trim, segment-meta cleanup, em-dash sweep, Street View embed, merge-all-the-work directive. Session shape was checkpoint + iterate; informal prompts substantially outnumbered formal checkpoints.
+- **Body prose word count at merge: 1,147** (window 800-1,200). Footnotes + Sources cut by ~250 words across two duplication-reduction passes; body untouched.
+- **External sources cross-checked / cited: ~20** — Wikipedia FR (Chaumeil, Suc au May, Ségurel, Jouvenel, Musique limousine), Wikipedia EN (1987 men's, 1987 Féminin), BnF authority record, Détours en Limousin, Tourisme Egletons, Violons Populaires Nouvelle-Aquitaine ×2, Libraria Occitana, Mémoire Filmique Nouvelle-Aquitaine ×3, YouTube oEmbed ×4, Wikimedia Commons API for 5+ images.
+- **Validators run repeatedly:** `validate_entries.py` + `validate_points.py` both green at each major change; dev preview confirmed via curl on rendered HTML.
+- **Wall-clock:** ~2 hours from issue #584 file at ~12:00 UTC to seg-15 PR merge at 14:08 UTC, interleaved with publisher review.
+- **Cleanup:** worktrees `tdf26-seg-15`, `tdf26-hist-fmt`, `tdf26-card-links` to be removed post-final-merge per `feedback_strand_session_self_cleanup.md`.
+
+## Items surfaced during seg-15 publish (2026-05-24)
+
+Seg 15 published to production via `./scripts/publish.sh --release-tag W21-seg15` at 14:38-14:42 UTC. Live: https://tour26.iamsosmrt.com/entries/15-suc-au-may-the-fierce-one/. Release: https://github.com/gneeek/tdf26/releases/tag/W21-seg15. Frontmatter PR: [#610](https://github.com/gneeek/tdf26/pull/610) (merged).
+
+### Decision-actionable observations
+
+- **publish.sh aborted at Step 10 (tag/release) even though Step 9 (frontmatter PR merge) actually succeeded.** The script ran `gh pr merge --squash` on PR #610, but the merge had already completed via a different path (auto-merge or repo merge-settings). The script saw the subsequent `gh api ... DELETE refs/heads/publish/...` return HTTP 404 (branch already deleted as part of merge), then exited with `ERROR: gh pr merge --squash failed for PR #610. Resolve manually.` Main was already fast-forwarded correctly; I had to invoke `scripts/create-release.sh W21-seg15 --title "W21-seg15 - Segment 15 publication"` manually after the script aborted. Worth a planning line on whether to make publish.sh idempotent about the "PR already merged" case — check PR state via `gh pr view` before invoking `gh pr merge --squash`, and skip the merge call (and the post-merge branch-delete call) if the PR is already MERGED.
+- **Seg 15's `dataCutoff: 2026-05-23`** — published with rider data through yesterday; the publisher confirmed at publish time that this was correct (rider stats added through 2026-05-23, no entry for 2026-05-24 since the actual rider day hadn'''t happened yet).
+
+## Items surfaced during seg-16 publish (2026-05-28, one day after publishDate)
+
+Seg 16 published to production via two-pass publish (initial `publish.sh --segment 16 --release-tag W22-seg16` + manual finalize PR + tar-pipe redeploy) on 2026-05-28. Live: https://tour26.iamsosmrt.com/entries/16-descent-from-the-monedieres. Release: https://github.com/gneeek/tdf26/releases/tag/W22-seg16. PRs: [#613](https://github.com/gneeek/tdf26/pull/613) (entry), [#614](https://github.com/gneeek/tdf26/pull/614) (publish.sh reconciliation), [#615](https://github.com/gneeek/tdf26/pull/615) (post-publish finalize).
+
+### Decision-actionable observations
+
+- **publish.sh has no draft-flip step.** The publisher (not the script) is expected to flip `draft: true → false` on the target entry before running publish.sh. I missed this and shipped seg 16 with `draft: true` still set; the Nuxt build excluded the entry, the deploy went out without it, and production showed 404 on `/entries/16-descent-from-the-monedieres` until a fix-up PR + manual redeploy landed. Worth deciding: (a) add a draft-flip step to publish.sh (with `--segment N` it knows which entry to mutate), (b) add a pre-flight check that aborts if the target entry is still draft, or (c) document the publisher's pre-publish responsibility more loudly (handoff `project_seg16_publish_handoff.md` had it wrong, said publish.sh flips draft). Recommend (b) as cheapest-with-most-leverage; (a) is the right end-state.
+- **`weather.py --entry current` targets the wrong segment when the target segment is still draft.** weather.py's "current" detection finds the most recently published (`draft: false`) entry with `publishDate <= today`. When seg N is still `draft: true`, "current" resolves to seg N-1, with two failure modes at once: seg N gets no weather injected, and seg N-1 gets a retroactive weather refresh (which violates `feedback_content_change_rule` if committed). The seg 15 weather got unintentionally rewritten on disk; I discarded the change before commit. Fix: pass `--entry $SEGMENT` explicitly from publish.sh so weather.py targets the segment being published, not the most-recent-published.
+- **publish.sh aborted at the same `gh pr merge --squash` step as seg 15** — same gotcha, same workaround (`scripts/create-release.sh` manually). Two instances now: worth promoting from "known issue" to "fix in v1.4.20". A `gh pr view --json state` check before the merge call would close it.
+- **Two-pass publish has no clean re-deploy path.** After the finalize PR merges, the redeploy step is "rebuild + tar-pipe" copied out of publish.sh by hand. The script has no `--deploy-only` / `--redeploy` flag for this exact recovery shape. Either add one, or treat the finalize-then-redeploy as a documented sub-runbook.
+- **`dataCutoff: 2026-05-27` matched publishDate exactly** (consistent with seg 15's pattern: dataCutoff = publishDate, rider distances logged through publishDate − 1). The handoff note "seg 15 used yesterday's date" was misleading; pattern is dataCutoff = publishDate, which on the actual publish day = today = publishDate. For a one-day-late publish (this one), dataCutoff = publishDate = yesterday-of-actual-publish-day.
+
+### Process observations (Tully-side)
+
+- **Two-pass publish was a budget hit.** What should have been one publish.sh run became: publish.sh run → reconciliation PR → realize it's broken → finalize PR → manual rebuild → manual tar-pipe deploy. Five extra steps over the canonical flow. The draft-flip miss was the root cause; everything downstream was rework.
+- **Post-publish hotfix mini-playbook** (the one captured in How-We-Work after Retro v1.4.18) didn't fit this case cleanly — the issue wasn't a post-deploy content fix, it was a deploy-time pipeline gap. Worth a separate "publish.sh recovery" mini-playbook in the same wiki section.
+- **The publisher's manual rider-data entry** (4 days of distances across 4 riders, ~16 numeric inputs) happened in parallel with my image-research pass without explicit coordination. The publisher just announced "rider distances are already entered" mid-stream. Pattern: when publisher-only work and Claude-side work are independent, parallelism without coordination is fine and saves wall-clock.
+- **Banner research did not surface palette early enough.** I picked a Babsy summit-panorama as the seg 16 banner without flagging that two Babsy summit panoramas existed for adjacent segments; the publisher caught the near-duplicate at read-through. Pattern: when picking from a small artist's collection (Babsy has ~3-4 Monédières panoramas on Commons, all summit-side), preview adjacent segments' banners against the candidate before committing. Worth a checklist line in the strand-brief template under "image picks": "check artists used in adjacent segments' banners".
+- **The Cirque de Freysselines beat got added mid-pass.** The publisher asked for it after the banner was settled (γ = Bruyère); I added one sentence to paragraph 2 with a single Wikimedia source check. Worked cleanly because the geography was non-controversial and the existing Sources entry for *Massif des Monédières* already covered it. Pattern: late-pass narrative additions are safe when (a) the new beat has a sourced existing-citation backstop, (b) it fits an already-described moment in the prose, and (c) it doesn't expand the word count significantly.
+
+### Numeric stats (lightweight)
+
+- **PRs opened: 3** — #613 (entry), #614 (publish.sh reconciliation, auto-opened), #615 (finalize fix-up).
+- **Commits across all branches: 5** — #613: 3 commits (initial WIP + image+street-view + read-through revisions). #614: 1 (auto). #615: 1.
+- **Image research passes: 2** — initial set (α/β/γ/δ/ε/ζ candidates + recommendations) and post-read-through banner-swap pass that added the Cirque de Freysselines / Confluent Corrèze-Vézère / Bruyère candidates. Two of the three banner candidates were added to the gallery for visual preview before publisher picked.
+- **AskUserQuestion checkpoints fired: 2** — image-pick + Street View source (batch), and read-through form. Most decisions happened in free-form chat.
+- **Wall-clock from "help me finish publishing" to live-on-prod: ~3.5 hours**, mostly publisher-paced read-through and image revisions; technical work took ~30 min of that.
+
+### Schedule decisions parked from the seg-16 drafting session (2026-05-27)
+
+Carried forward from the now-deleted `project_seg16_publish_handoff.md`. These were load-bearing chat decisions made during seg-16 drafting that need to land in tracked artifacts at planning time per `feedback_session_close_decision_persistence.md`.
+
+- **Schedule reshuffle for the run-in to the race.** Seg 26 stays **2026-07-01** (Canada Day). A **Tour-history special publication** targeted **2026-07-02**, 1-2 days before the 2026-07-04 Grand Départ (Barcelona TTT; Stage 9 = Sun 2026-07-12). **Seg 27 moves to 2026-07-03** (was 2026-07-09). **PENDING REPO EDIT:** `content/entries/27-place-voltaire-the-finish-line.md` still has `publishDate: 2026-07-09` — change to `2026-07-03` as its own small edit, not in any drafting PR.
+- **July special publication scope.** An essay on the Tour-de-France history of the Stage 9 area. Material already exists in `content/research/tour-history-research.md` and `data/historical-tdf.json`. Seg 16's closing line foreshadows it (date-free: *"an essay of its own, nearer the start of the race"*). Decide format at planning time: standalone entry vs. archive index vs. cross-link compendium.
+- **Walkers' arithmetic.** 185 km at the 2 km/day cap from the **2026-04-01** start finishes **2026-07-02** best-case (2026-07-12 fallback at the worst). Seg 27 = the last **2.8 km** (km 182.0-184.8; route total 184.8). Stated walker goal: finish before the Grand Départ. **NB:** `data/riders/rider-config.json` `startDate` is **2026-04-01** but CLAUDE.md says 04-02 — minor doc drift to reconcile.
+- **Broader planning backlog still open** (not blocking, but flagged for the next session): name/scope **v1.4.20** ("TBD" with ~15 open issues), triage the 2026-05-24 strand-blitz issues (#588/#589/#590/#591/#553/#554/#555/#549/#551/#547/#476), archive the now-very-long `project_next_planning_notes.md` (this file is ~800 lines).
+
+- **Who adds**: Piers and Tully add items during retrospectives, in-progress work, or meta-observations about the process. Items should have enough context to be actionable at planning time.
+- **Who consults**: publisher reads this file at the start of a planning session as one of the inputs (alongside the roadmap, open issues, and the calendar).
+- **Who clears**: at planning time, items that get decided (either scheduled into a release or explicitly deferred with a reason) are removed from this file. Items that stay pending stay in the file.
+- **Archives**: when the file grows beyond ~250 lines, the planning session may archive resolved content to `docs/planning/<date>-archive.md` and rewrite the live file with only forward-looking carryforwards. 2026-05-12 is the first such archive sweep.
+- **Size discipline**: this file should stay short. If it grows beyond roughly 15 carryforward items, planning should happen sooner — the backlog is signaling that the cadence of planning sessions is too slow.

--- a/docs/planning/NEXT.md
+++ b/docs/planning/NEXT.md
@@ -1,93 +1,83 @@
 # Planning continuation note
 
-> **Singleton convention:** at most one open planning continuation lives at this path. When a planning session closes that this note tracked, rename to a date-stamped archive (e.g. `docs/planning/2026-05-22-archive.md`) or delete. New sessions overwrite or replace this file.
+> **Singleton convention:** at most one open planning continuation lives at this path. When a planning session closes that this note tracked, rename to a date-stamped archive (e.g. `docs/planning/2026-06-XX-archive.md`) or delete. New sessions overwrite this file.
 
-## Status at handoff
+## Status at handoff (2026-05-28 planning session close)
 
-[Retro v1.4.19](https://github.com/gneeek/tdf26/wiki/Retro-v1.4.19) fired 2026-05-22, covering `W20-seg12` + `W20-seg13` + `W21-seg14`. The next planning session is expected Mon 2026-05-25 / Tue 2026-05-26 to (a) close v1.4.19 once its minimal-set issues land, (b) set the theme and scope of v1.4.20.
+Segs 1–16 are published (seg 16 shipped 2026-05-28). **v1.4.19 is closed** (drained, 23 issues). **v1.4.20 is themed: "Publish-pipeline hardening"** and trimmed to a 10-issue set. The next planning session has no fixed trigger — it fires when v1.4.20 drains, or sooner if the carryforward list (below) grows past ~15 items.
 
-Same-day pre-planning trim (2026-05-22) recorded below: v1.4.19 narrowed to a four-issue minimal close-out set; ten issues reassigned to v1.4.20.
+## Decisions made this session
 
-## Pre-planning trim decision (2026-05-22)
+- **v1.4.20 spine = publish-pipeline hardening.** Chosen over data-to-display reconciliation because seg 16 404'd in production; an unsafe publish.sh is the top reader-reliability risk with 11 segments left. Scope file: `docs/planning/v1.4.20-scope.md`.
+- **Three publish-day fixes are a hard gate before seg 17 (Sun 2026-05-31):** #617 (draft pre-flight), #618 (gh-merge idempotency), #619 (weather --entry). Weekend strand brief written: `docs/strands/strand-publish-safety-617-618-619.md`. **Publisher to spawn it this weekend.**
+- **#502 tour-history → v1.5.0, shape = standalone July-2 essay entry.** Publishes between seg 26 (07-01) and seg 27 (07-03, already moved via #616). Design now, schedule into the July milestone. Seg 16's closing line already foreshadows it date-free.
+- **Data-to-display reconciliation is the candidate spine for the *next* milestone.** Cluster seeded in backlog: #517, #588, #486, #476, #487. Climb data fixes don't reach readers because StageDetails.vue/ElevationChart.vue hardcode parallel values.
 
-Retro v1.4.19 surfaced that the milestone was past its original close-out target (`W21-seg14` = 2026-05-21) with 14 open issues, and that the "Reader uplift" half of the milestone title had no shipped item. The publisher took **Path B**: stretch v1.4.19 to close after seg 15 or seg 16 with a minimal scope, rather than close the milestone now and reassign all 14 (Path A).
+## Content production line (the critical path — binding constraint on the run-in)
 
-### Kept in v1.4.19 (4 issues)
+The entries are the deliverable; this line gates the schedule, the pipeline milestone runs alongside it.
 
-- [#513](https://github.com/gneeek/tdf26/issues/513) — Suc au May points-config drift. Seg 15 is Suc au May; must land before seg 15 publish (Sun 2026-05-24).
-- [#564](https://github.com/gneeek/tdf26/issues/564) — Chirac burial location in `data/attractions.json`. Seg 15 dossier reaches for Sarran/Chirac adjacency; small data fix.
-- [#535](https://github.com/gneeek/tdf26/issues/535) — Improve entry-card thumbnail selection. Honours the "at least one reader-uplift item ships visibly" criterion in the original scope file; strand brief already written at `docs/strands/strand-535-entry-card-thumbnails.md`.
-- [#518](https://github.com/gneeek/tdf26/issues/518) — Climb summit km drift assertion. Five-instance carry (Lachaud, Naves, Mont Bessou, Croix de Pey, Côte des Gardes); Retro v1.4.19 promoted from candidate to must-have.
+**Drafting:** segs 1–16 published. **Segs 17–27 are all stubs** (`draft: true`, title-only) — 11 entries to write, twice-weekly, with no schedule slack:
 
-### Reassigned to v1.4.20 (10 issues)
+| Seg | Publish | Research ready? |
+|-----|---------|-----------------|
+| 17 | 2026-05-31 | ✅ 17-19 dossier |
+| 18 | 2026-06-03 | ✅ 17-19 dossier |
+| 19 | 2026-06-07 | ✅ 17-19 dossier |
+| 20 | 2026-06-10 | ❌ **needs 20-22 dossier** |
+| 21 | 2026-06-14 | ❌ needs 20-22 dossier |
+| 22 | 2026-06-17 | ❌ needs 20-22 dossier |
+| 23 | 2026-06-21 | ❌ **needs 23-27 dossier** |
+| 24 | 2026-06-24 | ❌ needs 23-27 dossier |
+| 25 | 2026-06-28 | ❌ needs 23-27 dossier — **Meymac, saintsbury voice reservation** (`project_meymac_voice.md`) |
+| 26 | 2026-07-01 | ❌ needs 23-27 dossier |
+| — July special | 2026-07-02 | ✅ `tour-history-research.md` |
+| 27 | 2026-07-03 | ❌ needs 23-27 dossier — Ussel finish line |
 
-[#311](https://github.com/gneeek/tdf26/issues/311), [#326](https://github.com/gneeek/tdf26/issues/326), [#466](https://github.com/gneeek/tdf26/issues/466), [#476](https://github.com/gneeek/tdf26/issues/476), [#479](https://github.com/gneeek/tdf26/issues/479), [#481](https://github.com/gneeek/tdf26/issues/481), [#483](https://github.com/gneeek/tdf26/issues/483), [#486](https://github.com/gneeek/tdf26/issues/486), [#487](https://github.com/gneeek/tdf26/issues/487), [#517](https://github.com/gneeek/tdf26/issues/517).
+**Research gaps to spawn (block-research-then-N-drafts shape, the stable dossier pattern):**
+- **Segs 20–22 dossier** — must land before seg 20 drafts (~2026-06-10). Spawn ~first week of June.
+- **Segs 23–27 dossier** — must land before seg 23 drafts (~2026-06-21). Larger block (finish-line stretch); settle the seg-25 Meymac voice at the same time.
 
-Rationale: none are reader-visible by the seg 15/16 cycle deadline, none are blocking, and the milestone-as-tag honesty cost of carrying them another cycle is lower than the schedule cost of forcing them in now.
+**Committed strands this cycle.** Three briefs are written and scheduled to run within the v1.4.20 cycle — they are this-cycle work, not deferred:
+- `docs/strands/strand-seg-17-drafting.md` — run now, for the 2026-05-31 slot.
+- `docs/strands/strand-segs-20-22-content-research.md` — run before seg 20 (~06-10).
+- `docs/strands/strand-segs-23-27-content-research.md` — run before seg 23 (~06-21).
 
-### Sequenced execution this weekend (publisher-driven)
+## Sequenced execution
 
-1. Dependabot sweep (8 open PRs).
-2. Seg 15 draft + publish cycle (publishes Sun 2026-05-24).
-3. v1.4.19 planning session at Mon 2026-05-25 / Tue 2026-05-26.
+1. **This weekend:** spawn the publish-safety strand; merge #617/#618/#619 before seg 17.
+2. **Seg 17 cycle (Sun 2026-05-31):** draft + publish on the hardened pipeline. Brief ready: `docs/strands/strand-seg-17-drafting.md` (note: seg 17 = **Madranges + the Treignac approach**; the stub is mis-titled "treignac-granite-and-water" — that's seg 18 — re-title at the anchor checkpoint).
+3. **Segs 17–19 drafting cadence:** publisher-paced, one strand per segment; handle dossier-flagged data corrections (#549, #551, #602, #603) inline. Briefs for segs 18/19 to scaffold from the same 17-19 dossier.
+4. **Spawn the 20–22 research dossier** before seg 20 (~06-10): `docs/strands/strand-segs-20-22-content-research.md`. **Spawn the 23–27 dossier** before seg 23 (~06-21): `docs/strands/strand-segs-23-27-content-research.md` (settles the seg-25 Meymac voice + corrects the segs 24/25/26 stub-title drift).
+5. **July-2 tour-history essay (#502):** design now, draft from `tour-history-research.md` ahead of 07-02.
+6. **Pipeline spine + ceremony (#322/#479/#508/#326/#480/#521/#339):** across the seg 17–20 cycles, alongside (not gating) drafting.
 
-The four kept v1.4.19 issues line up with these phases: #513 and #564 ride the seg 15 cycle; #535 and #518 are planning-session work after.
+## Open carryforwards (not decision-pending; carry unless cleared)
 
-## Next planning trigger
-
-Mon 2026-05-25 / Tue 2026-05-26 session will:
-
-- Close v1.4.19 once the four kept issues land, or accept further slippage explicitly with a slip-rate-tally row.
-- Set the theme and full scope of v1.4.20 against its now-larger 17-issue list.
-- Decide whether seg 15 and seg 16 cycles belong to v1.4.19's tail or to v1.4.20's head.
+- **Data-to-display reconciliation cluster** (#517/#588/#486/#476/#487) — next-milestone candidate spine.
+- **Summit-km data backlog** (#589/#590/#591) — opportunistic; clears the #518 assertion skip-list. Not milestone-gated.
+- **Off-theme backlog** (#483 instrumentation, #481 planning shape, #466 map perf, #409 rider-stats, #509 worktree bootstrap) — reassess next planning.
+- **Tour-history July-2 essay design** — v1.5.0; decide drafting cadence and voice closer to July.
+- **Recommended-option calibration** — monitor for rubber-stamping. (Note: this session hit one option-set-too-binary signal on the pipeline-timing question; re-fired cleanly.)
+- **Tully/Piers explainer pages** — unfold#44 blocks tdf26#529.
+- **Voices design session** — `docs/strands/strand-voices-design-session.md`; spawn when scheduled.
+- **Strand-as-first-class unfold candidate** — re-evaluate after the v1.4.20 multi-strand cycle.
+- **Doc drift:** `data/riders/rider-config.json` `startDate` is `2026-04-01`; CLAUDE.md says `2026-04-02`. Reconcile (file a small issue or fix in a data-hygiene pass). Walker arithmetic in the seg-16 notes assumes 04-01.
 
 ## Reading order for the next session
 
-1. **This note.**
-2. **[Retro v1.4.19](https://github.com/gneeek/tdf26/wiki/Retro-v1.4.19)** — its "What we lack" section has eight new carryforward candidates for the v1.4.20 scope.
-3. **`project_next_planning_notes.md`** in agent memory.
-4. **`docs/planning/v1.4.19-scope.md`** — preserved as point-in-time artifact from 2026-05-12, not rewritten.
-5. **`docs/planning/2026-05-12-archive.md`** — prior session archive.
-
-## State of work at handoff
-
-### Releases
-
-- **v1.4.19** — open. 18 issues closed, 4 kept (per above), 10 reassigned. Close-out target shifted from `W21-seg14` to whichever cycle the four kept issues land in.
-- **v1.4.20 - TBD** — 17 open issues. Theme set at the planning session that closes v1.4.19.
-- **v1.5.0 / v1.6.0** — held for July (Tour de France) / Admin Tooling cycle respectively.
-
-### Production deploys this cycle
-
-- `W20-seg12` (Wed 2026-05-15), `W20-seg13` (Sun 2026-05-17), `W21-seg14` (Thu 2026-05-21) all shipped on-cadence.
-
-### Upcoming cycles
-
-- `W21-seg15`, Sun 2026-05-24 — Suc au May, the Barthes arc "develops" beat per `project_barthes_callback.md`. No drafting brief yet at brief-write time of this note; scaffold via `/strand-brief` before spawn.
-- `W22-seg16`, Wed 2026-05-27.
-
-### Open PRs
-
-Fluid as of this note; the dependabot sweep is one of the three priorities above. Refresh `gh pr list` at planning time.
-
-## Open carryforwards
-
-Active threads (not decision-pending; carry forward to next planning unless cleared):
-
-- Recommended-option calibration — monitor for rubber-stamping.
-- Tully/Piers explainer pages — unfold#44 blocks tdf26#529.
-- Existing milestone names under date-based scheme — future-only; first instance whenever v1.4.21 is created.
-- Voices design session — spawn when publisher schedules it.
-- Strand-as-first-class unfold candidate — re-evaluate with the v1.4.19 cycle's multi-strand evidence in hand.
-- Retro v1.4.19 "What we lack" items (8) — promotion-decision-actionable at next planning. Climb-coord assertion (#518) and tour-history reader surface (#502) are the two carrying >1 retro per the slip-rate tally row at the bottom of the retro page.
+1. This note.
+2. `project_next_planning_notes.md` (agent memory) — strand close-out inputs since this session.
+3. `docs/planning/v1.4.20-scope.md` — what we said we would do.
+4. The next Retro's "What we lack" section.
+5. `docs/planning/2026-05-28-archive.md` — this session's archived inputs.
 
 ## Pointers
 
-- v1.4.19 milestone-scope (point-in-time): `/home/jhs/code/tdf26/docs/planning/v1.4.19-scope.md`
-- Milestone-scope template: `/home/jhs/code/tdf26/docs/planning/MILESTONE-SCOPE-TEMPLATE.md`
-- Strand briefs: `/home/jhs/code/tdf26/docs/strands/`
-- Planning-notes file (durable input/output): `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/project_next_planning_notes.md`
-- 2026-05-12 archive: `/home/jhs/code/tdf26/docs/planning/2026-05-12-archive.md`
+- v1.4.20 scope: `docs/planning/v1.4.20-scope.md`
+- Milestone-scope template: `docs/planning/MILESTONE-SCOPE-TEMPLATE.md`
+- Strand briefs: `docs/strands/`
+- Planning-notes memory: `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/project_next_planning_notes.md`
+- v1.4.20 milestone: https://github.com/gneeek/tdf26/milestone/53
 - Roadmap (wiki): https://github.com/gneeek/tdf26/wiki/Roadmap
-- Retro v1.4.19 (wiki): https://github.com/gneeek/tdf26/wiki/Retro-v1.4.19
 - Slip-rate tally (wiki): https://github.com/gneeek/tdf26/wiki/Slip-rate-tally

--- a/docs/planning/v1.4.20-scope.md
+++ b/docs/planning/v1.4.20-scope.md
@@ -1,0 +1,70 @@
+# v1.4.20 — Publish-pipeline hardening
+
+Milestone-scope artifact for v1.4.20, written at the close of the 2026-05-28 planning session. The retros for production deploys under this milestone read this as the "what we said we would do" reference.
+
+## Milestone link
+
+https://github.com/gneeek/tdf26/milestone/53
+
+## Planned issues
+
+### Publish-day safety (the gate — must land before seg 17, Sun 2026-05-31)
+
+- [#617](https://github.com/gneeek/tdf26/issues/617) — publish.sh ships a still-draft entry without warning → production 404 — root cause of seg 16's 404.
+- [#618](https://github.com/gneeek/tdf26/issues/618) — publish.sh aborts at the frontmatter-PR merge step when the PR is already merged — fired on seg 15 and seg 16.
+- [#619](https://github.com/gneeek/tdf26/issues/619) — weather.py --entry current targets the wrong segment when the publish target is still draft — rewrote seg 15's weather retroactively.
+
+### Pipeline robustness (the spine)
+
+- [#322](https://github.com/gneeek/tdf26/issues/322) — No pre-publish verification; site can deploy with broken pages — the umbrella the three gate fixes live under.
+- [#479](https://github.com/gneeek/tdf26/issues/479) — Image frontmatter YAML form crashes publish.sh — second publish.sh crash class.
+- [#508](https://github.com/gneeek/tdf26/issues/508) — Shell scripts have no test harness — enables regression-testing publish.sh itself.
+- [#326](https://github.com/gneeek/tdf26/issues/326) — Consolidate four hand-rolled frontmatter parsers — publish.sh is one of the four; de-risks the parse path.
+
+### Release ceremony (automate the manual run-in steps)
+
+- [#480](https://github.com/gneeek/tdf26/issues/480) — publish.sh wiki Roadmap update is still manual after each release.
+- [#521](https://github.com/gneeek/tdf26/issues/521) — Full-lifecycle release checklist with conditional branching.
+- [#339](https://github.com/gneeek/tdf26/issues/339) — /release skill or hook to automate release ceremony steps.
+
+## Expected ship window
+
+Spans the seg 17–20 run-in publication cycles. Each production deploy triggers a retro per Topic 9c.
+
+- **Gate:** the three publish-day safety fixes (#617/#618/#619) land **before seg 17 (Sun 2026-05-31)** as one weekend strand. Hard deadline.
+- **Spine + ceremony:** land across the seg 17–19 cycles.
+- **Close-out target:** around **seg 20 publication (~W24, ~2026-06-10)**. Issues that don't land carry to the next milestone.
+
+## Success criteria
+
+- publish.sh runs end-to-end with no manual workaround on seg 17 and after: no still-draft ship, no abort when the PR is already merged, weather injected into the correct segment.
+- Seg 17–20 publish on schedule with no production 404 and no retroactive weather rewrite on a prior entry.
+- A test harness exists that can exercise publish.sh's failure modes (#508), so the three fixes have regression coverage.
+- The wiki Roadmap update step is no longer a manual post-deploy chore (#480), or is on a documented path to it.
+
+## Out of scope (explicit)
+
+- **Data-to-display reconciliation** ([#517](https://github.com/gneeek/tdf26/issues/517), [#588](https://github.com/gneeek/tdf26/issues/588), [#486](https://github.com/gneeek/tdf26/issues/486), [#476](https://github.com/gneeek/tdf26/issues/476), [#487](https://github.com/gneeek/tdf26/issues/487)) — moved to backlog as the **candidate spine for the next milestone**. Climb data fixes don't reach readers because StageDetails.vue/ElevationChart.vue hardcode parallel values; this is its own cycle, not a pipeline ride-along.
+- **Tour-history reader surface** ([#502](https://github.com/gneeek/tdf26/issues/502)) — moved to **v1.5.0**; ships as a standalone July-2 essay entry (see NEXT.md).
+- **Off-theme reader/process items** ([#483](https://github.com/gneeek/tdf26/issues/483) instrumentation, [#481](https://github.com/gneeek/tdf26/issues/481) planning shape, [#466](https://github.com/gneeek/tdf26/issues/466) map render perf, [#409](https://github.com/gneeek/tdf26/issues/409) rider-stats friction, [#509](https://github.com/gneeek/tdf26/issues/509) worktree bootstrap) — backlog; reassess next planning.
+- **Summit-km data backlog** ([#589](https://github.com/gneeek/tdf26/issues/589), [#590](https://github.com/gneeek/tdf26/issues/590), [#591](https://github.com/gneeek/tdf26/issues/591)) — opportunistic fixes that clear the #518 assertion skip-list; not milestone-gated, do whenever.
+- **Upcoming-segment data corrections** ([#549](https://github.com/gneeek/tdf26/issues/549), [#551](https://github.com/gneeek/tdf26/issues/551), [#602](https://github.com/gneeek/tdf26/issues/602), [#603](https://github.com/gneeek/tdf26/issues/603)) — handled inside the seg 17–19 drafting cycles, dossier-flagged.
+
+## Rationale notes
+
+- **Theme chosen over data-to-display because seg 16 404'd in production.** With 11 segments left to publish, an unsafe publish.sh is the highest reader-reliability risk on the board. Data-to-display is real but its failure mode is "stale number on a page," not "page is gone."
+- **v1.4.20 deliberately trimmed to ~10 themed issues** rather than carrying the 15 it inherited. Path-A discipline from the 2026-05-22 trim: a milestone-as-tag should mean something. The off-theme issues were in v1.4.20 by accretion, not intent.
+- **#326 (frontmatter parsers) kept in despite a "Backlog:" prefix** because publish.sh is one of the four parsers; consolidating de-risks the exact parse path that #479 crashes on.
+- **Data-to-display named as the next cycle's candidate spine** so #517/#588/#486/#476/#487 read as "queued with intent," not "dropped." This cycle = pipeline; next cycle = data reaches readers.
+
+## Cross-links to strand briefs
+
+Pipeline-milestone strand:
+
+- `docs/strands/strand-publish-safety-617-618-619.md` — the weekend gate strand (three publish-day fixes before seg 17).
+
+Content-line strands committed to run **this cycle** (the entries are the deliverable; these run alongside the pipeline issues, not gated by them):
+
+- `docs/strands/strand-seg-17-drafting.md` — seg 17 (Madranges / Treignac approach), publishes 2026-05-31.
+- `docs/strands/strand-segs-20-22-content-research.md` — block dossier, lands before seg 20 drafts (~06-10).
+- `docs/strands/strand-segs-23-27-content-research.md` — finish-block dossier, lands before seg 23 drafts (~06-21); settles the seg-25 Meymac voice.

--- a/docs/strands/strand-publish-safety-617-618-619.md
+++ b/docs/strands/strand-publish-safety-617-618-619.md
@@ -1,0 +1,80 @@
+# Strand: publish-day safety fixes (#617 / #618 / #619)
+
+## 1. Goal
+
+Land the three publish-day safety fixes that gate seg 17. Seg 16 shipped a still-draft entry and 404'd in production; the `gh pr merge` step aborted on both seg 15 and seg 16; and `weather.py` rewrote a prior entry's weather. All three must merge to `main` **before seg 17 publishes (Sun 2026-05-31)** so seg 17 runs on a hardened pipeline. This is the v1.4.20 ("Publish-pipeline hardening") gate strand. Auto-mode with conditional checkpoints; this is script work, not content.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/publish-safety /home/jhs/code/tdf26-publish-safety main
+```
+
+- Run from outside the repo or with `git -C`; do not nest the worktree.
+- Do NOT `ln -s` the `.claude` dir; it comes with the checkout.
+- Before each `git add` / `git commit`, run `git branch --show-current` and confirm `feature/publish-safety`.
+- Fresh worktree has no `node_modules` and no rider-seed data: run `npm ci`, then `cp data/riders/*.example.json` to their non-example names before `npm run build` (per `feedback_ci_seed_ordering.md`).
+
+## 3. Source-of-truth posture
+
+- The behaviour under test lives in `scripts/publish.sh`, `processing/weather.py`, and `scripts/create-release.sh`. Read them directly; do not assume the flow from the planning notes — verify against current source.
+- The failure descriptions are in issues #617/#618/#619 and in `project_next_planning_notes.md` under "Items surfaced during seg-16 publish (2026-05-28)" and "seg-15 publish (2026-05-24)". Treat those as the bug reports, not the fix spec — confirm each against the script before patching.
+- `weather.py`'s "current" resolver: read how `--entry current` selects the target before changing it. The fix is to honour an explicit `--entry $SEGMENT` from publish.sh, not to change the "current" semantics for standalone use.
+
+## 4. Target issues
+
+Milestone **v1.4.20 - Publish-pipeline hardening**. Order by dependency, not number:
+
+1. **#617** — draft pre-flight abort. Cheapest, highest leverage; do first.
+2. **#619** — `weather.py --entry $SEGMENT` from publish.sh. Independent of #617.
+3. **#618** — `gh pr merge` idempotency (check `gh pr view --json state` before merge+branch-delete).
+
+One PR may carry all three (they are small and all in `scripts/`/`processing/`), or split if review clarity wants it. Prefer one PR titled for the gate; the three issues close together.
+
+## 5. Workflow per issue
+
+- **#617:** Add a pre-flight near the top of publish.sh's `main()` (matching the fail-fast pattern Retro v1.4.18 promoted) that reads the target entry's frontmatter `draft:` field and aborts with a clear message if it is `true`. Decide with the publisher (checkpoint) whether to *abort* (publisher flips draft by hand, safest) or *auto-flip* (publish.sh sets `draft: false`). Recommend abort for this strand; auto-flip is the larger #322 design.
+- **#619:** Make publish.sh pass `--entry $SEGMENT` (the segment it is publishing) to `weather.py` instead of `--entry current`. Confirm weather lands in seg N and that seg N-1's weather block is untouched on disk (`git diff` clean on the prior entry).
+- **#618:** Before `gh pr merge --squash`, query `gh pr view <n> --json state`; if `MERGED`, skip the merge and the branch-delete and proceed to the tag/release step. Re-run cleanly against an already-merged PR.
+
+## 6. Verification commands
+
+- `bash -n scripts/publish.sh` — syntax check after edits.
+- `npm test` — full suite (expect 204 pass + skips).
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive`
+- `python3 processing/validate_points.py`
+- `npm run build` (after the seed-data step).
+- **Red-green for #617:** point publish.sh at an entry with `draft: true` (a scratch fixture or a temporary flag flip, reverted before commit) and confirm the pre-flight aborts; flip to `draft: false` and confirm it proceeds. Do not commit the breakage.
+- **Red-green for #618:** simulate the already-merged state (a PR that is MERGED, or a stubbed `gh pr view` returning `MERGED`) and confirm the merge step is skipped without error.
+- If #508's shell-test-harness lands first, wire these as harness cases; otherwise document the manual red-green in the PR body.
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `scripts/publish.sh`, `processing/weather.py`, and a possible new test fixture/harness file under `tests/` or `processing/tests/`.
+- **Reads:** `content/entries/*.md` (frontmatter only, no edits), `scripts/create-release.sh`, `data/segments.json`.
+- **Must NOT touch:** any `content/entries/*.md` body or frontmatter (published entries are fixed per `feedback_content_change_rule.md`); `data/` files; sibling work.
+- **Collisions:** this strand should be the **sole writer of `scripts/publish.sh`** for its window. Do not run it alongside a publish cycle. If #508 (shell-test harness) is being worked in parallel, coordinate — both touch the script's testability surface; land #508's harness first if it is close, else this strand ships its own minimal red-green and #508 generalises later.
+
+## 8. Scope discipline
+
+- File new issues for anything outside the three fixes (e.g. the two-pass-publish `--redeploy` path the seg-16 notes flagged — that is a real gap but a separate issue, not this strand).
+- The auto-flip-vs-abort choice for #617 is the one material checkpoint; everything else is mechanical. Do not rubber-stamp; do not over-ask.
+- Document any publisher override in the PR body.
+
+## 9. Memories that apply
+
+- `feedback_ci_seed_ordering.md` — fresh-worktree seed step before build.
+- `feedback_shared_tree_branch_verification.md` — branch check before commit.
+- `feedback_strand_worktree_path.md` — explicit-path worktree.
+- `feedback_production_preview.md` — use `nuxt generate`, not the SSR runtime, for any build spot-check.
+- `feedback_assertion_bug_class.md` — work the diagnostic by hand before writing a red-green check.
+- `feedback_content_change_rule.md` — do not touch published entries (relevant to #619's "don't rewrite seg N-1" check).
+- `feedback_strand_session_self_cleanup.md` — own the worktree teardown.
+
+## 10. Stop when
+
+- One PR open (or up to three) closing #617, #618, #619; CI green; red-green demonstrated for #617 and #618 (in harness or documented in PR body).
+- **Merged before seg 17 publishes (Sun 2026-05-31).** This is the gate — if it cannot land by then, surface that to the publisher immediately so seg 17 ships on the documented manual workaround rather than silently slipping.
+- **Cleanup (you run these):** `git -C /home/jhs/code/tdf26 worktree remove /home/jhs/code/tdf26-publish-safety` once merged.
+- Final report to publisher: PR link(s), which red-green ran, any new issue filed (e.g. `--redeploy` gap).
+- **Retro inputs written to `project_next_planning_notes.md`** under a new `## Items surfaced during publish-safety strand execution (<date>)` header: decision-actionable observations, light-tier pattern observations, numeric stats (files-touched, commits, checkpoints fired, wall-clock).

--- a/docs/strands/strand-seg-17-drafting.md
+++ b/docs/strands/strand-seg-17-drafting.md
@@ -1,0 +1,74 @@
+# Strand: seg 17 drafting — the Treignac approach via Madranges
+
+Publisher-paced single-segment drafting strand (deviation: "Workflow" lists the publisher checkpoints, not the prose-writing steps; cadence is publisher-driven). Mirrors the seg 13 / seg 15 drafting strands.
+
+## 1. Goal
+
+Draft `content/entries/17-*.md` (currently a 9-word stub) for the **Sun 2026-05-31** publish slot, 800-1,200 words, from `content/research/segs-17-19-block-research.md`. **The stub is mis-titled** `17-treignac-granite-and-water.md` — that title belongs to seg 18 (Treignac proper + the "Granite and Water" frame). Seg 17's verified content is **Madranges + the approach to Treignac across the Vézère gorges** (segments.json: seg 17 km 112-120, `towns: ["Madranges"]`, no climbs). Re-title at the arc/anchor checkpoint to a Madranges/approach anchor; flag that seg 18 likely wants the "Treignac — Granite and Water" frame.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/seg-17-draft /home/jhs/code/tdf26-seg-17 main
+```
+
+- Explicit-path worktree; no nesting, no `.claude` symlink. `git branch --show-current` → `feature/seg-17-draft` before each commit.
+- Rename the stub via `git mv` once the new slug is chosen (per the seg 12/13 precedent), don't create a second file.
+- Fresh worktree: `npm ci` + seed rider data (`cp data/riders/*.example.json` to non-example names, per `feedback_ci_seed_ordering.md`) before any `npm run build` / dev preview.
+- **Single-strand, orchestrator-session only — do not spawn sub-agents for the drafting itself.** Per the seg-13 finding, spawned agents don't surface AskUserQuestion cleanly; publisher-paced drafting runs in the orchestrator session so checkpoints fire directly.
+
+## 3. Source-of-truth posture
+
+- **Verify named on-route anchors against `data/town-coords.json` + the seg-17 GPX polyline before writing any prose around them** (the seg-16 strand's hardest-won lesson — a brief that named the wrong segment's anchor would have cost a whole draft). Madranges bourg is ~65 m off the polyline at ~km 113.5; confirm.
+- The dossier (`segs-17-19-block-research.md`, "Segment 17" section) is the research bedrock, but per `feedback_brief_content_is_carryforward.md` the dossier is scaffolding — re-verify load-bearing claims (the 1900 Protestant temple date + architect, the watershed hypothesis which the dossier explicitly flags as **unverified by Géoportail**) before they become assertions in published prose.
+- Do NOT transcribe CLAUDE.md tabular data. Narrative project context only.
+
+## 4. Anchors available (from the dossier)
+
+- **Madranges Protestant temple** — Protestantism arrived 1898; temple inaugurated **11 March 1900**, architect **Adolphe Augustin Rey** (Paris-trained, social-housing). An isolated upland Corrèze commune turning Protestant in 1898 is the segment's distinctive small-history beat. (Verify date + architect.)
+- **Église Saint-Barthélemy** — older Catholic village set-piece.
+- **The approach** — the medieval town of Treignac becoming visible across the Vézère gorges; *paysage à l'orée* register, looking onto the town rather than the massif. The dossier names this as the seg 17 frame.
+- **Landscape transition** — leucogranite basement continues from the Monédières; the open *lande* gives way to closed conifer plantation (Douglas-fir / sitka — the 20th-c. *fermeture paysagère*).
+- **No cycling-history beat** — the corridor's pro-cycling shadow is seg 18 (the 2020 Croix de Pey inversion). Per the dossier: write seg 17 as the approach; do not force a Tour beat.
+
+## 5. Workflow (publisher checkpoints — the cadence)
+
+Fire these as AskUserQuestion in the orchestrator session; iterate between them in free-form chat.
+
+1. **Anchor/title checkpoint (run first, before voice):** confirm the re-title (seg 17 = Madranges/approach, not Treignac) and the anchor selection (Protestant temple as the lead small-history beat? approach-as-frame?). This doubles as the "brief-reset" checkpoint the seg-16 strand showed is the right move when verification changes the framing.
+2. **Voice register:** pre-read the candidate register SKILL.md briefs *before* firing (per `feedback_voice_checkpoint_prep.md`). Seg 14-15 ran TLS-essay continuity; seg 17 opens a new sub-arc (post-Suc-au-May, the quiet approach) — present continuity vs a register break as a genuine fork, with one-line trade-offs. Survey, then ask.
+3. **Promises-inherited check (Retro v1.4.19 "what we lack" #2):** before drafting, enumerate the forward-looking promises earlier entries made that seg 17 must honour or consciously defer — the seg 16 close handed off the road descending toward the next commune; the Paris-continuation foreshadow planted earlier; the Monédières range is *spent* (seg 13 planted it, seg 15 earned it). Confirm what seg 17 picks up vs leaves for seg 18.
+4. **First-draft review.**
+5. **Fact-duplication audit pass** (codified from the seg-15 finding) between first-draft revisions and Sources/disclosure — catch prose/footnote/Sources triple-duplication before sign-off.
+
+## 6. Verification commands
+
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive`
+- `npm test`
+- `npm run build` then a **`nuxt generate`** preview (not the SSR runtime, per `feedback_production_preview.md`) — note the entry stays `draft: true` through drafting, so confirm rendering on the most-recent *published* entry, or temporarily preview with draft included; do NOT flip `draft: false` in the drafting PR (the publisher flips it at publish time, and #617 is adding the pre-flight).
+- MDC balance: if any `::name{...}` directives are used, grep opens vs closes (or rely on the #561/PR #563 validator now in `validate_entries.py`).
+
+## 7. Cross-strand sharing notes
+
+- **Owns (write):** `content/entries/17-*.md` (the renamed seg 17 entry) only; possibly `data/historical-tdf.json` *only if* a card is added (unlikely — no seg 17 cycling beat).
+- **Reads:** the 17-19 dossier, `data/segments.json`, `data/town-coords.json`, seg-17 GPX, `data/attractions.json`.
+- **Must NOT touch:** any other `content/entries/*.md` (published entries are fixed, `feedback_content_change_rule.md`); seg 18/19 stubs; `data/` beyond an optional historical-tdf card. Out-of-scope edits authorised mid-strand open as **sibling PRs** off main (`feedback_interpolated_pr_pattern.md`), not mixed into the draft PR.
+- **Data corrections in the corridor** (#549 Sprint-Bugeat, #551 Croix de Pey, #602 Pont de la Tourmente, #603 2017 TdL keying) are seg 18/19 concerns — note if seg 17 surfaces anything, file an issue, don't fix inline.
+
+## 8. Scope discipline
+
+- File new issues for findings outside the entry write-set; don't over-scope.
+- Style tics to actively avoid (cross-entry pattern grep before sign-off): the **"the X the Y will not Z" shape** (`feedback_will_not_shape.md` — overused seg 6-12), the word **"polyline" in prose** (`feedback_avoid_polyline_in_prose.md` — use "the road" / "the parcours"), em-dashes and exclamation marks (project standard: zero), internal-data citations in Sources (`feedback_sources_no_internal.md` — external URLs only).
+- Literary references get proper footnotes (`feedback_literary_footnotes.md`); optional `## Sources` section (`feedback_sources_section.md`); per-entry pair-writing/voice disclosure footer (`project_disclosure_practice.md`).
+
+## 9. Memories that apply
+
+- `feedback_content_change_rule.md`, `feedback_brief_content_is_carryforward.md`, `feedback_pre_publish_scrutiny.md`, `feedback_voice_checkpoint_prep.md`, `feedback_literary_footnotes.md`, `feedback_sources_section.md`, `feedback_sources_no_internal.md`, `project_disclosure_practice.md`, `feedback_will_not_shape.md`, `feedback_avoid_polyline_in_prose.md`, `feedback_interpolated_pr_pattern.md`, `feedback_on_route_checks.md`, `feedback_ci_seed_ordering.md`, `feedback_shared_tree_branch_verification.md`, `feedback_strand_worktree_path.md`, `feedback_strand_session_self_cleanup.md`. (Barthes arc is spent at seg 15 — no seg 17 obligation. Meymac/saintsbury voice is seg 25, not here.)
+
+## 10. Stop when
+
+- Renamed seg 17 entry drafted (800-1,200 words), validators green, dev preview confirmed by publisher; PR open against `main` closing/`Refs` the seg 17 tracking issue (open one if none exists).
+- Entry left `draft: true` (publisher flips at publish time).
+- **Cleanup (you run these):** `git -C /home/jhs/code/tdf26 worktree remove /home/jhs/code/tdf26-seg-17` once merged.
+- Final report: PR link, the chosen slug, voice register used, promises picked-up vs deferred to seg 18, any issue filed.
+- **Retro inputs written to `project_next_planning_notes.md`** under `## Items surfaced during seg-17-drafting strand execution (<date>)`: decision-actionable observations, light-tier pattern observations, numeric stats (word count, footnotes, MDC directives, em-dash/exclamation counts, checkpoint cycles, wall-clock).

--- a/docs/strands/strand-segs-20-22-content-research.md
+++ b/docs/strands/strand-segs-20-22-content-research.md
@@ -1,0 +1,66 @@
+# Strand: segs 20-22 block research dossier (km 134-154)
+
+Research-only strand (deviation: no "Workflow per issue"; output is a dossier, not commits to multiple file regions). Mirrors `content/research/segs-17-19-block-research.md` (PR #600), `segs-14-16-block-research.md` (PR #559), `segs-11-13-block-research.md` (PR #501).
+
+## 1. Goal
+
+Compile `content/research/segs-20-22-block-research.md`, the narrative-anchor research that feeds the seg 20, 21, 22 drafting strands. Must land **before seg 20 drafts (~publishes 2026-06-10)**. This is the Plateau-de-Millevaches heart + Mont Bessou block — the route's high-altitude traverse. Auto-mode; spawn a research subagent for depth as the 17-19 dossier did (~20-25 min subagent run). No publisher checkpoint expected unless a material framing fork surfaces.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/segs-20-22-research /home/jhs/code/tdf26-segs-20-22 main
+```
+
+- Explicit-path worktree; do not nest. No `.claude` symlink. `git branch --show-current` before commit → `feature/segs-20-22-research`.
+- Research-only branch: no `node_modules`, no rider seed needed (dossier doesn't touch entries or data files). `validate_entries.py` will run green because nothing under `content/entries/` changes.
+
+## 3. Source-of-truth posture
+
+- **Work from `data/segments.json`, `data/town-coords.json`, `data/attractions.json`, `data/competition/points-config.json`, and `data/segments/segment-{20,21,22}.gpx` directly.** The verified segment shape for this block:
+  - **seg 20** (km 134-140): no towns, no climbs — the open Plateau heart. The "verified empty" beat (per #498/#499 precedent): the Parc itself is the attraction; do not invent landmarks to fill it.
+  - **seg 21** (km 140-148): town = **Bugeat**; climb = Mont Bessou (begins). Bugeat town centre is ~24 m off the seg-21 polyline at ~km 144 — Bugeat is properly a seg 21 town (the seg 19 "gateway" title was a threshold-framing, not a literal-location, title).
+  - **seg 22** (km 148-154): no towns; climb = **Mont Bessou** (summit). Mont Bessou is the highest point in Corrèze (977 m); its town-coords coord was realigned to points-config km 152.31 under #499/PR #550 — verify it still holds.
+- Per `feedback_on_route_checks.md`: test on-route claims against the GPX polyline, not segments.json endpoints. Per `feedback_source_of_truth_framing.md`: trace provenance before treating a hand-curated value as bedrock.
+- Do NOT transcribe CLAUDE.md tabular data; narrative context only.
+
+## 4. Research plan
+
+Produce the dossier in the now-stable shape:
+
+1. **Cross-segment threads (top):** the threads that span the block. Strong candidates:
+   - **The Plateau de Millevaches proper** — heathland, peat bogs, *"mille sources"* (Celtic/Occitan, not "thousand cows"); Parc naturel régional; one of the least-populated areas of France; 20th-c. conifer afforestation (*fermeture paysagère*).
+   - **The geological-transition story deferred from seg 11** (see `project_next_planning_notes.md` forward-looking notes): the genuine lithological/topographic story of the Plateau basement belongs here or at Mont Bessou. Sources already gathered: BRGM Tulle 761 notice, Université de Limoges Bassin de Brive page, Géologie du Limousin FR Wikipédia. **This block is the natural home; develop it.**
+   - **The Resistance corridor** — the Bugeat 6 April 1944 atrocity (four L'Echameil inhabitants executed; eleven Jewish residents arrested, ten deported to Auschwitz) and the Bugeat Maquis stèle at km 143.64 (seg 21, already in attractions.json). The seg 18 dossier reserved the Bugeat-specific names for this block — they anchor seg 21.
+   - **Mont Bessou as the roof** — highest point in Corrèze, the day's altitude apex, the watershed/source country (the Vézère rises in the Longéroux peatland near here at 887 m).
+   - **2024 TdF Stage 11** re-keyed to seg 22 (Mont Bessou as altitude parallel for Puy Mary) under PR #478/#514 — verify the keying and write the beat from the seg 22 side.
+2. **Per-segment sections**, each with the six fixed headers: *Geography & geology / Local history & archaeology / Cycling context / Famous local people / Culture / Literary-musical*. Name which anchors belong to which segment (anchor allocation). Flag where a segment is genuinely thin (seg 20 likely is — write the "verified empty / the Plateau is the subject" framing rather than padding).
+3. **Data reconciliations:** capture any drift found vs points-config / town-coords / attractions as **recommended issue titles** (problem-only, per `feedback_issues_describe_problems.md`); do not file from the research worktree — planning files them. Cross-check the open summit-km items (#591 Croix de Pey is upstream; Mont Bessou drift was #499/closed — confirm). Note the Tourbière de Longeyroux (km 154.4, keyed seg 23).
+4. **Carryforwards:** explicit checklist + verification log so the drafting strands can run short and auto-mode (the 17-19 → drafting handoff worked because of this).
+5. **Sources:** external URLs backing factual claims, each flagged if it 503s/404s on spot-check (per `feedback_sources_section.md`). External only — never cite internal JSON (`feedback_sources_no_internal.md`).
+6. **Open questions:** unresolved framing forks for the drafters.
+
+## 5. Verification commands
+
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green (no entry changes).
+- Source URL spot-check: confirm each cited URL is reachable; flag failures inline rather than dropping.
+- `npm test` is **not** required (dossier-only branch, no JS/data changes — the 17-19 strand skipped it for this reason).
+
+## 6. Cross-strand sharing notes
+
+- **Owns (write):** `content/research/segs-20-22-block-research.md` only.
+- **Reads:** all `data/` files, `data/segments/*.gpx`.
+- **Must NOT touch:** any `content/entries/*.md`, any `data/` file, sibling research dossiers.
+- **Collisions:** none expected — single new file. If the seg 20-22 *data verification* (#499 follow-ups) is still in flight, read its PR for the latest town-coords; otherwise no shared write region.
+
+## 7. Memories that apply
+
+- `feedback_source_of_truth_framing.md`, `feedback_on_route_checks.md`, `feedback_corridor_commune_name_collisions.md` (disambiguate Bugeat / Millevaches communes by dept), `feedback_sources_section.md`, `feedback_sources_no_internal.md`, `feedback_issues_describe_problems.md`, `feedback_strand_worktree_path.md`, `feedback_shared_tree_branch_verification.md`, `feedback_strand_session_self_cleanup.md`.
+
+## 8. Stop when
+
+- `content/research/segs-20-22-block-research.md` committed; PR open against `main` (title references the block, body lists recommended issue titles, `Refs` not `Closes` if no umbrella issue).
+- Source URLs spot-checked; failures flagged inline.
+- **Cleanup (you run these):** `git -C /home/jhs/code/tdf26 worktree remove /home/jhs/code/tdf26-segs-20-22` once merged.
+- Final report: PR link, dossier path, anchor-allocation summary, recommended issue titles, open questions for the seg 20/21/22 drafters.
+- **Retro inputs written to `project_next_planning_notes.md`** under `## Items surfaced during segs-20-22-content-research strand execution (<date>)`: decision-actionable observations, light-tier pattern observations, numeric stats.

--- a/docs/strands/strand-segs-23-27-content-research.md
+++ b/docs/strands/strand-segs-23-27-content-research.md
@@ -1,0 +1,70 @@
+# Strand: segs 23-27 block research dossier (km 154-184.8) — the finish stretch
+
+Research-only strand (deviation: no "Workflow per issue"; output is a dossier). Mirrors the prior block dossiers. **Larger block (5 segments)** than the usual 3 — budget a longer subagent run, or split the subagent pass (23-25 / 26-27) if depth demands; the output is still one dossier file.
+
+## 1. Goal
+
+Compile `content/research/segs-23-27-block-research.md`, feeding the seg 23, 24, 25, 26, 27 drafting strands — the Meymac-to-Ussel finish stretch. Must land **before seg 23 drafts (~publishes 2026-06-21)**. Two things make this block special: (a) **seg 25 (Meymac) carries a voice reservation** — `project_meymac_voice.md` reserves the saintsbury register for the abbey segment, retargeted seg 24→25 under #500; settle the voice question here so samples can be developed before drafting; (b) **seg 27 is the finish line** (Ussel, Place Voltaire) and shares context with the **July-2 tour-history special** (#502) — coordinate so the two don't duplicate the Ussel/finish material. Auto-mode; spawn a research subagent for depth.
+
+## 2. Filesystem posture
+
+```
+git -C /home/jhs/code/tdf26 worktree add -b feature/segs-23-27-research /home/jhs/code/tdf26-segs-23-27 main
+```
+
+- Explicit-path worktree; no nesting, no `.claude` symlink. `git branch --show-current` before commit.
+- Research-only branch: no `node_modules` / rider-seed needed.
+
+## 3. Source-of-truth posture
+
+- **Work from `data/segments.json` directly. The stub entry titles are mis-anchored for this block** (the 26→27 segment re-split shifted content; stubs were named under the old scheme). Verified shape:
+  - **seg 23** (km 154-162): no towns, no climbs — descent off Mont Bessou toward Meymac. (Stub "23-descent-to-meymac" is roughly right.)
+  - **seg 24** (km 162-168): no towns, no climbs — approach/descent. (Stub "24-meymac-and-the-cote-des-gardes" is **wrong** — Meymac + Côte des Gardes are seg 25.)
+  - **seg 25** (km 168-176): town = **Meymac**; climb = **Côte des Gardes**. (Stub "25-approach-to-ussel" is **wrong**.) Benedictine Abbaye Saint-André (founded 1085); Centre d'Art Contemporain in the abbey. **Saintsbury voice reservation applies here.**
+  - **seg 26** (km 176-182): town = **Saint-Angel**. (Stub "26-ussel-place-voltaire" is **wrong** — Ussel is seg 27.) Saint-Angel village + priory (added under #500); a Monument Historique priory.
+  - **seg 27** (km 182-184.8): town = **Ussel**, the finish. Avenue Thiers finish; sprint judged at Place Voltaire. **Note #554: the GPX polyline ends ~216 m short of Place Voltaire** — the finish-line geometry has a known gap; write the finish on the verified endpoint, flag the discrepancy.
+- **Recommend the drafting strands re-title segs 24, 25, 26** at their arc-agreement checkpoints; the dossier should propose corrected anchor-aligned slugs. Do not rename the stub files from this research strand (no entry edits).
+- Per `feedback_corridor_commune_name_collisions.md`: disambiguate Meymac / Saint-Angel / Ussel against same-named communes (dept 19 + adjacency). Per `feedback_on_route_checks.md` and `feedback_source_of_truth_framing.md`.
+- The #500 verification strand already audited this block's data (filed #553/#554/#555, landed 9 fixes). Read its PR (#556) and the `tour-history-research.md` dossier so the research builds on verified ground, not re-discovers it.
+
+## 4. Research plan
+
+Dossier in the stable shape:
+
+1. **Cross-segment threads (top):** strong candidates —
+   - **The descent off the roof** — segs 23-24 are the long descent from Mont Bessou toward the Ussel basin; the Plateau gives way to the Limousin/Auvergne transition.
+   - **Meymac and the Benedictine foundation** — Abbaye Saint-André (1085), the Centre d'Art Contemporain, the medieval town. The set-piece of the block.
+   - **The Limousin→Auvergne gateway** — Ussel as the historical threshold between the Limousin lowlands and the Auvergne highlands.
+   - **Jacques Chirac and Corrèze politics** — Chirac began his political career as an Ussel municipal councillor (note: the Chirac *burial* is Montparnasse per #564/#585, and the Musée Chirac at Sarran opened 15 Dec 2000 per #586/#605 — do not re-import the corrected errors). The Musée du président Jacques-Chirac is at Sarran (off-route, near seg 14 country).
+   - **The finish line itself** — Avenue Thiers, Place Voltaire sprint-judge line; coordinate with the **July-2 tour-history special** so the historic-finishes material (Paris-Corrèze stages finishing in Ussel; Ussel never a TdF stage town) lives in the right surface.
+2. **Per-segment sections**, six fixed headers each. Be explicit where a segment is thin (segs 23, 24 likely are — descent corridors). Propose anchor allocation **and corrected slugs** for segs 24/25/26.
+3. **Voice note for seg 25:** present the saintsbury-register case (per `project_meymac_voice.md`) with enough sample texture that the publisher can confirm or diverge at the seg 25 voice checkpoint. This is the one place the research strand should do voice-prep, because the reservation predates drafting.
+4. **Data reconciliations:** recommended issue titles (problem-only) for any new drift; confirm the #500-era fixes held.
+5. **Carryforwards:** checklist + verification log for the five drafting strands.
+6. **Sources:** external only, spot-checked, failures flagged.
+7. **Open questions:** framing forks, especially the seg 27 / July-special division of labour.
+
+## 5. Verification commands
+
+- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green (no entry changes).
+- Source URL spot-check; flag failures inline.
+- `npm test` not required (dossier-only).
+
+## 6. Cross-strand sharing notes
+
+- **Owns (write):** `content/research/segs-23-27-block-research.md` only.
+- **Reads:** all `data/` files, `data/segments/*.gpx`, `content/research/tour-history-research.md`, PR #556.
+- **Must NOT touch:** any `content/entries/*.md` (including renaming the mis-titled stubs — that's the drafters' job), any `data/` file, the July-special entry, sibling dossiers.
+- **Collisions:** none on write (single new file). Coordination, not collision, with the July-2 special (#502) over Ussel/finish material — the dossier's open-questions section names the division.
+
+## 7. Memories that apply
+
+- `project_meymac_voice.md` (the seg 25 reservation — load this), `feedback_corridor_commune_name_collisions.md`, `feedback_source_of_truth_framing.md`, `feedback_on_route_checks.md`, `feedback_sources_section.md`, `feedback_sources_no_internal.md`, `feedback_issues_describe_problems.md`, `feedback_strand_worktree_path.md`, `feedback_shared_tree_branch_verification.md`, `feedback_strand_session_self_cleanup.md`.
+
+## 8. Stop when
+
+- `content/research/segs-23-27-block-research.md` committed; PR open against `main` (`Refs #502` for the finish/July coordination; body lists recommended issue titles + proposed corrected slugs for segs 24/25/26 + the seg 25 voice recommendation).
+- Source URLs spot-checked.
+- **Cleanup (you run these):** `git -C /home/jhs/code/tdf26 worktree remove /home/jhs/code/tdf26-segs-23-27` once merged.
+- Final report: PR link, dossier path, anchor allocation + slug corrections, seg 25 voice recommendation, July-special coordination note, open questions.
+- **Retro inputs written to `project_next_planning_notes.md`** under `## Items surfaced during segs-23-27-content-research strand execution (<date>)`: decision-actionable observations (esp. the slug corrections + voice call), light-tier pattern observations, numeric stats.


### PR DESCRIPTION
Close-out artifacts for the 2026-05-28 planning session. Docs only; no code or data changes.

## What this lands
- **`docs/planning/v1.4.20-scope.md`** — milestone-scope file. v1.4.20 themed **Publish-pipeline hardening** (seg 16 404'd in production; harden publish.sh for the 11-segment run-in). Trimmed to a 10-issue set; data-to-display reconciliation named as the next cycle's candidate spine.
- **`docs/planning/NEXT.md`** — refreshed handoff singleton (replaces the stale 2026-05-22 note). Leads with the content production line as the binding constraint: segs 17-27 to draft on a no-slack Sun/Wed cadence, research dossiers for 20-22 and 23-27 not yet spawned.
- **`docs/planning/2026-05-28-archive.md`** — prior planning-notes content (strand close-outs 2026-05-12 → seg-16 publish) archived for retro reference.
- **Four strand briefs** in `docs/strands/`:
  - `strand-publish-safety-617-618-619.md` — weekend gate strand: the three publish-day fixes (#617/#618/#619) before seg 17.
  - `strand-seg-17-drafting.md`, `strand-segs-20-22-content-research.md`, `strand-segs-23-27-content-research.md` — content-line strands committed to run this cycle.

## Session actions already landed (outside this PR)
- v1.4.19 milestone closed (drained, 23 issues); v1.4.20 renamed from "TBD".
- #617/#618/#619 filed; v1.4.20 triaged to its themed set.
- Roadmap wiki updated.

`Refs #481` (planning canonical entry/exit shape — this is the milestone-scope + handoff practice in action, not a close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)