### PR TITLE
research: segs 23-27 block dossier (Meymac to Ussel finish stretch)

### DIFF
--- a/content/research/segs-23-27-block-research.md
+++ b/content/research/segs-23-27-block-research.md
@@ -1,0 +1,297 @@
+# Block research dossier — segs 23-27 (km 154-184.8) — the finish stretch
+
+> Compiled 2026-05-29 by the segs 23-27 research strand. Feeds the seg 23, 24, 25, 26, 27 drafting strands — the Meymac-to-Ussel finish stretch, and the route's emotional climax. Mirrors the shape of `segs-20-22-block-research.md`, `segs-17-19-block-research.md` (PR #600), `segs-14-16-block-research.md` (PR #559), `segs-11-13-block-research.md` (PR #501). **Larger block than usual (five segments)** because segs 23, 24, 26 are thin descent/approach corridors and segs 25, 27 are the set-pieces; the depth is concentrated, not spread. Seg 23 drafts ~2026-06-21; this lands before that.
+>
+> **Two structural notes up front.** (1) **Seg 25 (Meymac) carries a voice reservation** — `project_meymac_voice.md` reserves the saintsbury register for the abbey segment. This dossier settles the voice question (see *Voice note for seg 25* below) so samples are ready before drafting. (2) **Seg 27 is the finish line** and shares the Ussel cycling-history corpus with the **July-2 tour-history special (#502)**; the deep Ussel cycling history already lives in `content/research/tour-history-research.md`. This dossier deliberately keeps seg 27's *cycling context* light and points there, spending its depth on Ussel the *place* and the *arrival*. The *Open questions* section names the division of labour.
+
+---
+
+## Cross-segment threads
+
+**Off the roof, into the gateway — the day's last act.** This five-segment block is the descent and run-in: from the granite roof of the Plateau de Millevaches (segs 23-24, still at 870-973m) down through Meymac (seg 25) and Saint-Angel (seg 26) to the finish at Ussel (seg 27, ~631m). The arc is plateau → edge-town → village → sub-préfecture; heath-and-bog → abbey → priory → granite town; and, throughout, *Atlantic drainage* (see watershed thread). The riders never leave the Hercynian crystalline basement (correction: there is **no sedimentary Ussel basin** — see Geology, seg 26/27), but they leave the high open country decisively. The block's job is the long exhale of a hard mountain stage toward a town that has never seen one finish.
+
+**Marius Vazeilles — the man who made the landscape and dug up its past.** The single richest through-line of segs 23-25. The conifer-clad slopes the riders descend in segs 23-24 were near-treeless moor (<9% forest cover) a century ago; the planting that closed the horizon was led, from Meymac, by **Marius Vazeilles** (1881-1973), forester, self-taught archaeologist, and Popular Front deputy for the *Ussel* constituency (1936). The same man excavated the Gallo-Roman plateau sites (Les Cars, the "Vénus gauloise") whose finds now fill the museum in Meymac's abbey (seg 25). The country crossed in 23-24 and the museum reached in 25 are *one man's legacy* — forest and archaeology in the same biography. (This is the natural home for the *enrésinement / fermeture paysagère* story the segs 20-22 dossier developed for the plateau interior; here it gets a face.)
+
+**The Vézère's cradle.** Just south of the seg 23-24 corridor lies the **Tourbière de Longeyroux**, a 255-hectare protected peatland in a granitic bowl, near where the **Vézère rises** — the river the route shadowed from the Treignac bridges (seg 18) onward. The riders pass the headwater country of the river that has been with them for a third of the stage. (CAVEAT: the *source altitude* is conflicting across sources — 700m vs the 870-900m peatland vs the brief's ~887m; the "rises at/near Longeyroux" claim is safe, the precise altitude is not. Also note: deep Vézère-source and Meymac-headwater material was partly reserved to the seg 20-22 strand; this dossier surfaces it as the landscape crossed, not as the set-piece.)
+
+**Meymac and the Benedictine foundation — the block's set-piece.** Abbaye Saint-André (founded 1085 by Archambaud III de Comborn as reparation to Saint-Martin de Tulle; raised to abbey 1146 under Ebles II de Ventadour). The Romanesque clocher-porche, the contested-provenance Black Madonna, the Centre d'art contemporain in the abbey wing, the Marius-Vazeilles archaeology museum, and the astonishing "Meymac-près-Bordeaux" wine-trade history. This is where the dossier spends. Saintsbury voice applies (see voice note).
+
+**The Tulle massacre's documented sequel — Meymac 1944.** The Tulle hangings (segs 9-10) have a hard, recent, morally freighted sequel in a Meymac forest: ~47-48 German prisoners (and one French woman) captured near Tulle on 7-8 June 1944 were executed near Meymac on 12 June 1944 in the chaotic FTP retreat before Das Reich. The story resurfaced via Edmond Réveil's 2019 testimony; ONAC-led excavations in May-June 2023 found period munitions but not the bodies. A through-line back to the stage's earlier Resistance set-piece, and the one place the "victors' justice" register enters the route. **Handle with editorial care** (see seg 25 flags).
+
+**Ventadour binds Meymac to Ussel.** The vicomté/duché de Ventadour had three capitals — Égletons, **Meymac, and Ussel**. The dukes abandoned their austere fortress and moved into Ussel (seneschal seated there from 1599; the Hôtel des Ventadour built end-16th c.). So the Ventadour thread can be *planted at Meymac* (seg 25) and *paid off at Ussel* (seg 27) — a built-in seg-25→27 callback, and the medieval-power counterweight to Saint-Angel's ecclesiastical anchor (seg 26, the priory of Charroux Abbey).
+
+**Everything flows to the Atlantic — the watershed that isn't quite here.** Saint-Angel's Triouzoune, Ussel's Diège and Sarsonne are *all* Dordogne tributaries → Gironde → Atlantic; ~97% of the Corrèze department drains to the Dordogne. The route never crosses a drainage divide in this block. The Loire/Dordogne divide runs across the plateau just to the north; the Atlantic/Mediterranean continental divide is far southeast in the Lozère. **Correct framing: Ussel drains to the Atlantic via the Diège and the Dordogne; the Loire's headwaters rise on the same plateau just to the north.** Do *not* place a watershed divide at Ussel, and do *not* invoke a Mediterranean basin.
+
+**The finish, and the first time.** Ussel has never hosted a Tour de France finish before 2026 — the strongest single cycling fact in the corpus, owned by `tour-history-research.md` / the July-2 special (#502). The name itself caps the climbing stage: Gallic *uxello-* = "the high place." A near-flat finishing straight on Avenue Thiers, the sprint judged in Place Voltaire beside a 1,800-year-old Roman granite eagle, in a granite sub-préfecture that has waited a century for this. That is the arrival the whole 27-segment blog has been riding toward.
+
+---
+
+## Segment 23 (km 154.0-162.0) — high descent off the Mont Bessou roof
+
+**Verified thin / descent corridor with no on-route landmark.** No towns, no climbs in `segments.json`. Start (45.56966, 2.04283) → end (45.56963, 2.12662); +172m / −113m; min 872m / max 973m. Note the elevations: this stays high (872-973m the whole way), so the "descent" here is gentle and undulating high-plateau crossing, *not* the steep drop — that comes in seg 24. **Drafters must not invent on-route landmarks.**
+
+### Geography & geology
+- Runs across the **roof of the Plateau de Millevaches**, the granite high country of Haute-Corrèze, immediately east of **Mont Bessou** (977m, highest point in Corrèze / Limousin / the plateau; its geographic summit and 26m Douglas-fir panoramic tower — built 2005, 148 steps — stand ~1.3km off-route. The *road* crest the route used is back in seg 22 at km 152.31 / 892m; the route passes *under* the peak. Mont Bessou's route-event belongs to seg 22 — reference it here only as the country just crossed).
+- Bedrock is **leucogranite** (the Millevaches batholith): coarse, pale, impermeable, acidic. That impermeability is why the plateau holds peat and "thousand springs."
+- The **Tourbière de Longeyroux** lies just south/southeast: a 255-hectare protected peatland (~870-900m) formed over ~8,000 years by the infilling of a pond in a *granitic bowl (alvéole granitique)*, spanning the communes of Meymac, Saint-Merd-les-Oussines, Chavanac and Saint-Sulpice-les-Bois (all dépt 19). The **Vézère rises at/near the peatland** (source altitude conflicting across sources — flag, do not assert a single number).
+
+### Local history & archaeology
+- No on-route historic site. The broader plateau is dense with **prehistory and Gallo-Roman remains**; the nearest significant complex is **Les Cars** (commune of Saint-Merd-les-Oussines, off-route south) — temple/funerary monuments and a villa excavated by Marius Vazeilles. Mention as "the country around here," not as on-route.
+
+### Cycling context
+- Fast but not technical: off the steepest Mont Bessou descent, rolling across high open ground (973m → 872m over 8km, a shallow average). **Exposed plateau — wind is the real factor**; crosswinds on open heathland split a peloton more than the gradient does. Breakaway groups would press here before the steeper plunge of seg 24.
+
+### Famous local people
+- None on-segment. **Marius Vazeilles** (the figure who made this forested landscape) is reserved for seg 25, where his museum sits.
+
+### Culture
+- The **bruyère (heather) and conifer-plantation mosaic is itself the cultural artefact** — a landscape engineered in the 20th century (the Vazeilles thread). Sheep/cattle grazing and forestry are the living economy.
+
+### Literary / musical
+- **No verified on-route literary or musical association — do not invent.** The plateau's place in Occitan and Resistance cultural memory belongs to the people (Vazeilles) and the maquis backdrop, not to a site on this segment.
+
+---
+
+## Segment 24 (km 162.0-168.0) — the steep drop toward the Meymac basin
+
+**Verified thin / descent corridor with no on-route landmark.** No towns, no climbs. Start (45.56963, 2.12662) → end (45.537, 2.1458); +18m / −269m; min 689m / max 940m. This is the **biggest net drop of the block** (−269m) — the genuine plunge off the plateau edge toward Meymac.
+
+### Geography & geology
+- The **plateau's eastern lip**: the road leaves the high granite roof (~940m) and drops ~250m toward the Meymac area (~689m at segment end). The transition is from open peat-and-heath plateau to steeper, wooded valley sides.
+- Still **leucogranite** — the descent cuts down through the batholith's flank rather than crossing a rock-type boundary; the dramatic change is *topographic* (high plateau → lower ground), not lithological. The "Plateau de Millevaches" proper effectively ends at this edge.
+- Off-route hamlets and the **lac de Sèchemailles** area sit on the commune of **Ambrugeat** (dépt 19), west/southwest. Anchor any place-name firmly to dépt 19 / Haute-Corrèze.
+
+### Local history & archaeology
+- No on-route site; same plateau-prehistory context as seg 23.
+
+### Cycling context
+- **The defining descent of the block.** −269m over 6km is a sustained, fast drop — the kind of plateau-edge descent where a committed rider gains real time and where the bunch strings out before the day's final categorised climb (Côte des Gardes, seg 25). After ~24km of high plateau, this is the road tipping decisively downhill toward the run-in. Sightlines on Haute-Corrèze descending roads are generally good; the danger is speed, not technicality. (Pro descent speeds at these gradients: see `reference_descent_speeds`.)
+
+### Famous local people
+- None on-segment.
+
+### Culture
+- As the riders drop, the landscape shifts from austere high heath to the greener, more inhabited approaches to Meymac — the plateau visibly softening. A sensory beat; no specific cultural institution on-route.
+
+### Literary / musical
+- **None verified on-segment — do not invent.**
+
+---
+
+## Segment 25 (km 168.0-176.0) — MEYMAC (the set-piece) + Côte des Gardes
+
+Town = **Meymac** (centre 47m off-route at km 168.10; Abbaye Saint-André 84m off-route at km 168.42). Climb = **Côte des Gardes** (on-route summit km 170.98 / ~757m; **data caveat:** the GPX elevation peak is actually ~200m earlier at km 170.766 / ~760m — confirmed; same minor bug-class as Côte de Naves #490, see Data reconciliations). Start (45.53704, 2.14589) → end (45.50332, 2.22555); +114m / −146m; min 651m / max 760m. Meymac is a **"Plus Beau Détour de France"** town.
+
+### Geography & geology
+- Meymac sits at **~650m at the southern gateway of the Plateau de Millevaches**, where the granite high country meets the lower ground toward Ussel — the natural "edge town," plateau behind, Auvergne-facing lowlands ahead. Still on granite, but the inhabited fringe.
+
+### Local history & archaeology
+- **Abbaye Saint-André de Meymac (Benedictine).** *Legend:* a hermit, Mamacus, built a church to St Andrew in the 6th c.; Bishop Rorice II of Limoges consecrated it in 546 (legendary, undocumented). *Documented:* founded **3 February 1085** by **Archambaud III, vicomte de Comborn**, as reparation for damage done to the abbey of Saint-Martin de Tulle; entrusted to the abbey of Uzerche. **Raised to abbey in 1146** with the support of **Ebles II de Ventadour** (the Ventadour thread — see seg 27).
+- **Church architecture:** Romanesque **clocher-porche (porch-bell-tower)**, oldest part, begun c.1085, Limousin-Romanesque style, eleven sculpted capitals; nave late 12th c.; ogival/rib vaulting added 13th c. Jointly dedicated **Saint-André-et-Saint-Léger**; reputedly preserves the **skull of Saint Léger (Léger d'Autun)** in an urn. (MH ref PA00099804.) **CAVEAT: the Léger-relic detail is search-snippet level — verify against a primary/diocesan source before a drafter states it as fact.**
+- **The Vierge noire (Black Madonna).** Polychrome-and-gilt carved-wood **Virgin-and-Child in majesty, 12th century**, black flesh; 61cm tall; classified MH (objet) 12 November 1908 (Palissy PM19000492). **CRITICAL PROVENANCE FLAG:** the official Palissy notice records **no documented provenance and no Crusades/Egypt legend** — the black colouring is treated purely as iconographic. **The "brought back from the Crusades / from Egypt" story is legend only, contradicted by the absence of any such record in the primary notice. Present it strictly as legend.** Also: the figure displayed in the church is a **recent copy**; the ~900-year-old original is kept in the **mairie's safe** and emerges ~once a year for two processions around 15 August.
+- **Revolution & after:** last monks left 27 January 1791; Mérimée's advocacy put the church on the **1840 monuments historiques list**; restoration began 1846.
+- **WWII — the Meymac execution.** ~47 German soldiers (sources 35-48) and one French woman, captured near Tulle 7-8 June 1944, were **executed and buried in a Meymac forest on 12 June 1944** in the FTP retreat before Das Reich (the division responsible for the Tulle hangings). Grave location resurfaced via **Edmond Réveil's 2019 testimony**; **ONAC excavations May-June 2023** found period bullets/casings and pre-1943 coins but **not the bodies** (the georadar-identified pit was empty); further LIDAR/archival work was planned. Morally freighted ("On a commis une faute," said Réveil). **The documented sequel to the Tulle massacre of segs 9-10 — frame with care; this is the route's one "victors' justice" register.**
+- **Marius Vazeilles archaeology:** the abbey east wing holds his collections, built on his excavation of plateau prehistory and Gallo-Roman sites (Les Cars; the 2nd-c. "Vénus gauloise"; gold bracelets from Bois-de-Train).
+
+### Cycling context
+- **Côte des Gardes** is the stage's **last categorised climb: ~2.2 km at 4.8%**, cresting **~14 km from the Ussel finish** — a short, modest ramp immediately after dropping into Meymac, a launchpad for late attacks on a stage that has already banked ~3,400-3,500m of climbing. (Data caveat: declared summit km 170.98 sits ~200m past the actual GPX elevation peak at km 170.766 — see Data reconciliations.)
+- Meymac is named in stage previews among the marquee towns the route passes (Beynat, Tulle, Treignac, Meymac → Ussel).
+
+### Famous local people
+- **Marius Vazeilles** (b. 29 July 1881, Messeix, Puy-de-Dôme; d. 7 June 1973, Meymac) — forester (*garde général des Eaux et Forêts*), self-taught archaeologist/ethnographer, politician. Settled in Meymac 1913; published *Mise en valeur du plateau de Millevaches* (1917), the foundational forestry text for the plateau (he found <9% forest cover on arrival). SFIO socialist → joined the Communist Party at the Tours Congress (Dec 1920); **Popular Front deputy for the Ussel constituency, 1936**; broke with the PCF in 1939 over the German-Soviet pact. 150+ publications. **The block's central figure** (see cross-segment threads).
+- **François Hédelin, abbé d'Aubignac (1604-1676)** — theorist of French classical theatre (*La Pratique du théâtre*); held the Meymac abbey *in commendam* (a literary tie, though not a native — footnote per literary-footnote practice).
+- Local political figures: **Georges Pérol**, **Marcel Audy** (senator of Corrèze, b. Ussel d. Meymac), **Arthur Delmas**.
+
+### Culture
+- **Centre d'art contemporain de Meymac (CAC Meymac)**, in a wing of the Saint-André abbey: founded **1979** by Caroline Bissière and Jean-Paul Blanchet; a leading rural contemporary-art venue; awarded the national label **"Centre d'art contemporain d'intérêt national" (spring 2022).** The genial collision of a 1085 Benedictine abbey housing cutting-edge contemporary art is strong material.
+- **Musée d'archéologie et du patrimoine Marius-Vazeilles**, abbey east wing: foundation created 1976; collections owned by the commune since 2015; Paleolithic/Neolithic, Gallo-Roman, Merovingian material, and 19th-20th-c. rural plateau life.
+- **"Meymac-près-Bordeaux"** — the block's most surprising hook. Around 1900, for ~50 years, several hundred natives of the Meymac region ran the Bordeaux wine trade in northern France and Belgium and gave "Meymac-près-Bordeaux" as their postal address to Belgian clients. Originated by **Jean Gaye-Bordas** (b.1826, Davignac, dépt 19); commemorated today by a heritage exhibition and the "chai des Moines Larose" museum-cellar. *This granite mountain town was, by reputation, a Bordeaux wine capital.*
+- **Markets/festivals:** town fair 2nd and 4th Fridays monthly; Sunday producers' market; **Journées artisanales d'art (14-16 Aug 2026)**, 100-artisan craft showcase. **CAVEAT:** Meymac sits in cèpe (porcini) and myrtille (blueberry) country, but **no Meymac-specific cèpe festival was found** — the cèpe fête is at the village of Corrèze (early October), the myrtille fête at Chaumeil (late July), both off-route. "Cèpe country" is fair regional colour; do not attribute a named cèpe festival to Meymac.
+- **Heritage:** "Plus Beau Détour de France"; 13th-c. beffroi attesting Meymac's standing under the Ventadour viscounts.
+
+### Literary / musical
+- **Abbé d'Aubignac** (above) — a genuine literary tie via the abbey *in commendam*.
+- **The Ventadour troubadour backdrop:** the viscounts of Ventadour (Meymac's medieval lords) gave their name to **Bernart de Ventadorn**, the great 12th-c. Occitan troubadour associated with the Ventadour court (ruins off-route near Égletons). **Keep this as regional troubadour-court context, not a Meymac event** — any direct Bernart-at-Meymac claim is unverified.
+
+---
+
+## Segment 26 (km 176.0-182.0) — Saint-Angel (Corrèze, dépt 19)
+
+Town = **Saint-Angel** (commune chef-lieu 96m off the polyline at km 176.53). No climbs. Start (45.50334, 2.22595) → end (45.52306, 2.29139); +55m / −82m; min 630m / max 687m. Anchor: the **Prieuré / église Saint-Michel-des-Anges** (on the foundational **1840 monuments historiques list** — one of the very first monuments France chose to protect).
+
+### Geography & geology
+- Massif Central, on the **Plateau de Millevaches**, within the *aire* of Ussel, in the **Parc naturel régional de Millevaches en Limousin**. The village sits on a **rocky outcrop (piton rocheux) overlooking the right bank of the Triouzoune**; commune altitude ~610-773m; heavily forested (~66% woodland, Douglas fir and Scots pine — the planted-resinous Millevaches landscape).
+- **Geology — CORRECTION to the brief's hypothesis.** The brief speculated the route is "leaving granite for the Ussel basin sediments." **There is no sedimentary basin.** Saint-Angel (and Ussel) sit on the **crystalline Hercynian socle — the "metamorphic and granite units of Ussel" (*unités métamorphiques et granitiques d'Ussel*)**; the village core is on a **gneiss outcrop**. Correct framing: **granite giving way to gneiss/migmatite within the same basement**, not crystalline-to-sedimentary. (Source: BRGM Carte géologique harmonisée Corrèze, RP-56816-FR.)
+- **River:** the **Triouzoune** (50.5 km; source ~900m on the plateau) joins the **Dordogne** in the retenue of the barrage de l'Aigle — Atlantic drainage.
+
+### Local history & archaeology
+- The village **takes its name from the priory**, founded in the **8th century**, dedicated to **Saint-Michel (Michael the Archangel)** — "des Anges."
+- **Prieuré / église Saint-Michel-des-Anges** (the segment anchor):
+  - **Foundation ~783** (some sources 785): a charter records **Count Roger of Limoges and his wife Euphrasie** donating the church (and the adjoining *castrum*) to **Charroux Abbey** (Poitou). **The charter's authenticity is debated by scholars** — present as "an 8th-c. donation recorded in a charter whose authenticity is debated," not flat fact.
+  - The **abbey church** is largely **Romanesque (11th-12th c.)** — its late-12th-c. nave walls resemble Meymac's abbey design (a seg-25 callback) — with **Gothic ogival vaults** added before c.1450 and the nave vaults + west façade rebuilt **late 15th c. by the Maurists**; ~6 building campaigns c.1100 to mid-16th c. Vault keystones bear French royal arms with the collar of the Order of Saint-Michel (post-1469) and Plas-family arms (post-1535).
+  - **Monument Historique:** the abbatiale was on the **"liste de 1840"** — the foundational administrative list drawn up under the inspectorate Prosper Mérimée headed, among the first ~1,000-1,100 monuments France ever protected. **Phrase as "on the 1840 list," not "classified by decree in 1840"** (it is a list protection predating individual decrees). The chapter house and presbytery round tower were classified later (15 July 1919); remaining structures + cemetery in 2000. **This is the strongest seg-26 fact: a small, depopulated plateau village holds one of the very first monuments France decided to protect.**
+  - **Restoration:** architect **Anatole de Baudot** (replaced wooden shingles with slate). The **Maurists (Benedictines of Saint-Maur)** took over in 1657 under prior François de La Fayette; 7 monks settled 1664, 5 remained 1790.
+- **Hundred Years' War:** English occupation ended with the **burning of the priory in 1375**.
+- **Revolution:** in 1793 the neighbouring commune Saint-Fréjoux-le-Mineur merged with Saint-Angel, which briefly renamed itself **Angel-la-Montagne** before reverting.
+- **WWII:** the **Jesser Brigade** (German anti-maquis column) passed through.
+
+### Cycling context
+- **No climbs** (verified). A transitional, descending-trending 6km (+55 / −82m) bridging the Côte des Gardes area toward Ussel — "settling before the finish" terrain. The day's last climb is behind (Côte des Gardes, ~14km to go); keep cycling content light here.
+
+### Famous local people
+- **Sparse, and honest to say so** — the commune's notability is institutional (Charroux / the 1840 listing) and architectural, not biographical. **Jean-Baptiste Poulbrière (1842-1917)**, Corrèze religious writer, is connected to the commune.
+
+### Culture
+- A self-styled **"Village Étoilé" (dark-sky village)** — fitting for a depopulated, forested plateau-edge commune. Good arrival material: *the last village before the finish is a dark-sky village*. Economy: forestry and livestock. Population ~702 (2023), slowly declining — the classic Millevaches demographic story.
+
+### Literary / musical
+- **Thin — no strong literary or musical association found for Saint-Angel specifically.** Lean on the priory and the silence-and-forest / village-étoilé register rather than inventing a hook. The musical material belongs to Ussel (seg 27).
+
+---
+
+## Segment 27 (km 182.0-184.84) — Ussel (Corrèze, dépt 19) — THE FINISH
+
+Town = **Ussel**, the finish. Start (45.52306, 2.29139) → end (45.5456, 2.30422); +54m / −60m; min 599m / max 640m. The route enters Ussel commune from the south (~km 182.45), runs ~2.4km north through central Ussel, and **ends at km 184.84 on Avenue Thiers (45.5456, 2.30422)**. The sprint is judged at **Place Voltaire**. **GEOMETRY GAP (do not paper over):** the GPX parcours ends **~216m west of Place Voltaire** — the recorded track stops short of the official sprint-judge line. Write the finish on the **verified endpoint (Avenue Thiers, 45.5456, 2.30422)** and note the ~216m discrepancy; the two are the same finishing straight ("Avenue Thiers at the height of Place Voltaire"), so the gap is a data-trace shortfall, not a different location (see Data reconciliations / #554).
+
+### Geography & geology
+- Ussel sits at **~631m** (commune range 588-761m) on the **last foothills (*derniers contreforts*) of the Plateau de Millevaches**; sub-préfecture and principal town of **Haute-Corrèze**; 9th-largest commune in Corrèze by area (~50km²). The town occupies a gentle hilltop **between two river valleys, the Diège and the Sarsonne** (sometimes styled *Ussel-sur-Diège*).
+- **The Diège** (54.4 km; source ~800m on the eastern Millevaches edge) is a **tributary of the Dordogne** → Gironde → **Atlantic**. **VERIFIED — Diège is a Dordogne tributary, not a Loire one** (matches the brief). **Watershed framing (FLAG):** Ussel is firmly Atlantic (Dordogne) basin; the Loire/Dordogne divide runs across the plateau a little to the north; the Atlantic/Mediterranean continental divide is far southeast in the Lozère. **Do not place a divide at Ussel; do not invoke a Mediterranean basin.** Accurate line: "Ussel drains to the Atlantic via the Diège and the Dordogne; the Loire's headwaters rise on the same plateau just to the north."
+- **Geology:** crystalline socle — the "metamorphic and granite units of Ussel." Ussel is a **granite town** (dark Haute-Corrèze building granite); the Roman eagle (below) is itself sculpted in granite. (Same correction as seg 26: no sedimentary basin.)
+
+### Local history & archaeology
+- **Gallic origin:** territory of the **Lémovices**; the name derives from Gallic **"uxello-/uxo-" = "elevated/high"** — Ussel = "the high place." **A neat etymological cap to a stage that climbs onto the high plateau and finishes in a town whose name means "the heights."**
+- **Roman — the Aigle romaine.** A **granite eagle** (probably late 2nd-early 3rd c.), thought to have topped a lost funerary monument, found near the moulin du Peuch on the Sarsonne. Found **headless; its head was added in 1804 by the sculptor Pic** when it was re-erected to honour Napoleon's coronation. Now stands on **Place Voltaire** (cleaned/temporarily removed during the square's 2009 refurbishment). **Finish-line set-piece: the sprint is judged beside an 1,800-year-old Roman eagle that a sculptor re-headed for Napoleon.**
+- **Medieval:** **February 1371 — Bertrand du Guesclin besieged Ussel** (then English-held). Ussel was a **ville de consulat** (13th-15th c.).
+- **The Ventadour connection (the seg-27 anchor, ties back to Meymac/seg 25):** the vicomté → comté → duché de **Ventadour** had three capitals — Égletons, Ussel, Meymac — held by the Ventadour (11th-15th c.), Lévis (1472-1673), then Rohan (1673-Revolution). In the Renaissance the dukes **abandoned the austere Château de Ventadour and moved into Ussel** (ducal seneschal seated there from 1599; Ussel became the seat of the duchy's justice). The **Hôtel / Maison ducale des Ventadour** (8 rue des Ventadours), built end-16th c., Renaissance style, is the emblematic old-town house (MH inscribed façade + roofing, decree 28 June 1932, ref PA00099939 — verify decree wording against POP/Mérimée when citing).
+- **17th-18th c. nickname "Pelauds"** — from the town's butchery and tanning trades. Usable local-character colour.
+
+### Cycling context (KEEP LIGHT — deep history lives in `tour-history-research.md` / the July-2 special, #502)
+- **Pointer, do not re-research:** Ussel has **never been a Tour de France stage town before 2026** — Stage 9's finish is genuinely Ussel's first (strongest fact; owned by the tour-history dossier). Also there: **Paris-Corrèze (2001-2012, founded by Laurent Fignon; spiritual home Chaumeil, not Ussel); 2009 Tour du Limousin Stage 1 Limoges → Ussel (closest precedent for the 2026 finish); Grand Prix d'Ussel (Koblet 1955).**
+- **One place-specific cycling fact OK to use here:** the **2003 Paris-Corrèze finish was on Avenue Thiers at the height of Place Voltaire** — the same finishing straight the 2026 stage uses.
+- **Finish geometry (this segment's job):** Stage 9 Malemort → Ussel, ~185km, ~3,400-3,500m climbing, "barely a metre of flat." Last categorised climb **Côte des Gardes (2.2km @ 4.8%)** crests ~14km out. **Final-km gradient ~0.3% → effectively flat.** Expected outcome: a **reduced-bunch / small-group finish or breakaway survivor**, not a pure-sprinter mass gallop — the day's vertical thins the field. A rest day follows, so GC skirmishes are plausible. (Verify exact final-km figure against the official profile before a drafter asserts it.)
+
+### The finish line (the emotional climax)
+- A near-flat finishing straight on **Avenue Thiers**, a granite sub-préfecture's main artery, judged in **Place Voltaire** beside the Roman eagle, in a town that has **never seen a Tour finish**. The high place (*uxello-*) gives the whole climbing stage its summit-town conclusion. This is the arrival the entire 27-segment blog has ridden toward — surface the "small Corrèze town that has never done this" register hard.
+
+### Famous local people
+- **Jacques Chirac & Ussel (ACCURATE, corrected-facts compliant).** Chirac's electoral career began in Corrèze in 1965 (first elected *conseiller municipal of Sainte-Féréole* — his paternal village, **not** Ussel). In the **1967 législatives he won the 3rd circonscription of Corrèze — the Ussel constituency — becoming député on 12 March 1967** (by ~537 votes, taking a traditionally left-leaning seat). **Ussel is literally where Chirac first won national office;** he rented a small pavilion in Ussel to anchor himself locally, and Corrèze became his lifelong *fief électoral*. **DO NOT MISPLACE:** Chirac is **buried at Montparnasse cemetery, Paris** (not in Corrèze); the **Musée du président Jacques-Chirac is at Sarran** (off-route, opened 15 Dec 2000) — **not in Ussel**. (Per memory: do not re-import the corrected #564/#585 burial error or the #586/#605 museum-date error.)
+- **Marcel Treich-Laplène (1860-1890)** — explorer and first administrator of the **Côte d'Ivoire**, **born in Ussel**; regarded as a founder of French Côte d'Ivoire. A strong, surprising native son.
+- **Antoine Queyriaux (1844-1918)** — dramatist and chansonnier, born in Ussel.
+- **Marcel Lagorce (1932- )** — jazz trumpeter, born in Ussel.
+- **Alain De Carvalho (1953- )** — former professional cyclist, born in Ussel (a light homegrown-cycling note).
+
+### Culture
+- **Musée du pays d'Ussel** ("Musée de France," opened 1976): history, arts and traditions of the Ussel country, across **four old-Ussel buildings — the Hôtel Bonnot de Bay (18th-c. bourgeois house), the Maison de l'Imprimerie, the Maison Moncourrier-Beauregard, and the Chapelle des Pénitents.** Collections: Marchois tapestries, folk-art tools and trades, typographic/lithographic printing equipment, vanished-trades displays. The cultural payoff of Ussel's preserved granite old town.
+- **Old-town heritage walk:** Hôtel Bonnot de Bay, Maison des Monloys, Maison des Cosnac, Maison 1647, Maison ducale des Ventadour, the Trois Pigeons inn sign, the Moncourrier butcher's shop — a dense, preserved bourgeois-and-noble granite ensemble.
+- Twinned with **Auray** (Morbihan). "Pelauds" identity (butchers/tanners) for local colour.
+
+### Literary / musical
+- **Charles-Dieudonné Régent** (b. Haguenau 1871 – d. Ussel 1951) — composer ("compositeur ussellois"); his portrait and his Pleyel piano are in the "Vie musicale" room of the Musée du pays d'Ussel. A specific musical hook for a finish entry.
+- **René Limouzin (1926-2020)** — writer and **accordionist**, died at Ussel — ties to the Corrèze accordion/lace tradition flagged for Tulle (seg 9/10): **the accordion thread re-surfaces at the finish.**
+- **Marcel Lagorce** (jazz trumpeter, b. Ussel 1932) and **Antoine Queyriaux** (dramatist/chansonnier) — see Famous people.
+
+---
+
+## Voice note for seg 25 (saintsbury reservation)
+
+**Recommendation: confirm saintsbury (period variant) for seg 25, with tls-essay as the documented fallback.** The reservation (`project_meymac_voice.md`, publisher directive 2026-04-20, segment corrected 24→25 under #500) holds, and the register's state now supports it.
+
+**Sample state — verified this session.** Saintsbury is fully developed in `/home/jhs/code/skills/registers-framework/saintsbury/`: `SKILL.md` (shared core), both variants (`variants/period.md`, `variants/modern.md`), and full samples per variant (period has `01-cadences`, two specimens by mood — critical and reflective — and `03-opening-moves`; modern has the parallel set). **This removes the "samples still incomplete" risk the memory flagged** — no dev work is blocking; the publisher can confirm at the seg 25 voice checkpoint against real specimens, not a stub.
+
+**Why it fits Meymac.** Saintsbury's register is *magisterial but genial*, its governing emotion *delight in its subject*, strong on history and architecture, the confident first person carrying the authority. The Meymac set-piece — a 1085 Benedictine foundation, a Romanesque clocher-porche, a Black Madonna whose Crusades legend the records quietly refuse, a contemporary-art centre lodged in the abbey, and the gloriously improbable "Meymac-près-Bordeaux" wine trade — is exactly the kind of subject the voice was built to enjoy. The cataloguing instinct ("the abbey holds three things worth the detour…") and the cheerful concession suit a town that rewards the patient enumerator.
+
+**Texture (what the publisher is confirming).** Period-Saintsbury opens on a specific, personal placement and earns its authority by enthusiasm; a Meymac opening in this register might begin not with the foundation date but with the pleasure of arriving at an abbey that has, against the odds, kept its Madonna in a safe and its contemporary art on the walls — then circle, by way of a nested aside on the Ventadour viscounts, back to 1085. Long hinged sentences with parenthetical interruptions, the occasional short flat verdict, one (not four) wine metaphor — and here the wine metaphor is *literal*, because Meymac really did run the Bordeaux trade, which the voice will find irresistible.
+
+**Project constraints that override the voice (flag for the drafter):**
+- **Em-dash ban** (`feedback_gitflow`): Saintsbury *loved* em-dashes and nested them inside parentheses. The entry must re-route that nesting through commas and parentheses. This is the single biggest mechanical adjustment and the most likely failure point.
+- **Word count** 800-1200 (CLAUDE.md): Saintsbury's accumulating sentences eat budget fast; the catalogue must be disciplined.
+- **Factual-grounding rules:** the Black Madonna legend must be voiced *as* legend (the voice's "cheerful concession" move is ideal for this — "the story is that she came from Egypt; the records, I am bound to say, know nothing of it"), and the Léger-relic and cèpe-festival caveats above must be respected.
+- **Disclosure footer** (`project_disclosure_practice`) and **literary footnotes from seg 6 forward** (`feedback_literary_footnotes`) apply — the abbé d'Aubignac tie wants a proper footnote.
+- **Period vs modern:** recommend **period variant** (subject is pre-1933 history/architecture; the register is most at home there). Use the **reflective** specimen mood for the abbey/arrival, the **critical** mood only if the entry turns to judge the contemporary-art collision.
+
+**Fallback:** if the publisher diverges at the checkpoint, **tls-essay** (fully developed; architectural subjects sit well in it) is the documented fallback — do not ship saintsbury against a weak anchor (v1.4.5 retro precedent). But the anchor is not weak here.
+
+---
+
+## Data reconciliations surfaced
+
+Problem-only issue-title candidates (per `feedback_issues_describe_problems`; em-dash-free per `feedback_gitflow`). Confirm against existing issues before filing — some may already be tracked.
+
+1. **"Côte des Gardes declared summit km (170.98) sits ~200m past the GPX elevation peak (km 170.766)"** — confirmed this session; same bug-class as Côte de Naves (#490/#515) and Puy de Lachaud (#477). The `Côte des Gardes` town-coords note already records this caveat and flags a possible follow-up; check whether an issue already exists before filing a duplicate.
+2. **"Entry stub slugs for segs 24, 25, 26 are anchored to the wrong towns/climbs after the 26-to-27 re-split"** — `24-meymac-and-the-cote-des-gardes` (Meymac + Gardes are seg 25), `25-approach-to-ussel` (seg 25 is Meymac), `26-ussel-place-voltaire` (Ussel is seg 27). Proposed corrected slugs in Open questions. (Recommendation, not a data-file drift; drafters re-title at their arc-agreement checkpoints, not this strand.)
+3. **"GPX parcours endpoint sits ~216m west of the Place Voltaire sprint-judge line for seg 27"** — already tracked as #554; restating for the drafter's awareness, not as new drift.
+
+**#500-era fixes confirmed to have held.** Spot-checked this session: `town-coords.json` carries the corrected coordinates and provenance notes for Meymac, Ussel (Place Voltaire, with the 216m note), Saint-Angel, Côte des Gardes (on-route summit), and Mont Bessou (road crest); `segments.json` towns/climbs for segs 23-27 match the verified shape. No regression found.
+
+**One brief hypothesis corrected by research:** the brief's "leaving granite for the Ussel basin sediments" is **wrong** — Saint-Angel and Ussel are crystalline socle (granite → gneiss/migmatite, the "units of Ussel"); **there is no sedimentary Ussel basin.** Drafters: write granite-into-gneiss within one Hercynian basement, not a sedimentary basin. (Not a data-file issue — a research correction recorded here so the error does not propagate into drafts.)
+
+---
+
+## Carryforwards — per-segment checklist for the drafting strands
+
+- **Seg 23** (drafts ~2026-06-21): *thin descent corridor.* Lean on granite-plateau geology, Longeyroux/Vézère headwater country, the Vazeilles made-forest thread, and wind/descent cycling craft. Do not invent on-route landmarks. No literary/musical hook — do not fake one.
+- **Seg 24:** *thinnest, steepest.* The −269m plunge off the plateau edge is the beat; cycling craft (the defining descent) carries it. Anchor any off-route place-name to dépt 19 (Ambrugeat / lac de Sèchemailles).
+- **Seg 25 (Meymac):** *set-piece.* Saintsbury (period) recommended — confirm at voice checkpoint; samples are ready. Black Madonna = legend only (Crusades/Egypt provenance contradicted by the record; displayed figure is a copy). Verify the Léger-relic claim before stating it. No Meymac-specific cèpe festival. Côte des Gardes summit-km caveat. The Meymac-1944 execution is verified but morally sensitive — frame with care; it is the documented sequel to the Tulle massacre (segs 9-10). Plant the Ventadour thread for payoff at seg 27.
+- **Seg 26 (Saint-Angel):** the **1840 MH listing** is the anchor (phrase "on the 1840 list," not "by decree"); Charroux foundation charter authenticity is debated. **Geology: granite → gneiss, no sedimentary basin.** "Village Étoilé" dark-sky register suits the last village before the finish. Famous-people material is genuinely sparse — say so, do not pad.
+- **Seg 27 (Ussel, the finish):** keep **cycling context light** and point to `tour-history-research.md` / the July-2 special (#502); coordinate so the historic-finishes material is not duplicated. Spend depth on the *place* and the *arrival*. Chirac: Ussel = first national seat (1967); burial Montparnasse, museum Sarran — do not misplace. Write the finish on the verified endpoint (Avenue Thiers, 45.5456/2.30422) and note the 216m gap to Place Voltaire (#554). The accordion thread (seg 9/10 Tulle) re-surfaces via René Limouzin. *uxello-* = "the high place": the etymological cap on the whole stage.
+
+**Verification log (this session):**
+- `data/segments.json` segs 23-27 read directly: towns/climbs/geometry as stated above. ✓
+- `data/town-coords.json`: Meymac, Ussel, Saint-Angel, Côte des Gardes, Mont Bessou notes carry #499/#500 corrections. ✓
+- Saintsbury register files present and complete in `registers-framework/`. ✓
+- `tour-history-research.md` confirmed to own the Ussel cycling-history corpus (never-a-TdF-town, Paris-Corrèze, 2009 Limoges→Ussel, GP d'Ussel). ✓
+- `processing/validate_entries.py` run: see commit/PR (no entry changes in this strand, so green-by-no-change).
+
+---
+
+## Sources (external only; spot-checked this session; failures flagged)
+
+**Meymac / abbey / segs 23-25**
+- Abbaye Saint-André: https://fr.wikipedia.org/wiki/Abbaye_Saint-Andr%C3%A9_de_Meymac (fetched OK)
+- Vierge noire official notice (load-bearing for the no-Crusades-provenance + copy-in-church findings): https://pop.culture.gouv.fr/notice/palissy/PM19000492 (fetched OK)
+- Vierge noire copy/original: https://france3-regions.franceinfo.fr/nouvelle-aquitaine/la-resurrection-de-la-vierge-noire-de-meymac-909013.html (search-snippet; verify exact wording)
+- CAC Meymac: https://fr.wikipedia.org/wiki/Centre_d'art_contemporain_de_Meymac ; http://www.cacmeymac.fr/presentation
+- Musée Marius-Vazeilles: https://fr.wikipedia.org/wiki/Mus%C3%A9e_d'arch%C3%A9ologie_et_du_patrimoine_Marius-Vazeilles (fetched OK)
+- Marius Vazeilles bio: https://maitron.fr/vazeilles-marius-vazeilles-antonin-annes-francisque-marius/ ; https://fr.wikipedia.org/wiki/Marius_Vazeilles
+- Meymac-près-Bordeaux: https://fr.wikipedia.org/wiki/Meymac-pr%C3%A8s-Bordeaux ; https://www.reussir.fr/agriculture-massif-central/meymac-pres-bordeaux-une-histoire-de-vin-et-de-negoce ; https://www.tourismecorreze.com/fr/meymac-pres-bordeaux.html
+- Tourbière de Longeyroux / Vézère source (NOTE altitude conflict): https://fr.wikipedia.org/wiki/Tourbi%C3%A8re_du_Long%C3%A9roux ; https://www.tourismecorreze.com/en/tourisme_detail/tourbiere_du_longeyroux.html
+- Mont Bessou: https://fr.wikipedia.org/wiki/Mont_Bessou ; https://www.cols-cyclisme.com/chaine-des-puys-monts-dore/france/mont-bessou-depuis-meymac-c2542.htm
+- Côte des Gardes / Stage 9 profile: https://www.cyclingstage.com/tour-de-france-2026-route/stage-9-tdf-2026/ (fetched OK) ; https://www.ledicodutour.com/etapes/etapes_par_annees/etapes_2026/etapes_2026_9.html
+- Meymac 1944 / 2023 excavation: https://www.francebleu.fr/infos/societe/fouilles-de-meymac-les-corps-des-soldats-allemands-n-ont-pas-ete-retrouves-mais-un-espoir-demeure-7537858 ; https://www.francebleu.fr/infos/societe/on-a-commis-une-faute-estime-edmond-reveil-79-ans-apres-la-capture-de-47-soldats-allemands-a-tulle-5956028 ; https://www.journal-ipns.org/les-articles/1740-meymac-derriere-le-scoop-lhistoire-instrumentalisee-oubliee-ou-malmenee
+- Maquis du Limousin: https://en.wikipedia.org/wiki/Maquis_du_Limousin
+- Church (Léger-relic, search-snippet only — verify): Structurae https://structurae.net/fr/ouvrages/eglise-saint-andre-et-saint-leger ; Monumentum https://monumentum.fr/monument-historique/pa00099804
+- HTTP 403 (not fetched): https://www.tourisme-hautecorreze.fr/en/la-haute-correze/meymac-plus-beau-detour-de-france/
+
+**Saint-Angel / seg 26**
+- https://fr.wikipedia.org/wiki/Prieur%C3%A9_Saint-Michel-des-Anges (fetched OK) ; https://fr.wikipedia.org/wiki/Saint-Angel_(Corr%C3%A8ze) (fetched OK)
+- MH notices (verify wording): https://pop.culture.gouv.fr/notice/merimee/PA00099838 ; https://monumentum.fr/ancien-prieure-saint-michel-des-anges-pa00099838.html
+- BRGM Corrèze geology (units of Ussel): http://infoterre.brgm.fr/rapports/RP-56816-FR.pdf (search-snippet; verify page)
+- Triouzoune → Dordogne: https://en.wikipedia.org/wiki/Triouzoune
+
+**Ussel / seg 27**
+- https://fr.wikipedia.org/wiki/Ussel_(Corr%C3%A8ze) (fetched OK) ; https://en.wikipedia.org/wiki/Ussel,_Corr%C3%A8ze (fetched OK — Roman eagle, museum, Auray twinning)
+- Ventadour: https://fr.wikipedia.org/wiki/Ch%C3%A2teau_de_Ventadour_(Corr%C3%A8ze) ; https://fr.wikipedia.org/wiki/Vicomt%C3%A9_de_Ventadour (search-snippet)
+- Hôtel Ventadour MH (monumentum returned 503/403 — verify decree 28 June 1932 via POP): https://pop.culture.gouv.fr/notice/merimee/PA00099939
+- Musée du pays d'Ussel: https://fr.wikipedia.org/wiki/Mus%C3%A9e_du_pays_d'Ussel ; https://www.alienor.org/musees/ussel/56-musee-du-pays-d-ussel (search-snippet)
+- Roman eagle: https://www.tourisme-hautecorreze.fr/en/patrimoine-culturel/aigle-romaine/ (host blocks WebFetch 403; corroborated via Wikipedia)
+- Diège = Dordogne tributary: https://fr.wikipedia.org/wiki/Di%C3%A8ge_(affluent_de_la_Dordogne) ; https://www.nouvelle-aquitaine.developpement-durable.gouv.fr/IMG/pdf/P07_0400_diege_cle5814f2.pdf
+- Plateau de Millevaches (granite + Loire/Dordogne watershed): https://en.wikipedia.org/wiki/Plateau_de_Millevaches
+- Chirac / Ussel (1965 Sainte-Féréole, 1967 Ussel seat): https://www.slate.fr/story/124133/politique-histoire-jacques-chirac-conquete-correze-ussel-election ; https://lesanneeschirac.wordpress.com/2012/04/12/le-fief-correzien-de-jacques-chirac/ (blog — corroborate against Slate)
+- Stage 9 finish profile (verify final-km figure): https://www.procyclingstats.com/race/tour-de-france/2026/stage-9/info/profiles ; https://www.domestiquecycling.com/en/features/tour-de-france-2026-stage-by-stage-guide/
+
+*Reliability note:* pages marked "search-snippet" were read via search results, not full fetch — consistent across independent hits but verify exact dates/wording against the primary page before a drafter publishes a claim. The `tourisme-hautecorreze.fr` host blocks WebFetch (403); its facts are corroborated via Wikipedia/POP. The Léger-relic and Charroux-charter claims carry explicit caveats above.
+
+---
+
+## Open questions for the publisher / drafters
+
+1. **Proposed corrected slugs** (drafters re-title at their arc-agreement checkpoints; this strand does not rename stub files):
+   - seg 23 `23-descent-to-meymac` → **`23-descent-off-the-roof`** (current slug implies Meymac, which is not reached until seg 25; the segment is the high-plateau descent off Mont Bessou).
+   - seg 24 `24-meymac-and-the-cote-des-gardes` → **`24-off-the-plateau-edge`** (Meymac + Gardes are seg 25; this is the steep −269m drop).
+   - seg 25 `25-approach-to-ussel` → **`25-meymac-and-the-cote-des-gardes`** (the actual Meymac + Gardes segment).
+   - seg 26 `26-ussel-place-voltaire` → **`26-saint-angel`** (Ussel is seg 27; the anchor here is the Saint-Michel-des-Anges priory).
+   - seg 27 `27-place-voltaire-the-finish-line` → **keep** (correct: Ussel finish at Place Voltaire). Optionally `27-ussel-the-finish-line` if a town anchor is preferred over a square anchor; weak preference, publisher's call.
+2. **Seg 27 / July-2 special (#502) division of labour.** Proposed: the **July-2 special owns the Ussel cycling history** (never-a-TdF-town, Paris-Corrèze, 2009 Limoges→Ussel, GP d'Ussel); **seg 27 owns the place and the arrival** (Ventadour, Roman eagle, Chirac's first seat, the finish-line geography, the *uxello-* etymology) and *points* to the special for the historic-finishes material, using only the single place-specific 2003-Paris-Corrèze-on-Avenue-Thiers fact inline. Confirm this split so neither surface duplicates the other.
+3. **Meymac-1944 framing.** The German-prisoner execution is verified and recent (2023 excavation) but morally complicated. Should seg 25 carry it as a developed beat (the documented sequel to the Tulle massacre, the "victors' justice" register), as a footnoted aside, or defer it entirely to avoid overloading the abbey set-piece? Editorial call before drafting.
+4. **The Vézère-headwater material** was partly reserved to the segs 20-22 strand. Confirm how much of the Longeyroux/Vézère-cradle thread seg 23 may use without duplicating seg 20-22, given seg 23 is otherwise thin and would benefit from it.
+5. **Saintsbury period vs modern, and mood.** Recommendation above is period/reflective; confirm at the seg 25 voice checkpoint against the now-complete samples.


### PR DESCRIPTION
## What

Compiles `content/research/segs-23-27-block-research.md`, the block research dossier feeding the seg 23, 24, 25, 26, 27 drafting strands. This is the Meymac-to-Ussel finish stretch and the emotional climax of the 27-segment route. Mirrors the shape of the prior block dossiers (segs 11-13, 14-16, 17-19, 20-22).

Five-segment block: segs 23, 24, 26 are thin descent/approach corridors (honestly marked as such, with explicit "do not invent landmarks" notes); segs 25 (Meymac) and 27 (Ussel finish) are the set-pieces where the depth is concentrated.

`Refs #502` (coordinates the seg 27 finish material with the July-2 tour-history special; does not close it).

## Key findings and decisions

- **Seg 25 voice reservation settled.** The saintsbury reservation (`project_meymac_voice.md`) holds. Verified this session that the register is fully developed in `registers-framework/` (both variants, full samples) so no dev work blocks it. Recommendation: period variant, with tls-essay as documented fallback. Confirm at the seg 25 voice checkpoint.
- **Brief geology hypothesis corrected.** The brief speculated the route "leaves granite for the Ussel basin sediments." There is no sedimentary basin; segs 26-27 sit on crystalline socle (granite into gneiss, the "units of Ussel"). Recorded so the error does not propagate into drafts.
- **Black Madonna provenance.** The "brought back from the Crusades / Egypt" story is legend only, contradicted by the Palissy heritage record; the figure displayed in the church is a copy (original in the mairie safe). Must be voiced as legend.
- **Meymac 1944 execution** surfaced as the documented sequel to the Tulle massacre (segs 9-10), verified via the 2023 ONAC excavation; flagged as morally sensitive, framing deferred to the publisher.

## Proposed corrected slugs (drafters re-title at their checkpoints; not renamed here)

- seg 23 `23-descent-to-meymac` to `23-descent-off-the-roof`
- seg 24 `24-meymac-and-the-cote-des-gardes` to `24-off-the-plateau-edge`
- seg 25 `25-approach-to-ussel` to `25-meymac-and-the-cote-des-gardes`
- seg 26 `26-ussel-place-voltaire` to `26-saint-angel`
- seg 27 keep `27-place-voltaire-the-finish-line`

## Recommended issue titles (problem-only; confirm against existing before filing)

1. "Cote des Gardes declared summit km (170.98) sits ~200m past the GPX elevation peak (km 170.766)" (same bug-class as Naves #490; may already be tracked in the town-coords caveat)
2. "Entry stub slugs for segs 24, 25, 26 are anchored to the wrong towns/climbs after the 26-to-27 re-split"
3. "GPX parcours endpoint sits ~216m west of the Place Voltaire sprint-judge line for seg 27" (already tracked as #554; restated for drafter awareness)

## Verification

- `data/segments.json` segs 23-27 read directly; towns/climbs/geometry confirmed.
- #500-era data fixes confirmed held (town-coords corrections for Meymac, Ussel, Saint-Angel, Cote des Gardes, Mont Bessou present).
- `tour-history-research.md` confirmed to own the Ussel cycling-history corpus.
- `processing/validate_entries.py --entries-dir content/entries --non-interactive` green (no entry changes).
- Source URLs spot-checked; search-snippet-only and 403/503 sources flagged inline.

## Open questions (in the dossier)

Seg 27 / July-special division of labour; Meymac-1944 framing depth; Vezere-headwater material overlap with the segs 20-22 strand; saintsbury period-vs-modern and mood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)