### PR TITLE
#479: document inline-JSON image-frontmatter convention (Phase 2d)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,13 +209,7 @@ kmStart: 0
 kmEnd: 7.1
 gpxFile: /gpx/segment-01.gpx
 elevationData: /data/elevation/segment-01.json
-images:
-  - src: /images/segment-01/malemort-centre.jpg
-    alt: "Malemort town centre"
-    attribution: "Photo by Jean Dupont, CC BY-SA 4.0, Wikimedia Commons"
-  - src: /images/segment-01/brive-panorama.jpg
-    alt: "View toward Brive-la-Gaillarde"
-    attribution: "Photo by Marie Claire, CC BY 2.0, Flickr"
+images: [{"src": "/images/segment-01/malemort-centre.jpg", "alt": "Malemort town centre", "attribution": "Photo by Jean Dupont, CC BY-SA 4.0, Wikimedia Commons"}, {"src": "/images/segment-01/brive-panorama.jpg", "alt": "View toward Brive-la-Gaillarde", "attribution": "Photo by Marie Claire, CC BY 2.0, Flickr"}]
 weather: null  # Populated by publish script
 draft: false
 ---
@@ -226,6 +220,8 @@ The name alone should give our four riders pause...
 
 [Narrative content here — scenery, history, culture, cycling context]
 ```
+
+**Image frontmatter convention — use inline JSON.** The `images` field must be a single-line JSON array of objects (`images: [{"src": ..., "alt": ..., "attribution": ...}]`), as shown above — not a multi-line YAML block list. Rationale: the frontmatter parsers are currently regex-based, and only the inline-JSON form yields real per-image fields. `processing/validate_entries.py` accepts the YAML block-list form but parses it crudely (it counts `- src:` lines and drops `alt`/`attribution`), and this fragility is the class of bug behind the seg-9 publish-day crash. Full YAML-list support is gated on #326 (consolidation onto a single real parser); until that lands, inline JSON is the required form for every new entry.
 
 ## Phase 3: Rider Stats Tracker
 


### PR DESCRIPTION
## #479 — inline-JSON image-frontmatter convention

First PR of the v1.4.20 pipeline-spine strand (`feature/pipeline-spine`). Doc-only; zero shared-code risk.

### What changed
- New Phase 2d subsection in `CLAUDE.md` naming **inline JSON** as the required form for the `images` frontmatter field, with rationale and the `#326` cross-link.
- Updated the canonical Phase 2d example from a YAML block list to the inline-JSON form so the example matches the rule.

### Current-behaviour verification (per strand brief §3)
Confirmed against source before writing the rule: `processing/validate_entries.py` **accepts both** forms but only the inline-JSON path yields real per-image fields (`json.loads`). The YAML block-list path is parsed crudely — it counts `- src:` lines into `{"_yaml": True}` placeholders and drops `alt`/`attribution`. That fragility is the class behind the seg-9 publish-day crash. So the documented rule reflects what the validator actually does today; full YAML-list support is gated on the parser consolidation in #326.

### Cross-strand note
Seg 18/19 drafting strands: new entries must use the inline-JSON `images` form, not the YAML block list. (Seg 18 already merged in #632; flagging for seg 19 and forward.)

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)
