### PR TITLE
research: segs 20-22 block dossier (Plateau de Millevaches + Mont Bessou)

### DIFF
--- a/content/research/segs-20-22-block-research.md
+++ b/content/research/segs-20-22-block-research.md
@@ -1,0 +1,302 @@
+# Block research dossier — segs 20-22 (km 134-154)
+
+> Compiled 2026-05-28 by the segs 20-22 research strand. Feeds drafting strands for segs 20, 21, 22. Mirrors the shape of `segs-17-19-block-research.md` (PR #600), `segs-14-16-block-research.md` (PR #559), `segs-11-13-block-research.md` (PR #501). This is the Plateau-de-Millevaches heart + Mont Bessou block — the route's high-altitude traverse and altitude apex. Seg 20 drafts ~2026-06-10; this dossier lands before that.
+
+## Cross-segment threads
+
+**The Plateau de Millevaches itself is the subject.** This 20 km block is the only stretch of Stage 9 that crosses the *interior* of the Plateau de Millevaches — the high granite tableland the seg 17-19 block only reached the *threshold* of (Lestards crest). The segs 17-19 dossier explicitly reserved "the Plateau body" for here; this is where it spends. The Parc itself is the attraction. The empirical backing for the "verified empty" beat is hard: the Canton du Plateau de Millevaches groups ~33 communes for ~10,290 people; Toy-Viam (off-route, adjacent) is the smallest commune in the Limousin by population at **35 inhabitants** (density 3 hab/km²); densities of 3-8 hab/km² are normal here. Seg 20 (km 134-140) has no on-route town and no climb in `segments.json` — and that is *correct*, not a data gap. Drafters: do not invent landmarks to fill seg 20. The writable beats are the heath, the peat, the granite, the depopulation, the planted forest, and the people who chose to live and write here anyway.
+
+**The name that resists its own folk-etymology.** The meaning of "Millevaches" is genuinely contested (Wikipedia FR: "très controversé"). Lay it out as a spectrum from folk to scholarly: *(a)* **"mille vaches" / thousand cows** — the obvious modern-French reading, treated as folk etymology; *(b)* **"mille sources" / thousand springs** — the tourism-marketing favourite ("pays des mille sources"), proposing a Celtic root *batz* = source, but Wikipedia notes it "lacks historical/linguistic documentation"; *(c)* **Dauzat–Rostaing (scholarly-favoured)** — Gaulish ***melo*** ("height, high place") + Latin ***vacua*** ("empty, abandoned") = **"the empty highland,"** a bilingual Gaulish-Latin compound; *(d)* **Ernest Nègre** — Occitan *mila vacas*, but glossed *metaphorically* (scattered granite boulders "grouped like herds of cattle"); *(e)* **Jean Costes** — Old French *mi* + *vaque* = "the empty middle"; *(f)* a reading via geographer **Roger Brunet** (Lavalade/Vignaud) — *miu bachas* "between the valleys." Drafter angle for seg 20: the name itself enacts the place's ambiguity — empty highland, thousand springs, herds of stone, between-the-valleys are all true of the landscape; the literal "thousand cows" is the one thing it is *not*.
+
+**The granite roof and its deferred geology.** (The seg 11 dossier deferred the genuine lithological story of the Plateau basement; this block is its natural home — develop it here or at Mont Bessou.) The Plateau is floored by the **Massif de Millevaches**, a major N-S leucogranite batholith — one of the largest granite massifs in the Massif Central, ~100 km long. **Variscan / Hercynian** origin, emplaced late in the orogeny: the HAL thesis fixes the window at **granites 360–300 Ma**, the main generations at ~350 Ma, intruded under transpressive tectonics during the Laurentia–Gondwana collision, rising as successive injections along the N-S Pradines fault/shear zone into older Paleozoic micaschists and leptynites. The reason the Plateau reads as *high-but-flat*: the summits coincide with an ancient **planation surface (pénéplaine / surface d'aplanissement)**, gently tilted SE→NW, uplifted *en bloc*, then dissected by river gorges at its edges. So the interior is a rolling high tableland while the rivers cut deep gorges off the rim (the Vézère gorge at Treignac, seg 18, is one such edge-cut). And the **impermeable granite floor** is what breeds the peat: cold wet climate + poorly-drained shallow granitic basins let water pool, and since the post-glacial Holocene (~7,500–8,000 yr) sphagnum has accumulated in granite bowls to build the *tourbières*. The bogs literally sit in granite basins. This is the through-line that connects seg 20's heath, seg 22's Mont Bessou, and the Tourbière de Longeyroux at the block's far edge.
+
+**The water-castle and the watershed.** The Plateau is the *château d'eau de la France* — the PNR cites **eleven rivers over 50 km** rising on or around it (Vienne, Creuse, Vézère, Taurion, Corrèze, Tardes, Maulde, Luzège, Briance, Chavanon, Diège). The watershed split runs through the block: northern drainage (Vienne, Creuse) feeds the **Loire**; southern drainage (Vézère, Corrèze → Dordogne) feeds the **Atlantic via the Garonne**. Mont Bessou (seg 22) sits at the apex of this hinge. The Vézère — the river the riders crossed at Treignac on the medieval bridge (seg 18) — rises in the Longeyroux peatland at the block's eastern edge (~887 m); **its source and Meymac are RESERVED for segs 23-24** (Saintsbury voice, `project_meymac_voice.md`), but the block may name the headwater country as the landscape the rider crosses the top of.
+
+**The planted wilderness (enrésinement / *fermeture paysagère*).** The central landscape-transformation story, and the best single piece of material in the block. Pre-1950s the Plateau was **open country** — a near-treeless high moor of heath and pasture. After WWII the **Fonds Forestier National (FFN, from ~1947)** subsidised mass planting of *exotic* conifers — **Douglas fir, Sitka spruce, grand fir** — onto abandoned farmland and heath: **~45,000 hectares of forest created in ~40 years** on the Plateau, plantation cover passing two-thirds of the territory in many communes. Wikipedia FR names the result ***fermeture paysagère*** — "landscape closing": open horizon walled in by dark even-aged conifer blocks. The plantations skewed toward absentee/corporate *forêt de placement*, deepening the split with resident stock-farmers; the December 1999 storm flattened large areas of the young monoculture, exposing the model's fragility. Drafter angle: the rider crosses a landscape whose "wildness" is partly an industrial artefact — Douglas walls that did not exist within living memory, planted over a thousand-year-old moor.
+
+**The Resistance corridor — terrain, set-piece, and chronology.** Seg 20's empty terrain *is* maquis terrain — remote, forested granite uplands with thin population, ideal hiding country for **Georges Guingouin's Maquis du Limousin (FTP)**. The block's *on-route* node is the **Bugeat set-piece of 6 April 1944** (seg 21, below). Keep the chronology straight: spring-1944 anti-maquis/anti-Jewish *repression* (Bugeat, 6 April, by the **Brehmer Division** — NOT Das Reich, which struck Tulle/Oradour two months later) precedes the summer-1944 *battle* (**Bataille du Mont Gargan, 18-24 July 1944** — ~3,500 FTP under Guingouin vs the German colonne Jesser, the hardest fight Guingouin's men fought, ~40 km west on the Plateau's Haute-Vienne rim), which precedes the August Liberation. Jean-Marie Borzeix's book ***Jeudi saint*** (2008) frames the Bugeat events as one node in a "semaine sanglante" across the Plateau (l'Église-aux-Bois, Tarnac, Bugeat). Seg 20 carries the *why the terrain sheltered fighters*; seg 21 carries *the human cost*; Mont Gargan is the regional climax to gesture toward, not to relocate onto the route.
+
+**Mont Bessou — the roof of the day, and a Tour de France first.** Seg 22 crests the **highest point of the Corrèze, of the Limousin, and of the Plateau de Millevaches: Mont Bessou, 977 m** — on the commune of Meymac (seg 23-24 territory, but the route event is seg 22). **The route does NOT cross the geographic summit.** The road crest is at route-km 152.31 / **892 m** (verified: GPX argmax 892 m at km 152.25, 0 m off the climb coordinate); the 977 m peak and its 26 m Douglas-fir panoramic tower (built 2005, 148 steps) stand ~1.3 km off-route to the east at km 161.18 (seg 23 area). The road passes *under* the peak. And the categorised climb is **gentle — ASO Cat 4, ~5 km @ 2.7%** — so the day's altitude apex is *not* its hardest climb (Suc au May, seg 15, and the Côte de la Croix du Pey, seg 18, are harder). Two clean beats: **(1)** Mont Bessou has **never been climbed by the Tour de France** — the 2026 ascent is its debut; **(2)** the *gentle giant* / the-roof-is-soft framing. Bonus image: Mont Bessou was equipped as a **cross-country ski (ski de fond) station in the 1970s** — a Nordic winter spot that becomes a July Tour summit.
+
+**The 2024 Tour Stage 11 altitude parallel.** Keyed to seg 22 in `historical-tdf.json` (re-keyed from segs 14-16 under #478). **Stage 11, Wednesday 10 July 2024, Évaux-les-Bains → Le Lioran (Cantal)** ran ~60 km *east* of the Stage 9 corridor and **shared no roads** — it is an *altitude parallel, not a route overlap*: its high climb, **Puy Mary (1,589 m)**, is the high-altitude analogue for Mont Bessou (977 m), the roof of each respective stage. **Jonas Vingegaard** beat **Tadej Pogačar** in an uphill sprint (Evenepoel 3rd) after Pogačar attacked near the top of Puy Mary with ~31.6 km to go and Vingegaard clawed back the gap on the Col de Pertus — his first big GC move back from his pre-Tour crash. The seg 22 beat: write the parallel from the Mont Bessou side (the modest 977 m roof against the 1,589 m one, two days and 60 km apart in 2024-vs-2026 race memory).
+
+**Writers of the Plateau.** A genuine literary cluster is associated with Millevaches, and one of them was born *on this block's route*. Vincent Pélissier's ***Autour du Grand Plateau*** (2002, Éd. Mille Sources) is devoted to **five writers of the place: Pierre Bergounioux, Alain Lercher, Jean-Paul Michel, Pierre Michon, and Richard Millet.** The thread spans the block and is strongest at seg 20 (the open interior); see the per-segment Literary/musical sections for allocation. The matching musical note is the **chabrette limousine** (the mirror-set Limousin bagpipe), near-extinct and revived from 1987.
+
+## Segment 20 (km 134-140) — the open Plateau, the verified-empty heart
+
+> Route fact: 741 GPX points, km 134.0-140.0. **No on-route town, no climb** (`segments.json`) — verified correct. Net descent: 827 m at km 134.0 (the seg 19/20 boundary, near the Lestards-area high ground) down to 722 m at km 136.86, recovering to ~735 m at the seg 20/21 boundary. Bugeat town centre is 3,245 m off the polyline here. The corridor runs NE of Lestards toward Bugeat along the D979/D36 line. **This is the segment where the Plateau body-material spends.**
+
+### Geography & geology
+
+- The road crosses the *interior* high tableland — the planation-surface country described in the cross-segment geology thread. What the rider sees: open *landes* (heath: *Calluna vulgaris*, *Erica*), poorly-drained shallow valleys, peat in granitic hollows, and the dark Douglas-fir / Sitka-spruce plantations of the post-1947 *enrésinement*. Altitude band here ~720-830 m; oceanic-montane climate, 1,000-1,400 mm precipitation, real winter snow.
+- **Commune territory (the corridor crosses tiny Plateau communes; flag on-route vs adjacent carefully):** the seg-20 line runs through/along the territories of **Gourdon-Murat** and **Pérols-sur-Vézère** toward Bugeat. **Gourdon-Murat (19087):** ~85-109 inhabitants, 15.87 km², ~720 m average altitude, density ~7 hab/km², pop -30% since 1999; borders Lestards (2.8 km) and Bugeat (5.3 km). **Pérols-sur-Vézère (19160):** ~192-199 inhabitants, ~47 km² (a large, very sparse upland commune), altitude 708-943 m; the upper Vézère rises in this area; birthplace of Félix Lestang (1889 — see seg 21); it gives its name to the "pink granite of Pérols." **Adjacent but NOT on the seg-20 road (use as "the Plateau around them," not as on-route landmarks): Viam** (the Plateau lake set-piece — Lac de Viam, 183 ha on the Vézère, EDF barrage de Monceaux-la-Virolle in service 1946, ~663 m, an 18 km lakeside trail) and **Toy-Viam** (35 inhabitants, the smallest commune in the Limousin — the demographic-extremity detail). **Drafters: confirm on the ground which commune the polyline actually enters; the territory-level reading is research-grade, not polyline-verified for these tiny communes.**
+- **Watershed:** the block straddles the Loire/Atlantic divide (cross-segment thread). On seg 20 the rider is on the high interior where the headwaters gather; the directional split sharpens toward Mont Bessou (seg 22).
+
+### Local history & archaeology
+
+- The Plateau's deep history is *thin settlement on poor granite* — pastoral, rye-grain, granite-quarrying country. The archaeology is **protohistoric**: tumuli and cairns scattered across the heath (the same Bronze/Iron-Age burial landscape that includes Bugeat's La Tène mounds, seg 21). The set-piece archaeological site of the block, **Les Cars (Gallo-Roman)**, sits ~4.9 km north of the route on the Saint-Merd-les-Oussines / Pérols-sur-Vézère boundary — an *off-route* anchor; full detail under seg 21 (it is keyed nearest km 143.64) but its *landscape* is this open interior.
+- **Marius Vazeilles** is the human key to the Plateau's history-and-landscape both: a forester / reforestation engineer and self-taught archaeologist who *discovered Les Cars in 1917* during reforestation surveys — i.e. the man who helped plant the Plateau's modern forests also dug up its Roman past. A genuine seg-20 figure (he belongs to the *open-Plateau* story); see Famous people.
+
+### Cycling context
+
+- **No prior Tour de France passage** through the open Plateau heart. The 2020 Stage 12 (Chauvigny → Sarran) only skirted the Plateau's *southern* fringe at Suc au May (seg 15) and never reached the interior or Bugeat. Seg 20 has *no* pro-cycling shadow of its own — and that is fine. Write it as the high crossing, the quiet middle of the back half, the rider alone on the open moor. The cycling beats are reserved for seg 21 (Bugeat / Tour du Limousin) and seg 22 (Mont Bessou).
+
+### Famous local people
+
+- **Richard Millet** (b. **1953, Viam, Corrèze** — a Plateau commune on/beside this block's route). A major French novelist whose entire fictional world is the Plateau, transposed to the invented village of **Siom**: *La Gloire des Pythre* (1995), *L'Amour des trois sœurs Piale*, *Lauve le pur*, *Ma vie parmi les ombres*. Critics liken the Plateau's role in his work to Giono's Haute-Provence, Faulkner's Yoknapatawpha, Hardy's Wessex. **The block's single strongest native-son anchor — born on the route.** (Note: Millet is also a controversial public figure for later political/polemical writing; drafters who use him should anchor on the *Siom*-cycle Plateau fiction, which is what ties him to this ground.)
+- **Marius Vazeilles** (forester, reforestation pioneer, archaeologist; discovered/excavated Les Cars from 1917). Doubles as an archaeology *and* people beat — the man who both forested and unearthed the Plateau.
+- The seg-20 communes (Gourdon-Murat, Pérols, Viam, Toy-Viam) yield no further documented famous native beyond Lestang (born Pérols, anchored to Bugeat / seg 21). Drafters: do not invent one; the Plateau's "famous people" are mostly its *writers* (below) and its *settlers*.
+
+### Culture
+
+- **The least-populated-France texture** is the cultural fact: a 35-person commune (Toy-Viam), 3-hab/km² densities, the aged demographic profile (over-75s ~14% vs 8.2% nationally). This is *vécu* emptiness, not scenic emptiness.
+- **The néo-paysan / "retour à la terre" movement** is the Plateau's distinctive modern culture. From the **1970s** the *Montagne limousine* drew back-to-the-land settlers — the 1968 generation, mixing communist, Maoist, libertarian and Occitanist activists with locals (one account: they settled here because it was "the first 'desert' they hit" coming from Paris). This fed the **anti-*enrésinement* struggle**: the association *Vivre dans la Montagne Limousine* organised a **march of ~500 people on 15 May 1977** defending agriculture and the open landscape against conifer planting. The independent paper **IPNS** (*Information Politique Nouvelles Sociales* — "journal d'information et de débat du plateau de Millevaches") has chronicled this for decades. The Plateau has a durable identity as a *leftist / utopian, self-consciously written-about place*. (Verify the 1977-march detail before citing a hard number — see Sources flags.)
+- **Cuisine** is upland-Limousin: rye bread, blueberries/myrtilles, mushroom cookery, the Plateau's poor-soil pastoral food — the shift the seg 19 dossier located at the Lestards threshold is fully arrived here.
+
+### Literary / musical
+
+- **The "writers of the Plateau" cluster is the seg-20 literary spend.** Pélissier's *Autour du Grand Plateau* (2002) names five: **Pierre Bergounioux, Alain Lercher, Jean-Paul Michel, Pierre Michon, Richard Millet.** Allocation suggestion: **Millet** (native son, Siom = the Plateau) is seg 20's anchor; **Bergounioux** offers a deliberately *dark* counter-reading (he regards the Plateau de Millevaches as austere, somber, "everything he dislikes" — the paternal Millevaches set against his sunny maternal Quercy; his *Miette* and *La Casse* are Corrèze-territory books). A drafter can pair Millet's elegiac Plateau with Bergounioux's bleak one — the same granite read two ways.
+- **Marcelle Delpastre (1925-1998)** — the strongest *Occitan* literary anchor, though her ground (Germont, commune of Chamberet) sits on the Plateau's *western edge* just off the block. A working farmer who became one of the ten greatest Occitan writers of the 20th century: poet, ethnographer, storyteller of the disappearing peasant Limousin (*La Vinha dins l'òrt*, 1968; *Los Contes dau Pueg Gerjant*, 1970). Her 2025 centenary ran a Nouvelle-Aquitaine programme. Use her as the *voice of the land itself* — Occitan verse rooted in exactly this granite-and-heath world.
+- **Music: the chabrette limousine** — the bagpipe "with mirrors" (its bag/box set with small tin-framed mirrors), the instrument specific to the Limousin, attested since the 17th century (Mersenne's *Harmonie Universelle*), modal and drone-heavy. Nearly lost — only three traditional players were ever recorded — and revived from **1987** by the Limoges Conservatory and sustained by the CRMT Limousin. A near-extinct mirrored bagpipe revived on the empty Plateau pairs naturally with Delpastre's Occitan verse.
+
+## Segment 21 (km 140-148) — Bugeat, the granite town and the 6 April 1944 wound
+
+> Route fact: 618 GPX points, km 140.0-148.0. Town = **Bugeat**, bourg **24 m off the polyline at route-km 143.64** — firmly on-route, the block's only real town. The **Stèle des fusillés** (attractions "Stele des Maquisards") is 448 m off at km 143.61. The segment's high point is 772 m at km 146.69; the Mont Bessou climb's *toe* falls near the seg 21/22 boundary (the categorised ascent is essentially a seg 22 event — see Data reconciliations). Net roughly flat-to-rolling across the Plateau into and out of Bugeat.
+
+### Geography & geology
+
+- Bugeat sits in the Plateau interior at 667-844 m commune elevation; 30.99 km², density ~23 hab/km². The town is the granite-and-rail bourg of the high country — see the Maison du Granite (Culture) for the local stone's named colour variants ("pink granite from Pérols, ochre granite from Bugeat").
+- The route reaches its on-segment high (772 m) late, at km 146.69, then dips slightly before the Mont Bessou ascent proper begins in seg 22. The Vézère runs near Bugeat in its upper-mountain reach (the river the riders crossed at Treignac, seg 18, here near its source country).
+
+### Local history & archaeology
+
+- **Deep history:** La Tène Gallic tumuli (~450-50 BC, e.g. in the wood of Chaleix); a Gallo-Roman villa ("Champ du palais," 1st c. AD) — the bourg functioned as a Roman *vicus*. Medieval parish around **Église Saint-Pardoux** (Gothic, 14th-15th c., with a 12th-c. Romanesque baptismal font). **Château de Gioux (1749).**
+- **The railway, 8 October 1883** — the Eymoutiers–Meymac section of the Limoges–Ussel line reached Bugeat; the defining modern-infrastructure event for a remote bourg, and the reason Bugeat became a service town and (later) a sports-centre town. WWI cost the commune 74 dead. Bugeat was a **communist stronghold**, communist-run until 1967.
+- **Les Cars Gallo-Roman site (off-route, ~4.9 km north; nearest km 143.64).** The block's richest archaeological anchor, on the Saint-Merd-les-Oussines / Pérols-sur-Vézère boundary. A luxury villa + two funerary monuments, built first half of the 2nd c. CE (mausoleums late 2nd / early 3rd c.). The two mausoleums are of large granite ashlar assembled *dry* but bound by iron-in-lead clamps: **Mausoleum 1** held a single **blue-glass funerary urn** (the estate owner's ashes); **Mausoleum 2** held the whole *familia* (family + slaves), with an **octagonal granite sarcophagus carved with a boar-hunt relief** (an elite Roman pursuit). The villa had running water, hypocaust heating, mosaics, painted walls, a **~8-tonne monolithic granite basin** (the *cuve*), lead piping to a full bath suite (caldarium/tepidarium/frigidarium), two kitchens, a circular granite fountain. **Discovered by Marius Vazeilles in 1917**; classified Monument historique by decree of **11 September 1935**; systematic excavation from 1936; free access year-round. **Drafters: an off-route beat (~4.9 km), within the corridor's precedent for off-route attractions but at the far edge — write it as "on the Plateau north of Bugeat," not as a roadside sight.**
+
+#### The 6 April 1944 set-piece (Bugeat's Resistance wound)
+
+A standalone fr.wiki article exists: ***Fusillés et déportés de Bugeat***. The verified facts (with corrections to earlier corridor material):
+
+- **Perpetrator: the Brehmer Division** (Gen. Walter Brehmer), running an anti-Jewish / anti-maquis sweep across Dordogne–Corrèze in spring 1944. **NOT** Das Reich (Tulle/Oradour, two months later).
+- **Four farmers shot at the hamlet of L'Échameil**, 6 April 1944: **Léon Gane (37), Antoine Gourinal (44), Antoine Nauche (56), Henri Vacher (50).**
+- **A fifth man, Chaïm Rozent (33)**, a Jewish resident/résistant, arrested in Bugeat and shot separately at l'Église-aux-Bois the same day — reportedly refused under torture to give up the maquis. (A 2023 documentary, *Sortie des ombres*, traces his story.)
+- **Ten Jewish women and children** arrested 6 April 1944, deported in **Convoi 72** (left Drancy 29 April 1944) to Auschwitz; **only one survived.** Named: Lucie Fribourg (70), Carola Hoch (49), Anna Izbicka (6), Jeanne Izbicka (16), Anna Kleinberg (11), Maryem Kleinberg (40), Rosa Kleinberg (9), Brana Tencer (37), Serge Tencer (3½), Clara Uhlmann (67). **The ages are the load-bearing horror — a 3½-year-old, a 6-year-old, two in their 60s-70s.**
+- **Verified count for drafters: 5 men shot + 10 Jews deported (1 survivor).** Earlier corridor research said "11 arrested / 10 deported" — that conflated Rozent into the deportee group; treat the corrected figures as authoritative.
+- **Memorials:** a **stèle at the pont de Vezou (D32), inaugurated 6 April 1947** for the four L'Échameil men; the **Monument aux morts** on Place du Champ de foire; a **new memorial plaque unveiled 8 May 2025 at the town hall** (a live, recent "still remembered" beat). Annual ceremony at the stèle des fusillés de l'Échameil. Published account: **Jean-Marie Borzeix, *Jeudi saint* (2008).**
+- **CAUTION (see Data reconciliations #1):** the on-route memorial at km 143.61 is, on the evidence, the **stèle des fusillés de L'Échameil**, not a "Stèle des Maquisards" dedicated to "Maquis du Mont Gargan and Plateau de Millevaches partisans" (the Mont Gargan maquisards stèle is at the Mont Gargan summit, Haute-Vienne, ~40 km off-corridor). Drafters: write the Bugeat memorial as the *fusillés/déportés* memorial; do not assert a Mont-Gargan dedication without on-the-ground confirmation.
+
+### Cycling context
+
+- **Bugeat already knows the pro caravan — via the Tour du Limousin (UCI 2.1), not the Tour de France.** Twice a stage town: a **1992** stage ran **Bugeat → Limoges** (won by Patrick Strouken), and **Stage 3 of the 2021 edition departed from Bugeat** (Thu 19 Aug 2021, to Lubersac), the start tied to the **Espace 1000 Sources** complex. A real, writable distinction: the Plateau's town has hosted pro racing for decades through the regional race; 2026 is the *Tour de France's* first visit.
+- No Tour de France has crossed Bugeat or the Plateau heart before 2026. A local **cyclosportive loop, "Circuit cyclo sportif au Cœur de Millevaches" (78.4 km), departs from Bugeat** and rides the peat-and-heather plateau through Peyrelevade — road-cycling infrastructure already centred on this block.
+
+### Famous local people
+
+- **Félix Lestang** (b. Étienne Félix Lestang, **21 Jan 1889 at Pérols-sur-Vézère**; d. **25 Oct 1967 at Bugeat**). Socialist then **communist** (joined the PCF at the 1920 Tours Congress). **Mayor of Bugeat 1932-1959; conseiller général 1937-1961; président du conseil général de la Corrèze in 1945** (at the Liberation). The figure who made Bugeat a communist commune for a generation. (Maitron is the biographical source; the direct page 403'd this round — verify the 1945 président claim before publishing it as fact. See Sources flags.)
+- **Alain Mimoun (1921-2013)**, Olympic marathon champion (Melbourne 1956) — *at the origin* of the **Espace 1000 Sources** altitude/physical-prep centre at Bugeat (created **1960**, ~720 m, among the forests/lakes/peatlands). Jacques Chirac backed an accommodation-and-pitch expansion in **1989** (Chirac recurs across the corridor). The centre keeps Mimoun's name today ("Espace 1000 Sources – Centre sportif Alain Mimoun," a departmental facility). **Note:** Mimoun is associated by *patronage*, not by birth — write the connection precisely.
+- **Henri Troyat** (Académie française; b. Lev Tarassov) **lived in Bugeat** (his then-wife's home town) and drew on it for his five-volume saga ***Les Semailles et les Moissons*** (from 1953), whose opening generation is set in a small Corrèze town. A literary tie directly to Bugeat.
+- No strongly documented third "born-in-Bugeat" celebrity surfaced; drafters should not invent one.
+
+### Culture
+
+- **The Maison du Granite** — a permanent exhibition inside the Bugeat tourist office on the Plateau's granite heritage (geology, quarrying, blockwork, building craft). The texture detail to keep: the local stone has *named regional colour variants* — **"pink granite from Pérols, ochre granite from Bugeat."** Free access in tourist-office hours.
+- Cuisine is upland-Limousin (rye, myrtilles, mushrooms, granite-country pastoral food). The town's modern identity braids three threads: granite (Maison du Granite), rail (1883 station), and altitude sport (Espace 1000 Sources) — a usable triad for the seg-21 drafter.
+
+### Literary / musical
+
+- **Henri Troyat / *Les Semailles et les Moissons*** is the Bugeat-anchored literary beat (above). Beyond it, the block's literary spend is the "writers of the Plateau" cluster, allocated mostly to seg 20 (Millet, Bergounioux) — seg 21 can reach forward/back to that cluster but Troyat is its own, town-specific anchor.
+- The chabrette / Occitan-music note (seg 20) and Delpastre (seg 20) are the block's musical/poetic register; seg 21 need not re-spend them.
+
+## Segment 22 (km 148-154) — Mont Bessou, the roof of the day
+
+> Route fact: 319 GPX points, km 148.0-154.0. **Climb = Mont Bessou**, road crest at route-km **152.31 / 892 m** (GPX argmax 892 m at km 152.25, 0 m off the climb coordinate — the #499/PR #550 realignment holds). Net climb: 758 m at km 148.0 → 892 m at the crest, ≈ +134 m over ~4.3 km ≈ 3.1% (ASO Cat 4, points-config 5 km @ 2.7%). No on-route town. The **Tourbière de Longeyroux** sits ~1.2 km off the polyline at km 154.0 — the seg 22/23 hinge.
+
+### Geography & geology
+
+- **Mont Bessou, 977 m — the highest point of the Corrèze, the Limousin, and the Plateau de Millevaches**, on the south-eastern rim of the Plateau (commune of Meymac). **The route crosses its gentle road crest at 892 m, not the geographic summit** (cross-segment thread; verified). The 977 m peak and its 26 m Douglas-fir panoramic tower (inaugurated 17 June 2005; 148 steps, 7 platforms — symbolically lifting the visitor to ~1,000 m) stand ~1.3 km east of the road. From the summit on a clear day: a 360° sweep east to the Monts Dore / Puy de Sancy, Banne d'Ordanche, Puy de Dôme, and the Monts du Cantal. **Etymology:** "Bessou" from Occitan *bessou/besson* = "twin," read as the twinning with the near-equal **Puy Pendu (970 m, second-highest in Corrèze, <2 km NW)**. *(Correction to brief: Puy Pendu is 970 m — LOWER than Bessou's 977 m; Bessou is unambiguously the high point.)*
+- **Geology:** the apex of the leucogranite planation surface (cross-segment thread). Mont Bessou dominates the lower secondary plateaus toward the Dordogne by 250-300 m — literally the roof. The block ends at the threshold of the **Tourbière de Longeyroux** (project spelling; fr.wiki "Tourbière du Longéroux"), the **largest peat bog in the Limousin** (~259.67 ha; altitude 870-900 m; sedimentation began ~7,500 yr ago, post-glacial sphagnum infill of a pond in a granitic basin). It spans four communes (Meymac, Saint-Merd-les-Oussines, Chavanac, Saint-Sulpice-les-Bois), protected since a biotope decree of 10 June 1986, Natura 2000, managed by CEN Limousin; fauna includes otters and the short-toed snake eagle, flora includes sundew (*Drosera*). **The Vézère rises here (~887 m, SE of the bog, near Meymac) — RESERVED for segs 23-24; seg 22 may name the headwater/peat country as the landscape it crests into, but not develop the source or Meymac.**
+
+### Local history & archaeology
+
+- Mont Bessou's "history" is geological-and-recreational rather than settled: it is a summit and a watershed marker, not a village. The human history of this stretch is the **Tourbière de Longeyroux as a managed natural monument** (1986 biotope decree, the boardwalk trail through the heather moor) and the broader Plateau-archaeology landscape (the protohistoric cairns; Les Cars to the north-west, seg 21). The peat itself is an 8,000-year archive — pollen cores from Limousin tourbières record the post-glacial vegetation and the medieval-to-modern deforestation/reforestation cycles.
+- The commune is **Meymac**, whose abbey, town, and the Vézère source are **RESERVED for segs 23-24** (`project_meymac_voice.md`). Seg 22 names Meymac only as the territory the summit sits in.
+
+### Cycling context
+
+- **Mont Bessou has never been climbed by the Tour de France** — the 2026 Stage 9 ascent is its debut (multiple 2025-26 race previews state this explicitly). The route's altitude apex is a first-ever for the Tour: a clean headline beat for seg 22.
+- **The "gentle giant" framing is supported:** the 2026 race crosses Mont Bessou by its *gentle* road crest (Cat 4, ~5 km @ 2.7%), not the steep Meymac south face (a cyclo-climb listed with pitches >15% — a *different* approach, not the race line; drafters must not conflate them). The day's crux climbs are Suc au May (seg 15) and the Côte de la Croix du Pey (seg 18); the roof is soft. The apex is not the crux — a genuine cycling-narrative inversion.
+- **The 2024 Tour Stage 11 / Puy Mary altitude parallel** (cross-segment thread): Vingegaard beat Pogačar at Le Lioran on 10 July 2024, ~60 km east, no shared roads — the high-altitude analogue (1,589 m) for Stage 9's modest 977 m roof. Write the parallel from the Mont Bessou side.
+- **Seasonal inversion:** Mont Bessou was equipped as a **cross-country ski (ski de fond) station in the 1970s** (rental chalet; tourist development incl. a plan d'eau from 1973); today a major **MTB/gravel hub** ("vitrine du VTT en Haute-Corrèze," one of France's largest FFCT-labelled networks, a dedicated descent track). A Nordic-ski summit that becomes a July Tour climb is a vivid image.
+
+### Famous local people
+
+- Mont Bessou is a summit, not a birthplace — it yields no native figure of its own. The block's people are anchored at seg 20 (Millet, Vazeilles, the writers) and seg 21 (Lestang, Mimoun-by-patronage, Troyat). **Meymac's figures are RESERVED for segs 23-24.** Drafters: seg 22's "people" beat, if needed, reaches back to the writers of the Plateau or forward (lightly) to the headwater country — do not import Meymac names.
+
+### Culture
+
+- The summit's culture is **the panorama and the peat** — the Douglas-fir tower (itself a monument to the tree that remade the Plateau), the cross-country-ski heritage, the MTB network, and the Tourbière de Longeyroux's boardwalk. The cultural register is *the high open roof*: the rider tops out on the day's apex, the conifer walls fall away to a 360° horizon, the watershed tips from Loire toward Atlantic, and the headwater country (the Vézère source, reserved) opens to the east.
+- Cuisine remains upland-Limousin; the *myrtille* (bilberry) of the heather moor is the seasonal Plateau marker.
+
+### Literary / musical
+
+- The Plateau literary cluster (seg 20) and Delpastre's Occitan voice (seg 20) are the block's literary register; seg 22 can close the block on the *summit-as-threshold* image rather than a new literary anchor. A quiet beat: Mont Bessou as the place where the day's climbing ends and the long descent to Ussel (segs 23-27) begins — the roof crossed, the watershed tipped.
+
+## Data reconciliations surfaced
+
+> Recommended issue titles are problem-only (`feedback_issues_describe_problems.md`). Do NOT file from this research worktree — planning files them. `Refs`, not `Closes`.
+
+1. **`data/attractions.json` "Stele des Maquisards" (km 143.64) dedication appears misattributed.** The entry reads "Monument in Bugeat commemorating the Maquis du Mont Gargan and Plateau de Millevaches partisans." The documented on-route Bugeat memorial is the **stèle des fusillés de L'Échameil (pont de Vezou, inaugurated 6 April 1947)** for the four farmers shot on 6 April 1944 — a *fusillés/déportés* memorial, not a "maquisards" stèle. The "Stèle des Maquisards" that matches the "Mont Gargan partisans" dedication is at the **Mont Gargan summit (Haute-Vienne, ~40 km off-corridor)**, commemorating the July 1944 battle. **Recommended issue title:** *"attractions.json 'Stele des Maquisards' (Bugeat, km 143.64) dedication conflates the Bugeat fusillés stèle with the off-corridor Mont Gargan maquisards stèle."*
+
+2. **`data/attractions.json` "Stele des Maquisards" coordinate (45.6, 1.923) is coarse and unverified.** Only 3-4 significant figures; the documented memorial (pont de Vezou, D32) was not coordinate-matched this round. Lands 448 m off-polyline at km 143.61, which is plausible, but the name/coordinate pair should be ground-truthed alongside reconciliation #1. **Recommended issue title:** *"Verify and refine the Bugeat on-route memorial coordinate and name in attractions.json (pont de Vezou stèle des fusillés)."*
+
+3. **`data/segments.json` lists "Mont Bessou" as a climb for BOTH seg 21 and seg 22.** The categorised climb (`points-config` summit km 152.31, length 5 km → toe ~km 147.31) has its toe ~0.69 km inside seg 21, but the ascent is overwhelmingly a seg 22 event (GPX: seg 21 tops at 772 m @ km 146.69, then dips; the genuine 758→892 m climb is in seg 22). The dual listing is defensible (the toe is in seg 21) but may over-attribute the climb to seg 21 in any per-segment climb display. **Recommended issue title (only if the display treats this as a seg 21 climb):** *"segments.json attributes Mont Bessou to seg 21 though the categorised ascent falls almost entirely in seg 22 (climb toe ~0.69 km into seg 21)."* — Soft; confirm against how the site renders per-segment climbs before filing.
+
+4. **Mont Bessou summit-km / coordinate (#499, closed) — CONFIRMED, no new issue.** The town-coords realignment to the `points-config` km 152.31 / 892 m road crest holds: GPX argmax is 892 m at km 152.25 (0 m off the climb coordinate); the 977 m geographic peak sits off-route at km 161.18 (seg 23). The #499 note in `town-coords.json` remains accurate. (The brief's "verify it still holds" — it holds.)
+
+5. **`data/historical-tdf.json` 2024 Stage 11 keying to seg 22 — CONFIRMED, no new issue.** The event (Évaux-les-Bains → Le Lioran, Puy Mary, Vingegaard over Pogačar, re-keyed under #478) is correctly seg 22 as an altitude parallel, not a route overlap.
+
+## Carryforwards out of scope
+
+### Verification log (so the drafting strands can run short / auto-mode)
+
+| Claim | Method | Result |
+|---|---|---|
+| Seg 20 has no on-route town/climb | GPX min-distance to Bugeat = 3,245 m; `segments.json` empty arrays | **Verified empty — correct, not a gap** |
+| Bugeat bourg on-route | GPX min-distance to town-coords = **24 m @ route-km 143.64** | **On-route (seg 21)** |
+| Bugeat memorial on-route | GPX min-distance to attractions coord = **448 m @ km 143.61** | On-route; name/dedication flagged (recon #1, #2) |
+| Mont Bessou road crest | GPX argmax = **892 m @ km 152.25**, 0 m off climb coord km 152.31 | **#499 realignment holds** (recon #4) |
+| Mont Bessou geographic peak off-route | 977 m peak at km 161.18, ~1.3 km off the road (seg 23) | Confirmed off-route |
+| Tourbière de Longeyroux placement | GPX min-distance = 1,217 m @ km 153.99 (seg 22/23 hinge) | Confirmed; keyed seg 23 |
+| Les Cars Gallo-Roman off-route | ~4,920 m off @ km 143.61 | Confirmed off-route (~4.9 km N) |
+| Puy Pendu vs Mont Bessou | fr.wiki Puy Pendu | **970 m < 977 m — brief's "979m?" corrected** |
+| Bugeat 6 April 1944 perpetrator/counts | fr.wiki *Fusillés et déportés de Bugeat* | **Brehmer Division; 5 shot + 10 deported (1 survivor)** — brief's "Das Reich? / 11 arrested" corrected |
+| 2024 Stage 11 seg-22 keying | `historical-tdf.json` + cyclingnews/Lanterne Rouge | Confirmed |
+
+### To `data/attractions.json` (potential data-strand additions or corrections)
+
+- **"Stele des Maquisards" → fusillés/déportés memorial** (recon #1, #2): correct the dedication and verify the coordinate.
+- **Maison du Granite, Bugeat** — optional add (Plateau granite museum in the tourist office; "pink Pérols / ochre Bugeat" granite).
+- **Espace 1000 Sources Alain-Mimoun, Bugeat** — optional add (1960 altitude-sport centre, on-route town; cycling/tourism tie-in).
+- **Tour panoramique du Mont Bessou** — optional add as an *off-route* landmark (~1.3 km E of the road crest; the 977 m peak's Douglas-fir tower), clearly flagged off-route.
+- **Lac de Viam** — optional add as an *adjacent* (not on-route) Plateau-lake set-piece, flagged off-route.
+
+### To `data/historical-tdf.json` (potential additions)
+
+- **Tour du Limousin at Bugeat** — 1992 stage finish (Bugeat → Limoges) and 2021 Stage 3 départ (from Espace 1000 Sources). Candidate seg-21 additions (regional-race pedigree distinct from the Tour de France).
+- 2024 Stage 11 (seg 22) already keyed — no action (recon #5).
+
+### To later segments (RESERVED — do not use in this block)
+
+- **Meymac** (abbey Saint-André, Centre d'Art Contemporain, town, the Saintsbury voice) — **segs 23-24** (`project_meymac_voice.md`).
+- **The Vézère source at Longeyroux (~887 m)** — name the headwater country only; develop the source + Meymac at **segs 23-24**.
+- **Lac de Sèchemailles** (Meymac side) — segs 23-25.
+- **Ussel** (Place Voltaire sprint, Aigle Romaine, Chirac's start in politics) — **segs 25-27**.
+
+## Sources
+
+> External URLs only (`feedback_sources_no_internal.md`). Spot-checked at compile time 2026-05-28; reachability flagged. Per-source caveats noted inline.
+
+### Wikipedia (FR + EN)
+- **Plateau de Millevaches** — https://fr.wikipedia.org/wiki/Plateau_de_Millevaches — etymology debate, boundary indeterminacy (2005 Atlas rhombus), landes/tourbières, *fermeture paysagère*, depopulation, watershed. (OK)
+- **Plateau de Millevaches (EN)** — https://en.wikipedia.org/wiki/Plateau_de_Millevaches — Nègre *mila vacas* metaphor reading. (OK)
+- **Parc naturel régional de Millevaches en Limousin** — https://fr.wikipedia.org/wiki/Parc_naturel_r%C3%A9gional_de_Millevaches_en_Limousin — decree 18 May 2004, 3,346 km², 124 communes, otter emblem, eleven rivers >50 km, Natura 2000. (OK)
+- **Mont Bessou** — https://fr.wikipedia.org/wiki/Mont_Bessou — 977 m high point, Douglas-fir tower 2005, *bessou*=twin, cross-country ski 1970s, view. (OK)
+- **Puy Pendu** — https://fr.wikipedia.org/wiki/Puy_Pendu — 970 m, second-highest in Corrèze (corrects brief). (OK)
+- **Tourbière du Longéroux** — https://fr.wikipedia.org/wiki/Tourbi%C3%A8re_du_Long%C3%A9roux — largest Limousin peat bog, ~259.67 ha, 870-900 m, ~7,500 yr, four communes, 1986 biotope decree, Natura 2000. (OK)
+- **Bugeat** — https://fr.wikipedia.org/wiki/Bugeat — pop 719 (2023, -10.46%), 30.99 km², 667-844 m, Bugeacois, name from Gallic *Bugios*+*-acus*, tumuli/villa, railway 1883, communist commune, Église Saint-Pardoux, Château de Gioux. (OK)
+- **Bugeat (EN)** — https://en.wikipedia.org/wiki/Bugeat — La Tène mounds, Roman vicus, railway, WWI dead. (OK)
+- **Fusillés et déportés de Bugeat** — https://fr.wikipedia.org/wiki/Fusill%C3%A9s_et_d%C3%A9port%C3%A9s_de_Bugeat — Brehmer Division, the four L'Échameil farmers, Chaïm Rozent, ten deportees (Convoi 72, one survivor), 1947 stèle, 2025 plaque, Borzeix *Jeudi saint*. (OK)
+- **Ruines gallo-romaines des Cars** — https://fr.wikipedia.org/wiki/Ruines_gallo-romaines_des_Cars — villa + two mausoleums, blue-glass urn, boar-hunt sarcophagus, 8-tonne granite basin, Vazeilles 1917, MH 1935. (OK)
+- **Lac de Viam** — https://fr.wikipedia.org/wiki/Lac_de_Viam — 183 ha, barrage de Monceaux-la-Virolle (1946), EDF. (OK)
+- **Viam (EN)** — https://en.wikipedia.org/wiki/Viam — Plateau commune fundamentals. (OK)
+- **Pérols-sur-Vézère (EN)** — https://en.wikipedia.org/wiki/P%C3%A9rols-sur-V%C3%A9z%C3%A8re — ~47 km², 708-943 m, Lestang birthplace. (OK)
+- **Bataille du Mont Gargan** — https://fr.wikipedia.org/wiki/Bataille_du_Mont_Gargan — 18-24 July 1944, ~3,500 FTP under Guingouin vs colonne Jesser, summit stèle. (OK)
+- **Mont Gargan** — https://fr.wikipedia.org/wiki/Mont_Gargan — the *summit* maquisards stèle (Haute-Vienne, distinct from Bugeat). (OK)
+- **Richard Millet** — https://en.wikipedia.org/wiki/Richard_Millet — b. Viam 1953, Siom-cycle Plateau fiction. (OK)
+- **Marcelle Delpastre** — https://en.wikipedia.org/wiki/Marcela_Delpastre — b. Germont (Chamberet) 1925, Occitan poet/ethnographer. (OK)
+- **Pierre Bergounioux** — https://fr.m.wikipedia.org/wiki/Pierre_Bergounioux — dark-Plateau counter-reading; *Miette*, *La Casse*. (OK)
+- **Les Semailles et les Moissons (roman)** — https://fr.wikipedia.org/wiki/Les_Semailles_et_les_Moissons_(roman) — Troyat's Corrèze saga. (OK)
+- **Chabrette** — https://en.wikipedia.org/wiki/Chabrette — the mirrored Limousin bagpipe. (OK)
+- **Musique limousine** — https://fr.wikipedia.org/wiki/Musique_limousine — Occitan music context, 1987 revival. (OK)
+
+### Official / institutional
+- **Espace 1000 Sources — histoire du centre** — https://www.espace1000sources.fr/le-centre/lhistoire-du-centre — Mimoun origin, 1960, ~720 m, Chirac 1989 expansion. (OK)
+- **Espace 1000 Sources (home)** — https://espace1000sources.fr/ . (OK)
+- **Conseil départemental de la Corrèze — L'espace 1000 sources** — https://www.correze.fr/nos-missions/culture-patrimoine-sports/les-sports/lespace-1000-sources . (OK)
+- **Tourisme Corrèze — Maison du Granite (Bugeat)** — https://www.tourismecorreze.com/en/tourisme_detail/maison_du_granite.html — pink Pérols / ochre Bugeat granite. (OK)
+- **Maison du Granite (assoc. page)** — http://lamaisondugranite.free.fr/section.php?num=001 — (OK; plain HTTP, free.fr host).
+- **Tourisme Corrèze — Ruines gallo-romaines des Cars** — https://www.tourismecorreze.com/en/tourisme_detail/ruines_gallo-romaines_des_cars.html . (OK)
+- **Tour panoramique du Mont Bessou** — https://www.tourismecorreze.com/en/tourisme_detail/tour_panoramique_du_mont_bessou.html . (OK)
+- **Tourisme Haute-Corrèze — Mont Bessou (VTT)** — https://www.tourisme-hautecorreze.fr/le-mont-bessou-une-vitrine-du-vtt-en-haute-correze/ — MTB hub; "jamais gravie dans l'histoire du Tour." (OK)
+- **CEN Nouvelle-Aquitaine — Tourbière du Longeyroux** — https://cen-nouvelle-aquitaine.org/sites/tourbiere-du-longeyroux/ . (OK)
+- **PNR Millevaches — liste des 124 communes (PDF)** — https://www.pnr-millevaches.fr/wp-content/uploads/2024/09/LISTE-124-COMMUNES.pdf . (OK)
+- **AJPN — Bugeat 1939-1945** — https://www.ajpn.org/commune-bugeat-en-1939-1945-19033.html — WWII commune detail / Rozent. (OK)
+- **Mémoire Vive de la Résistance — Maquis du Limousin / combats du Mont Gargan** — https://mvr.asso.fr/maquis-du-limousin/ , https://mvr.asso.fr/les-combats-du-mont-gargan/ . (OK)
+- **Gourdon-Murat commune blog — L'Échameil ceremonies** — https://gourdon-murat.over-blog.com/ (and the 2023/04 and 2024/04 posts) — primary for the annual stèle ceremony / "semaine sanglante." (OK)
+
+### Cycling
+- **Cyclingnews — 2024 TdF Stage 11 results** — https://www.cyclingnews.com/races/tour-de-france-2024/stage-11/results/ — Vingegaard over Pogačar. (OK)
+- **Lanterne Rouge — 2024 Stage 11 analysis** — https://lanternerouge.com/2024/07/10/vingegaard-returns-to-beat-pogacar-tour-de-france-2024-stage-11/ — Puy Mary attack ~31.6 km out, Col de Pertus. (OK)
+- **Cyclingnews — 2020 TdF Stage 12 results** — https://www.cyclingnews.com/races/tour-de-france-2020/stage-12/results/ — Hirschi; corridor's southern fringe only. (OK)
+- **Cyclingstage — 2020 TdF Stage 12** — https://www.cyclingstage.com/tour-de-france-2020-route/stage-12-tdf-2020/ . (OK)
+- **Tour du Limousin — official (2021 Stage 3 from Bugeat)** — http://www.tourdulimousin.com/index.php?option=com_content&view=article&id=283 — (OK; plain HTTP).
+- **France Bleu — Tour du Limousin 2021 Stage 3 (Bugeat départ)** — https://www.francebleu.fr/sports/cyclisme/en-direct-tour-du-limousin-perigord-nouvelle-aquitaine-2021-suivez-la-3e-etape-entre-bugeat-et-1628604663 . (OK)
+- **Tourisme Corrèze — Circuit cyclo sportif au Cœur de Millevaches (from Bugeat)** — https://www.tourismecorreze.com/fr/randonnees/circuit-cyclo-sportif-au-coeur-de-millevaches/113254/circuit?id=170568 . (OK)
+- **Rêve de Vélo — Étape 9 TdF 2026 (Malemort-Ussel) parcours** — https://events.revedevelo.com/etape-9-tour-de-france-2026-malemort-ussel-parcours/ — Mont Bessou "never climbed by the Tour." (OK)
+- **Actus Limousin — Suc au May & Mont Bessou, étape 100% corrézienne 2026** — https://www.actus-limousin.fr/sport-et-loisirs/2025/10/23/le-suc-au-may-et-le-mont-bessou-au-programme-letape-100-correzienne-du-tour-de-france-2026-le-12-juillet/ . (OK)
+
+### Geology / landscape (deferred geology thread)
+- **HAL thesis — granites du Millevaches (360-300 Ma)** — https://theses.hal.science/tel-00008553 — Variscan leucogranite batholith, ~350 Ma main generations, Pradines shear zone. (OK; search-served)
+- **ScienceDirect — Millevaches leucogranite (AMS/gravity)** — https://www.sciencedirect.com/science/article/abs/pii/S0191814105001343 — (OK abstract; full text may paywall).
+- **BSGF / GeoScienceWorld — Millevaches massif** — https://pubs.geoscienceworld.org/sgf/bsgf/article-abstract/175/3/239/88393/ — (OK abstract).
+- **ResearchGate — Millevaches leucogranite emplacement** — https://www.researchgate.net/publication/40534715 — (OK; search-served).
+- **BRGM InfoTerre — 1:50,000 notices (Royère 0690N, Bugeat 0714N)** — http://ficheinfoterre.brgm.fr/Notices/0690N.pdf , http://ficheinfoterre.brgm.fr/Notices/0714N.pdf — primary geology map notices; **NOT individually fetched this round — treat as primary references, open manually before any hard lithological claim.**
+
+### Culture / literary / néo-paysan
+- **Journal IPNS — Écrivains du Plateau** — https://www.journal-ipns.org/les-articles/558-ecrivains-du-plateau — Pélissier's five writers. (OK domain; article-level fetch may 403, see flags)
+- **Journal IPNS — Le plateau de Pierre Bergounioux** — https://www.journal-ipns.org/les-articles/les-articles/1391-le-plateau-de-pierre-bergounioux . (OK domain)
+- **Terrestres — Retour en Millevaches (néo-rural sociology)** — https://www.terrestres.org/2025/01/20/retour-en-millevaches-le-champ-larbre-et-le-sociologue/ . (OK; search-served)
+- **OpenEdition VertigO — forest communities of practice (Millevaches)** — https://journals.openedition.org/vertigo/29205 . (OK; search-served)
+- **Forestopic — enrésinement critique** — https://www.forestopic.com/ — FFN-era afforestation, 45,000 ha / 40 yr, 1999 storm. (OK; search-served)
+- **ONF — Fonds Forestier National (history)** — https://www.onf.fr/ — FFN post-1947 context. (OK; search-served)
+- **Aquitaine Online — Marcelle Delpastre** — https://www.aquitaineonline.com/actualites-en-aquitaine/limousin/marcelle-delpastre-poetesse-ecrivaine-ethnographe.html . (OK; search-served)
+- **Culture Nouvelle-Aquitaine — Centenaire Marcelle Delpastre (2025)** — https://www.culture-nouvelle-aquitaine.fr/langues-et-cultures-regionales/centenaire-marcelle-delpastre/ . (OK)
+- **CRMT Limousin (traditional music)** — https://crmtl.fr/ . (OK)
+- **Cairn / Espace géographique 2018 — "Millevaches: un Entrevaux" (etymology scholarship)** — https://shs.cairn.info/revue-espace-geographique-2018-1-page-82 . (OK; search-served)
+- **Détours en France — Plateau de Millevaches, "pays des mille sources"** — https://www.detoursenfrance.fr/ — the marketing reading. (OK; search-served)
+
+### FLAGGED — verify before any hard reliance
+- **Maitron — Félix Lestang** — https://maitron.fr/ — **HTTP 403 on direct fetch** (anti-bot). Lestang's dates/roles captured from search snippets; Maitron is the authoritative bio. **Re-fetch in a browser before publishing the "président du conseil général 1945" claim.**
+- **Yad Vashem France — les Juifs raflés à Bugeat** — https://yadvashem-france.org/ — **not fetched (session permission gate).** Strong corroborating source for deportee names / Convoi 72; verify directly.
+- **Journal IPNS — article-level pages** — **HTTP 403 on direct fetch** (domain live, article fetch refused). The "march of ~500 on 15 May 1977 / Vivre dans la Montagne Limousine" detail is from a search excerpt; verify the page in a browser before citing a hard number.
+- **fauxlamontagne.fr** (incl. the 2020 *Rapport Enrésinement* PDF and "Plateau ou Montagne") — **fetch blocked this session**; domain/PDF appear live in search. The ~45,000 ha / 40 yr figure traces here and to forestopic.com — open manually to confirm.
+- **IGN — sylvoécorégion G21 (PDF)** — https://inventaire-forestier.ign.fr/IMG/pdf/G_21.pdf — **fetch blocked**; good corroborating geomorphology source, open manually.
+- **ProCyclingStats — 2024 Stage 11** — https://www.procyclingstats.com/race/tour-de-france/2024/stage-11 — **HTTP 403** (bot-blocked); figures cross-confirmed via cyclingnews + Lanterne Rouge.
+- **Cols-Cyclisme — Mont Bessou depuis Meymac** — https://www.cols-cyclisme.com/ — **not re-verified**; the ">15%" pitches describe the *steep Meymac south face*, distinct from the 2026 race crest — do not conflate.
+- **Grokipedia** — **do NOT cite** (blocked, and not an authoritative source); geology recovered from HAL/ResearchGate/BRGM instead.
+
+### Wikimedia Commons image candidates (per-file licences to verify)
+- **Plateau de Millevaches / landes / tourbières** — Category:Plateau de Millevaches, Category:Tourbière du Longéroux — heath, peat-boardwalk, conifer-plantation landscapes for seg 20/22.
+- **Bugeat** — Category:Bugeat — town, Église Saint-Pardoux, station, Espace 1000 Sources; the stèle des fusillés / pont de Vezou if a file exists.
+- **Mont Bessou** — Category:Mont Bessou — the Douglas-fir panoramic tower, summit panorama (note: tower is the *off-route* 977 m peak, not the road crest).
+- **Les Cars** — Category:Ruines gallo-romaines des Cars — mausoleums, granite basin/cuve, boar-hunt sarcophagus (off-route archaeology).
+- **Lac de Viam** — Category:Lac de Viam — the Plateau-lake set-piece (adjacent, off-route).
+
+Wikimedia Commons default licence is CC BY-SA 4.0 (verify per-file before publication; per-file licence is authoritative).
+
+## Open questions for the publisher / drafters
+
+1. **The Bugeat memorial's true identity (recon #1/#2).** The on-route memorial at km 143.61 is, on the evidence, the **stèle des fusillés de L'Échameil** (pont de Vezou, 1947), not a "Stèle des Maquisards / Mont Gargan partisans" stèle. **Recommend the seg-21 drafter writes it as the fusillés/déportés memorial** and treats the attractions-data name as suspect until ground-truthed.
+2. **Bugeat 6 April 1944 — corrected counts.** Write **5 men shot (4 L'Échameil farmers + Chaïm Rozent) + 10 Jews deported in Convoi 72 (1 survivor)**, perpetrator the **Brehmer Division**. The named deportees' ages (3½, 6, 9, 11; 67, 70) are the load-bearing detail. Borzeix's *Jeudi saint* (2008) is the published account.
+3. **Mont Bessou road-vs-peak.** Write the crest as the **892 m road high point** (the day's roof crossed *under* the 977 m geographic summit and its tower, ~1.3 km east). The climb is **soft (Cat 4)** — the apex is not the crux. **The 2026 ascent is the Tour de France's first-ever Mont Bessou.**
+4. **Puy Pendu correction.** Puy Pendu is **970 m, lower** than Mont Bessou (977 m). Do not write Puy Pendu as higher.
+5. **Seg 20 commune attribution.** The territory-level reading (corridor through Gourdon-Murat / Pérols-sur-Vézère, with Viam/Toy-Viam adjacent) is research-grade, not polyline-verified for the tiny communes. **Recommend the seg-20 drafter confirms on the ground** which commune the polyline enters, and keeps Viam/Toy-Viam framed as *adjacent*, not on-route.
+6. **Richard Millet as native son.** Born in Viam (1953), on the route — the block's strongest people-anchor for seg 20. Anchor on the *Siom*-cycle Plateau fiction; be aware of his later political controversy if foregrounding him.
+7. **Mont Bessou commune = Meymac (reserved).** The summit sits on Meymac territory (segs 23-24). Seg 22 names Meymac only as the territory; the abbey, town, and **Vézère source** stay reserved.
+8. **Tour du Limousin pedigree (seg 21).** Bugeat hosted a 1992 finish and a 2021 départ — a writable "the Plateau town already knows pro racing" beat, distinct from the Tour de France's 2026 debut. Candidate `historical-tdf.json` additions (carryforward).
+9. **The enrésinement / néo-paysan thread.** The richest seg-20 cultural material (planted forest as industrial artefact; the 1977 march; IPNS; the back-to-the-land settlers). Verify the hard 1977-march number against a browser-readable IPNS/fauxlamontagne page before citing it precisely.
+10. **Anchor allocation across segs 20, 21, 22:**
+    - **Seg 20 (open Plateau heart):** the Plateau-as-subject — etymology, PNR/otter, landes/peat, depopulation, *enrésinement*/*fermeture paysagère*, néo-paysan/IPNS, the water-castle; the writers of the Plateau (Millet born Viam, Bergounioux's dark reading, Delpastre's Occitan voice, the chabrette); Marius Vazeilles. The geology spine. *Verified-empty: the Parc is the subject — do not invent landmarks.*
+    - **Seg 21 (Bugeat):** the granite-rail-altitude town; **the 6 April 1944 Resistance wound** (the block's emotional set-piece); Félix Lestang (communist commune); Mimoun / Espace 1000 Sources (by patronage); Henri Troyat / *Les Semailles et les Moissons*; the Maison du Granite; Les Cars Gallo-Roman (off-route N); Tour du Limousin pedigree.
+    - **Seg 22 (Mont Bessou):** the roof of the day — 977 m high point crossed at the 892 m road crest, the gentle-giant Cat-4 inversion, the **Tour-de-France first**, the 2024 Puy Mary altitude parallel, the cross-country-ski-to-MTB seasonal inversion, the Tourbière de Longeyroux threshold (headwater country; Vézère source reserved). Close the block on the summit-as-threshold — the roof crossed, the watershed tipped toward Ussel.


### PR DESCRIPTION
## What

Adds `content/research/segs-20-22-block-research.md` — the narrative-anchor research dossier for the **Plateau-de-Millevaches heart + Mont Bessou block** (km 134-154), feeding the seg 20/21/22 drafting strands. Research-only branch: one new file, no entry or data-file changes. Mirrors the segs 17-19 (#600), 14-16 (#559), 11-13 (#501) dossier shape.

Lands before seg 20 drafts (~publishes 2026-06-10).

## The block, in one line each

- **Seg 20 (km 134-140)** — the verified-empty open Plateau heart (no on-route town/climb — *correct, not a data gap*). The Plateau-as-subject: etymology, PNR/otter, *enrésinement*/*fermeture paysagère*, néo-paysan/IPNS, the geology spine, and the writers of the Plateau (Richard Millet, **born in Viam on the route**).
- **Seg 21 (km 140-148)** — Bugeat (24 m off-route @ km 143.64) and the **6 April 1944 Resistance set-piece**; Félix Lestang, Mimoun/Espace 1000 Sources, the Maison du Granite, Les Cars Gallo-Roman (off-route), Tour du Limousin pedigree.
- **Seg 22 (km 148-154)** — **Mont Bessou, the roof of the day**: 977 m high point crossed at the 892 m *road crest* (the geographic peak is off-route), a soft Cat-4 "gentle giant," the Tour's **first-ever** Mont Bessou, the 2024 Puy Mary altitude parallel.

## Verification (GPX + data, all green)

`validate_entries.py` green (no entry changes). On-route claims checked against the segment GPX polylines, not segments.json endpoints (`feedback_on_route_checks.md`). Highlights:
- Bugeat bourg **24 m off @ km 143.64**; Mont Bessou road crest **892 m @ km 152.25**, 0 m off the km-152.31 climb coord — **#499 realignment holds**.
- 2024 Stage 11 seg-22 keying (re-keyed under #478) confirmed.

## Corrections surfaced vs the brief

- 6 April 1944 perpetrator was the **Brehmer Division**, not Das Reich; verified counts are **5 men shot + 10 Jews deported (1 survivor)**, not "11 arrested / 10 deported."
- **Puy Pendu is 970 m — lower than Mont Bessou (977 m)** (brief asked "979m?").

## Recommended issue titles (problem-only; not filed from this worktree — planning files them)

1. `attractions.json "Stele des Maquisards" (Bugeat, km 143.64) dedication conflates the Bugeat fusillés stèle with the off-corridor Mont Gargan maquisards stèle`
2. `Verify and refine the Bugeat on-route memorial coordinate and name in attractions.json (pont de Vezou stèle des fusillés)`
3. *(soft)* `segments.json attributes Mont Bessou to seg 21 though the categorised ascent falls almost entirely in seg 22`

## Open questions for the seg 20/21/22 drafters

See the dossier's final section. Headlines: write the Bugeat memorial as the *fusillés/déportés* memorial (not "maquisards") until ground-truthed; write Mont Bessou as the 892 m road crest under the off-route 977 m peak; confirm the seg-20 commune on the ground (Gourdon-Murat / Pérols-sur-Vézère on-route; Viam/Toy-Viam adjacent); anchor Richard Millet on his *Siom*-cycle Plateau fiction. Meymac, the Vézère source, and Ussel stay RESERVED for segs 23-27.

Refs #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)