### PR TITLE
Release-ceremony automation: Roadmap step, lifecycle checklist, /release skill (#480 #521 #339)

### DIFF
--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,0 +1,151 @@
+# Release checklist
+
+The full lifecycle of a tdf26 release, with the conditional branches that real
+releases have taken. This is the human-readable spec that the `/release` skill
+(#339) mechanises for the ceremony steps, and the single artifact a fresh agent
+session can follow to know "what should happen for this release."
+
+It **operationalises** the process declared on the wiki — it does not restate it.
+Where the wiki is authoritative, this file links to it rather than copying:
+
+- [How We Work](https://github.com/gneeek/tdf26/wiki/How-We-Work) — goals, PR
+  workflow, late-add/hotpatch policy, conventions (the source of truth).
+- [Roadmap](https://github.com/gneeek/tdf26/wiki/Roadmap) — Now / Completed.
+- [Retrospectives](https://github.com/gneeek/tdf26/wiki/Retrospectives) — the
+  four-section retro index; enforced by the `/retro` skill.
+
+Out of scope (covered elsewhere, do not duplicate here): the planning-session
+entry/exit ritual (#481) and the tag/version naming scheme (#519, the date-based
+`W<NN>` migration — already documented on the Roadmap's "Naming note").
+
+---
+
+## 1. Pick the release type
+
+The release type sets which branches apply. Determine it **before** scoping.
+
+| Type | When | Tag | Deploy path | Held to "publish better"? |
+|------|------|-----|-------------|---------------------------|
+| **Publication** | Anchored by a segment going live | `W<NN>-seg<N>` | `scripts/publish.sh` (full path) | Yes — content + ≥1 reader + ≥1 dev improvement |
+| **Non-publication / intervention** | Single-goal, urgency-driven, between publishes | `W<NN>.<N>` | `scripts/create-release.sh` after deploy | No — scoped to the urgent issue |
+| **Chore / same-day interleaved** | Small follow-on shipped hours after a publication | `W<NN>.<N>` | `scripts/create-release.sh` | No |
+| **Hotfix / post-publish patch** | A fix after the publication tag is already live | `W<NN>.<N>` (own tag) | `scripts/create-release.sh` | No |
+
+Worked examples: publication — `W19-seg11`…`W22-seg16`, v1.4.5/6/9/10/14/17.
+Intervention — v1.4.7 (protect incoming publisher), v1.4.11 (security), v1.4.12
+(ceremony foundation + publish fix). Chore/same-day — v1.4.15, v1.4.16 (both
+shipped within hours of v1.4.14, each as its own tag). Hotfix — v1.4.18's
+post-publish cycle (rider-stats bug, EntryCard objectPosition).
+
+**Milestone vs tag (since 2026-05-07):** milestones are issue-bags decoupled from
+tags. One milestone can span several production deploys (e.g. v1.4.20 spans
+seg 17–20), and **each production deploy gets its own retro**. The Roadmap
+"Completed" move and the milestone close happen at **milestone close**, not on
+every deploy within it.
+
+---
+
+## 2. Plan (the planning session decides; retro only reflects)
+
+- [ ] Define **1–3 goals** as sentences, mapped to the five project goals. Not issue titles.
+- [ ] Every cycle includes some continuous improvement (DX or process). **Order DX issues first** so tooling is available for the rest.
+- [ ] Only add issues that serve a goal; new discoveries become issues for a future release.
+- [ ] Write the goals to the Roadmap **`## Now`** section as outcomes, not issue numbers (`feedback_roadmap_style`).
+- [ ] Confirm the milestone exists and is the issue-bag for this cycle; link it **by number** (`/milestone/<n>`, `feedback_milestone_urls`).
+
+## 3. Brief — **multi-strand releases only**
+
+Skip for single-strand. Multi-strand examples: v1.4.10 / v1.4.17 (3 strands),
+v1.4.19 (8-strand blitz).
+
+- [ ] Scaffold a brief per strand from [docs/strands/STRAND-BRIEF-TEMPLATE.md](strands/STRAND-BRIEF-TEMPLATE.md) (or the `/strand-brief` skill).
+- [ ] Each brief declares: filesystem posture, source-of-truth posture, target issues, workflow, verification, **cross-strand sharing notes (owns / reads / must-not-touch)**, and stop conditions.
+- [ ] Resolve hard sequencing between strands (e.g. "start only after the gate has merged") and shared-file ownership in the briefs, not at runtime.
+
+## 4. Execute (one issue at a time)
+
+- [ ] One issue per PR — separate PR for each issue (per How We Work). A coherent nested pair may share one PR; say so in the PR body.
+- [ ] Add acceptance criteria as a checkbox list on the issue; comment the planned approach.
+- [ ] If `test-first` label: write failing tests first.
+- [ ] Feature branch off `main`; explicit-path worktree for strand work. **Before every `git add`/`commit`, confirm `git branch --show-current`** (`feedback_shared_tree_branch_verification`).
+- [ ] Fresh worktree: `npm ci`, then `cp data/riders/*.example.json` to non-example names before any build (`feedback_ci_seed_ordering`).
+- [ ] PR body carries a **test plan** (acceptance criteria + how to verify); the publisher should not re-derive it.
+- [ ] Use closure keywords (`Closes #N`) only when the PR actually closes the issue; brief/scaffold-only PRs use `Refs #N` (`feedback_pr_closure_keywords`).
+
+## 5. Review, verify, merge
+
+- [ ] CI green. `npm test`; `bash -n` for any touched shell script; the shell-test harness once #508 lands.
+- [ ] **Rendered-page verification** (the build-and-preview step). The *automated* render-check (CI generates the site and asserts each entry page renders, no blank/500) is owned by **#322**. Until #322 lands, do this manually: `npm run build` + a `nuxt generate` static preview — **not** the SSR runtime (`feedback_production_preview`). *(Ownership split with #322: #322 implements the verification step; this checklist only references it.)*
+- [ ] Visible / blast-radius actions (push, deploy, force) confirmed with the publisher unless pre-authorised for a defined scope.
+- [ ] Merge to `main` via PR (squash). Verify the merge via the GitHub API before post-merge steps (`feedback_pr_polling`). Never push directly to `main`.
+
+## 6. Pre-publish scrutiny — **publication releases only**
+
+The window between "entry merged to `main`" and "`publish.sh` has deployed".
+After deploy, the content-change rule freezes prose and images.
+
+- [ ] Verify geography, attribution, image rights, and image-caption faithfulness (`feedback_pre_publish_scrutiny`). Raise concerns rather than proceeding silently.
+- [ ] Confirm the entry is **not** still `draft: true` (publish.sh's draft pre-flight, #617, halts on this — treat a halt as the contract working).
+- [ ] Pair-writing disclosure footer present on the entry (seg 7 onward).
+
+### Late-add / hotpatch during the window
+
+- **Pre-tag (publish.sh in flight):** only site-wide, **≤10-line**, orthogonal changes with publisher sign-off. No entry-body / rendering-path changes for the shipping entry. (See How We Work → Late-add policy.)
+- **Post-tag (already deployed):** any further change ships as **its own tag** — there is no amend-the-tag path. Test: "would this look incoherent in the deployed release notes if folded in?" → yes means a new tag (the chore-release pattern, v1.4.15/16).
+
+## 7. Deploy + tag
+
+- **Publication:** run `scripts/publish.sh --segment N --release-tag W<NN>-seg<N>`.
+  It handles stats, points, snapshots, weather, image validation, build, deploy,
+  the frontmatter-PR merge, and Step 10 (tag + GitHub Release via `create-release.sh`).
+- **Non-publication / chore / hotfix:** deploy, then `scripts/create-release.sh W<NN>.<N> [--title ...]`.
+- [ ] Tag sequence is `git tag -a` → `git push origin <tag>` → `gh release create <tag> --notes-file …` (what `create-release.sh` already does). **Never** `gh release create --target <sha>` — it fails with "tag_name is not a valid tag."
+- [ ] Deploy is SSH to the OVH VM, not rsync (`project_deployment`).
+
+## 8. Ceremony (the seven steps `/release` mechanises)
+
+Driven by `/release` (#339); run at **milestone close** (the Roadmap/milestone
+steps), per production deploy for the retro. Each step stops on error with partial
+state documented for recovery. The skill handles both the main repo and the
+**wiki repo (separate clone, HTTPS — the SSH host key is not trusted in headless
+runs)**.
+
+1. [ ] Annotated tag at the target commit.
+2. [ ] Push the tag to origin.
+3. [ ] Create the GitHub Release with notes (steps 1–3 = `create-release.sh`).
+4. [ ] Close the milestone (linked by number).
+5. [ ] Create the retro wiki page from the four-section template (`Retro-<tag>.md`).
+6. [ ] Add a row to `Retrospectives.md` (`| Release | Date | Theme | Page |`).
+7. [ ] **Roadmap Completed move** — `create-release.sh --update-roadmap --milestone <n>`
+       appends the Completed bullet (idempotent) and warns that the `## Now`
+       block needs a **manual trim** (it does not rewrite the prose). #480.
+
+## 9. Retro (reflect — file after each production deploy)
+
+- [ ] Run the `/retro` skill: exactly four sections — **What went well / What was
+      challenging / What we learned / What we lack** — in order, with those exact
+      headings. `What we lack` is the systematically-dropped section; enforce it.
+- [ ] Publisher reviews the draft (input point 1), then a Piers/Tully voice pass, then publisher sign-off (input point 2) before committing to the wiki.
+- [ ] Retro **reflects**; decisions belong to the next planning session. Findings exit to issues, memory entries, or planning-notes flags — not same-session implementation.
+- [ ] Update the slip-rate tally if a publication slipped.
+
+## 10. Close out
+
+- [ ] Close each issue with a comment (closure keywords auto-close on merge).
+- [ ] Delete merged feature branches (local + remote); strand sessions remove their own worktree (`feedback_strand_session_self_cleanup`).
+- [ ] Confirm the Roadmap `## Now` block now describes what is *actually* in flight (the manual trim from step 8.7).
+- [ ] Carry unresolved items into `project_next_planning_notes.md`.
+
+---
+
+## What is automated vs human
+
+| Step | Owner |
+|------|-------|
+| 1–6 (type, plan, brief, execute, review, scrutiny) | Human / agent judgement |
+| 7 deploy | `publish.sh` / `create-release.sh` |
+| 8 ceremony (tag, push, release, milestone, retro stub, index row, Roadmap move) | `/release` skill (#339), wrapping `create-release.sh` (incl. #480) |
+| 9 retro content | `/retro` skill scaffolds; humans write and sign off |
+
+The render-check verification (step 5) is implemented by **#322**; this checklist
+references it, by the agreed ownership split between the spine and ceremony strands.

--- a/docs/skills/release-skill.md
+++ b/docs/skills/release-skill.md
@@ -1,0 +1,146 @@
+# /release skill — repo mirror
+
+> This is a version-controlled snapshot of the `/release` skill for review.
+> The **canonical, installed** copy lives at `~/.claude/skills/release/SKILL.md`
+> (user-global, alongside `/retro`, `/strand-brief`, `/tdf26-voice`). Skills in
+> this project are installed globally, not loaded from the repo — this file exists
+> so the skill is reviewable in a PR and survives in history. If you edit one, edit
+> both. Origin: #339.
+
+---
+
+---
+name: release
+description: Run the tdf26 release ceremony — tag, GitHub Release, milestone close, retro stub, Retrospectives index row, and the Roadmap Completed move — as one stop-on-error sequence over the main repo and the wiki repo. Use when the publisher asks to "cut the release", "run the release ceremony", "tag and release vX", or at milestone close. Supports a dry-run.
+---
+
+# tdf26 /release skill
+
+Codifies the post-deploy release ceremony so steps stop being driven by memory and
+ad-hoc judgement. Mechanises the lifecycle declared in
+[docs/RELEASE-CHECKLIST.md](https://github.com/gneeek/tdf26/blob/main/docs/RELEASE-CHECKLIST.md)
+(#521) — read it for the conditional branches; this skill executes the **ceremony**
+phase (checklist step 8). It composes existing tools rather than re-implementing them:
+
+- `scripts/create-release.sh` — tag → push → GitHub Release, and (with
+  `--update-roadmap`) the Roadmap Completed move (#480). Already robust and dry-runnable.
+- the `/retro` skill — writes `Retro-<tag>.md` and adds the `Retrospectives.md`
+  index row (ceremony steps 5–6 live there; do not duplicate them here).
+- `gh` — milestone close, by number.
+
+## Scope: what this skill does NOT do
+
+- It does **not** deploy. Deploy happens first (`publish.sh` for publications,
+  the build+deploy path for chore/intervention releases). This skill runs **after**
+  a successful deploy.
+- It does **not** write retro content. It invokes `/retro`, which scaffolds the
+  four-section structure for humans/agents to fill and sign off.
+- It does **not** rewrite the Roadmap `## Now` prose (see step 6).
+
+## Inputs
+
+Establish before running:
+
+1. **Tag** — date-based, year-implicit: `W<NN>-seg<N>` (publication) or `W<NN>.<N>`
+   (non-publication). `create-release.sh` validates the form and refuses duplicates.
+2. **Target commit** — defaults to `HEAD` of `main`. Confirm `main` is at the
+   deployed artifact before tagging.
+3. **Release type** — publication / non-publication / chore / hotfix (RELEASE-CHECKLIST §1).
+   Determines the tag form and whether this is also a **milestone close**.
+4. **Milestone number** — for the `--milestone <n>` link and the close step. Link
+   milestones **by number** (`/milestone/<n>`), never title search.
+5. **Is this a milestone close?** Milestones are decoupled from tags and span
+   several deploys. Close the milestone and do the full Roadmap Completed move
+   **only** at milestone close; per-deploy ceremony still tags, releases, and files
+   a per-deploy retro.
+
+## The reliable tag sequence
+
+Always `git tag -a <tag> -m <msg> <sha>` → `git push origin <tag>` →
+`gh release create <tag> --notes-file <file>`. **Never** `gh release create --target
+<sha>` — it fails with "tag_name is not a valid tag." `create-release.sh` already
+uses the correct sequence; call it rather than hand-rolling.
+
+## Procedure
+
+Run the steps **in order**. **Stop on the first error**, print what completed and
+what did not, and document the partial state for recovery (see "Recovery" below).
+Do a dry-run first whenever the release is non-routine.
+
+### Step 0 — preconditions
+- Confirm the working repo is clean and `main` is at the intended target commit.
+- Confirm wiki push access. **The wiki is a separate repo cloned over HTTPS**
+  (`https://github.com/gneeek/tdf26.wiki.git`); the SSH host key is not trusted in
+  headless/CI runs, so do not rely on `git@…`. `create-release.sh --update-roadmap`
+  clones it for you.
+
+### Steps 1–3 + 6 — tag, push, GitHub Release, Roadmap Completed move
+Run, after the deploy, from the repo root:
+
+```
+# dry-run first (no tag, no release, no push — prints commands + Roadmap diff):
+scripts/create-release.sh <tag> --title "<title>" --update-roadmap --milestone <n> --dry-run
+
+# then for real:
+scripts/create-release.sh <tag> --title "<title>" --update-roadmap --milestone <n>
+```
+
+- This tags, pushes, creates the Release, and (idempotently) inserts the Completed
+  bullet into the wiki Roadmap.
+- It prints a **WARNING that the `## Now` block needs a manual trim** — it does not
+  rewrite that prose, to preserve the goals-and-outcomes Roadmap voice. Do the trim
+  by hand (step 6, below) when this is a milestone close.
+- Omit `--update-roadmap` for a mid-milestone deploy where you do not yet want a
+  Completed row.
+
+### Step 4 — close the milestone (milestone close only)
+```
+gh api -X PATCH repos/gneeek/tdf26/milestones/<n> -f state=closed
+```
+Skip for a mid-milestone production deploy.
+
+### Steps 5 — file the per-deploy retro
+Invoke the **`/retro`** skill, scoped to this tag/deploy. It enforces the four
+sections (What went well / What was challenging / What we learned / What we lack),
+runs the publisher review + Piers/Tully voice pass, and on sign-off commits
+`Retro-<tag>.md` and adds the `Retrospectives.md` index row. Add the retro link
+back into the GitHub Release notes once the retro page exists.
+
+### Step 6 — trim the Roadmap `## Now` block (milestone close only)
+The `--update-roadmap` step added the Completed bullet but deliberately left `## Now`
+describing the just-shipped milestone. Edit `## Now` to describe what is **now** in
+flight (the next milestone), preserving the goals-and-outcomes prose style. Commit
+and push to the wiki.
+
+## Dry-run
+
+`--dry-run` is passed straight through to `create-release.sh` for steps 1–3 + the
+Roadmap move (it prints the tag/release commands and the Roadmap diff, changing
+nothing). For steps 4–6, "dry-run" means: state the milestone you would close, the
+retro page you would create, and the `## Now` edit you would make — do not execute.
+
+## Stop-on-error and recovery
+
+| If this fails | State left behind | Recover by |
+|---------------|-------------------|------------|
+| tag/push (`create-release.sh`) | no tag, no release | rerun; it refuses to act if the tag already exists |
+| GitHub Release | tag pushed, no Release | `gh release create <tag> --notes-file <file>` |
+| Roadmap move | release exists; wiki commit local-only or unpushed | the script prints the temp clone path; push it manually |
+| milestone close | release + Roadmap done | rerun the `gh api` PATCH |
+| retro | everything above done | run `/retro` separately |
+
+Because the release exists once steps 1–3 succeed, **a later step failing never
+invalidates the release** — it only leaves a documented follow-up.
+
+## Acceptance / proving
+
+Per #339, the skill is "proven" only after it has driven **one real release**. A
+**non-publication tag** (`W<NN>.<N>`) is the safest first proving target. Until a
+real release has used it end-to-end, treat #339 as shipped-pending-proof and name
+the proving run as its close condition.
+
+## Self-checks before running for real
+- Tag matches `W<NN>-seg<N>` or `W<NN>.<N>` and does not already exist.
+- `main` is at the deployed commit.
+- Milestone number is correct and you have decided whether this is a milestone close.
+- You ran the `--dry-run` and the Roadmap diff looks right.

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -2,15 +2,32 @@
 # Tag HEAD and create a GitHub Release for it.
 #
 # Usage:
-#   ./scripts/create-release.sh <tag> [--title <title>]
+#   ./scripts/create-release.sh <tag> [--title <title>] [--update-roadmap]
+#                               [--milestone <n>] [--dry-run] [--wiki-url <url>]
 #
 # Tag format is date-based, year-implicit (this is tdf26):
 #   Publication deploys:     W<NN>-seg<N>   (e.g. W19-seg11)
 #   Non-publication deploys: W<NN>.<N>      (e.g. W19.1)
 #
+# Flags:
+#   --title <title>     Release title (defaults to the tag).
+#   --update-roadmap    After the release is created, move it to the wiki
+#                       Roadmap's '## Completed' section (clone wiki over HTTPS,
+#                       append a Completed bullet, commit, push). Idempotent: a
+#                       Completed row already mentioning the tag is left as-is.
+#                       Does NOT rewrite the '## Now' prose block; it only warns
+#                       that the block needs a manual trim.
+#   --milestone <n>     Milestone number, linked by number in the Completed
+#                       bullet (per feedback_milestone_urls). Optional.
+#   --dry-run           Print the tag/release commands and the Roadmap diff
+#                       without tagging, releasing, or pushing anything.
+#   --wiki-url <url>    Wiki clone URL (default the gneeek/tdf26 wiki over HTTPS).
+#                       Point at a scratch clone/branch for testing.
+#
 # Example:
 #   ./scripts/create-release.sh W19-seg11
 #   ./scripts/create-release.sh W19-seg11 --title "W19-seg11 - Segment 11 publication"
+#   ./scripts/create-release.sh W19.1 --update-roadmap --milestone 53
 #
 # The release body is auto-generated from the git log between the previous tag
 # and HEAD, plus a retro-link placeholder. The publisher can edit the body and
@@ -23,6 +40,11 @@ set -e
 
 TAG=""
 TITLE=""
+UPDATE_ROADMAP=false
+MILESTONE=""
+DRY_RUN=false
+WIKI_URL="https://github.com/gneeek/tdf26.wiki.git"
+REPO_URL="https://github.com/gneeek/tdf26"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -32,6 +54,22 @@ while [ $# -gt 0 ]; do
             ;;
         --title)
             TITLE="$2"
+            shift 2
+            ;;
+        --update-roadmap)
+            UPDATE_ROADMAP=true
+            shift
+            ;;
+        --milestone)
+            MILESTONE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --wiki-url)
+            WIKI_URL="$2"
             shift 2
             ;;
         -*)
@@ -66,6 +104,110 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Move the just-shipped release into the wiki Roadmap's '## Completed' section.
+# Clones the wiki over HTTPS, inserts a Completed bullet as the newest entry,
+# commits and pushes. Idempotent (a row already mentioning the tag is left
+# untouched). Deliberately does NOT touch the '## Now' prose block — it only
+# warns that the block needs a manual trim, preserving the goals-and-outcomes
+# Roadmap voice (feedback_roadmap_style.md).
+update_roadmap() {
+    local tag="$1" title="$2" milestone="$3" dry_run="$4" wiki_url="$5"
+    local release_url="$REPO_URL/releases/tag/$tag"
+    local milestone_link=""
+    if [ -n "$milestone" ]; then
+        milestone_link=" | [milestone]($REPO_URL/milestone/$milestone)"
+    fi
+
+    # Factual, link-bearing bullet. Prose enrichment is left to the publisher;
+    # the automation does not invent the goals-and-outcomes summary.
+    local bullet
+    bullet="- **$title** — released as \`$tag\` ([release]($release_url) | retro: _pending_$milestone_link). _Roadmap summary pending manual edit._"
+
+    local wiki_dir
+    wiki_dir=$(mktemp -d)
+
+    echo "Cloning wiki ($wiki_url) to update the Roadmap..."
+    if ! git clone --depth 1 "$wiki_url" "$wiki_dir" >/dev/null 2>&1; then
+        echo "ERROR: failed to clone wiki at $wiki_url." >&2
+        echo "       Release $tag exists; the Roadmap must be updated manually." >&2
+        rm -rf "$wiki_dir"
+        return 1
+    fi
+
+    local roadmap="$wiki_dir/Roadmap.md"
+    if [ ! -f "$roadmap" ]; then
+        echo "ERROR: Roadmap.md not found in the wiki clone; update manually." >&2
+        rm -rf "$wiki_dir"
+        return 1
+    fi
+
+    # Idempotency: a Completed row already mentioning this tag → no duplicate.
+    if grep -qF "\`$tag\`" "$roadmap"; then
+        echo "Roadmap already references \`$tag\` — no duplicate row added (idempotent)."
+        rm -rf "$wiki_dir"
+        return 0
+    fi
+
+    if ! grep -qx "## Completed" "$roadmap"; then
+        echo "ERROR: '## Completed' heading not found in Roadmap.md; update manually." >&2
+        rm -rf "$wiki_dir"
+        return 1
+    fi
+
+    # Insert the bullet as the first entry under '## Completed' (newest-first).
+    # ENVIRON avoids awk -v escape processing of backticks/em-dashes in the bullet.
+    BULLET="$bullet" awk '
+        flag && /^- / { print ENVIRON["BULLET"]; flag=0 }
+        /^## Completed$/ { flag=1 }
+        { print }
+        END { if (flag) print ENVIRON["BULLET"] }
+    ' "$roadmap" > "$roadmap.new"
+    mv "$roadmap.new" "$roadmap"
+
+    if [ "$dry_run" = true ]; then
+        echo "--- DRY RUN: Roadmap.md diff (not committed, not pushed) ---"
+        git -C "$wiki_dir" --no-pager diff -- Roadmap.md
+        echo "--- DRY RUN: would commit and push the above to $wiki_url ---"
+        rm -rf "$wiki_dir"
+        return 0
+    fi
+
+    # A fresh wiki clone carries no committer identity, and this project sets
+    # git identity per-repo (local), not globally — so the commit would abort
+    # with "Author identity unknown". Carry the main repo's identity onto the
+    # wiki commit so it is attributed consistently with the release's commits.
+    local git_name git_email
+    git_name=$(git -C "$PROJECT_DIR" config user.name 2>/dev/null || true)
+    git_email=$(git -C "$PROJECT_DIR" config user.email 2>/dev/null || true)
+    if [ -z "$git_name" ] || [ -z "$git_email" ]; then
+        echo "ERROR: no git user.name/user.email configured in $PROJECT_DIR;" >&2
+        echo "       cannot attribute the wiki Roadmap commit. Set them and rerun." >&2
+        rm -rf "$wiki_dir"
+        return 1
+    fi
+
+    git -C "$wiki_dir" add Roadmap.md
+    if ! git -C "$wiki_dir" \
+            -c user.name="$git_name" -c user.email="$git_email" \
+            commit -m "Roadmap: move $tag to Completed" >/dev/null; then
+        echo "ERROR: wiki Roadmap commit failed (see above)." >&2
+        rm -rf "$wiki_dir"
+        return 1
+    fi
+    if ! git -C "$wiki_dir" push origin HEAD >/dev/null 2>&1; then
+        echo "ERROR: push of the Roadmap commit failed for $wiki_url." >&2
+        echo "       The Completed bullet is committed locally at $wiki_dir but NOT pushed." >&2
+        echo "       Push it manually, then remove $wiki_dir." >&2
+        return 1
+    fi
+    rm -rf "$wiki_dir"
+
+    echo "Roadmap updated: \`$tag\` added to '## Completed'."
+    echo ""
+    echo "WARNING: the '## Now' Roadmap block still describes the just-shipped"
+    echo "         release. Trim/rewrite it manually to reflect what is now in flight."
+}
 
 if git -C "$PROJECT_DIR" rev-parse "$TAG" >/dev/null 2>&1; then
     echo "ERROR: tag $TAG already exists locally." >&2
@@ -103,13 +245,26 @@ trap 'rm -f "$NOTES_FILE"' EXIT
     echo "Retro link will be added when the retro is filed: https://github.com/gneeek/tdf26/wiki/Retrospectives"
 } > "$NOTES_FILE"
 
-echo "Tagging $HEAD_SHA as $TAG..."
-git -C "$PROJECT_DIR" tag -a "$TAG" -m "Release $TAG"
-git -C "$PROJECT_DIR" push origin "$TAG"
+if [ "$DRY_RUN" = true ]; then
+    echo "DRY RUN: would tag $HEAD_SHA as $TAG and create GitHub Release '$TITLE'."
+    echo "  git tag -a $TAG -m \"Release $TAG\" && git push origin $TAG"
+    echo "  gh release create $TAG --title \"$TITLE\" --notes-file <generated notes>"
+else
+    echo "Tagging $HEAD_SHA as $TAG..."
+    git -C "$PROJECT_DIR" tag -a "$TAG" -m "Release $TAG"
+    git -C "$PROJECT_DIR" push origin "$TAG"
 
-echo "Creating GitHub Release $TAG..."
-gh release create "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE"
+    echo "Creating GitHub Release $TAG..."
+    gh release create "$TAG" --title "$TITLE" --notes-file "$NOTES_FILE"
 
-echo ""
-echo "Release created: https://github.com/gneeek/tdf26/releases/tag/$TAG"
-echo "Edit the release on GitHub to expand the framing and add the retro link as needed."
+    echo ""
+    echo "Release created: $REPO_URL/releases/tag/$TAG"
+    echo "Edit the release on GitHub to expand the framing and add the retro link as needed."
+fi
+
+if [ "$UPDATE_ROADMAP" = true ]; then
+    echo ""
+    echo "--- Updating wiki Roadmap ---"
+    update_roadmap "$TAG" "$TITLE" "$MILESTONE" "$DRY_RUN" "$WIKI_URL" \
+        || { echo "ERROR: Roadmap update failed (see above). The release itself succeeded; reconcile the Roadmap manually."; exit 1; }
+fi


### PR DESCRIPTION
v1.4.20 release-ceremony strand. Takes the manual post-deploy ceremony off the publisher's plate. Runs after the publish-safety gate (#617/#618/#619, merged in #629), which it sequences behind because #480 edits the same `scripts/publish.sh`/`create-release.sh` release region.

Shipped as one strand PR (mirroring the gate strand #629, which closed its three issues in a single PR). The three commits are cleanly separated by issue.

## #480 — automate the wiki Roadmap Completed move (`Closes #480`)
`scripts/create-release.sh` gains an opt-in `--update-roadmap` path (plus `--milestone <n>`, `--dry-run`, `--wiki-url <url>`):
- Clones the wiki **over HTTPS** (the SSH host key is not trusted in headless/CI runs), inserts a factual Completed bullet as the newest entry (release link, retro placeholder, milestone linked **by number** per `feedback_milestone_urls`), commits, pushes.
- **Idempotent** — a Completed row already mentioning the tag is left untouched.
- **Append + flag, not collapse** — does NOT rewrite the `## Now` prose; warns that the block needs a manual trim, preserving the goals-and-outcomes Roadmap voice (`feedback_roadmap_style`).
- Carries the main repo's git identity onto the wiki commit (this project sets identity per-repo; a fresh wiki clone has none). Commit **and** push are explicitly error-guarded — the call site uses `||`, which disables `set -e` inside the function, so failures must be checked by hand.

**Verified ground truth:** the live Roadmap uses `## Now` / `## Completed` (not the "In flight" #480 guessed); the input contract is Now -> Completed.

**Scope decision:** not wired into `publish.sh` Step 10. A milestone spans several segment deploys (v1.4.20 = seg 17-20), so the Completed move belongs at milestone close (driven by `/release`), not every publish.

## #521 — full-lifecycle release checklist (`Closes #521`)
`docs/RELEASE-CHECKLIST.md`, mined from the actual v1.4.5-v1.4.17 + W19-seg11..W22-seg16 lifecycles. Conditional branches drawn from real releases: release type (publication / non-publication-intervention / chore-same-day / hotfix-post-publish), strand count (single vs multi-strand), and the milestone-vs-tag decoupling. Operationalises the wiki How-We-Work process rather than restating it; links to the wiki where authoritative; models four-section enforcement on `/retro`.

## #339 — `/release` skill (`Refs #339`, shipped-pending-proof)
The skill walking the ceremony as one stop-on-error sequence over the main repo and the (separate, HTTPS) wiki repo. Composes `create-release.sh` (tag/release + #480 Roadmap move), `/retro` (retro stub + Retrospectives row — moved there since #339 was filed), and `gh` (milestone close by number). Documents stop-on-error with a per-step recovery table, `--dry-run`, and the milestone-close distinction. Canonical skill installed user-global at `~/.claude/skills/release/SKILL.md`; `docs/skills/release-skill.md` is the version-controlled mirror.

**Not closed:** #339's acceptance bar requires driving one real release. A non-publication tag is the safest first proving target. Shipped-pending-proof; the proving run is the close condition.

## Cross-strand
- **#322/#521 split** (pre-agreed by both the spine and ceremony briefs): #322 implements the automated render-check/build-and-preview verification step; #521 only references it. Adopted, no divergence.
- **#508 harness is still open** (spine strand). Per the brief, #480's red-green is documented manually below; wiring it as a #508 harness case is follow-up.

## Test plan
- [x] `bash -n scripts/create-release.sh scripts/publish.sh` — clean.
- [x] `npm test` — 209 passed, 3 skipped (unchanged from baseline).
- [x] **#480 red-green** against a local bare wiki clone (no GitHub side effects): tag absent -> Completed bullet added as newest entry via real commit+push; rerun -> "no duplicate row (idempotent)"; exactly one occurrence. Surfaced and fixed two real bugs (silent commit failure under `||`; missing git identity on fresh clone).
- [x] Full-script `--dry-run` -> prints tag/release commands + Roadmap diff, creates no tag, pushes nothing.
- [x] `/release` skill registers and milestone-close API path confirmed (read-only GET on milestone 53).
- [ ] **Pending:** #339 proven on one real release (close condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)