### PR TITLE
Data-state corrections: attractions.json (#547, #602)

### DIFF
--- a/data/attractions.json
+++ b/data/attractions.json
@@ -369,8 +369,13 @@
     "category": "bridge",
     "lat": 45.5365,
     "lng": 1.7945,
-    "description": "13th/14th-century stone bridge with three arches spanning the Vezere. Iconic view of the medieval town.",
-    "links": [],
+    "description": "Granite bridge of three broken arches spanning the Vezere, the 'Pont ancien sur la Vezere' (also Vieux Pont / Pont Medieval), inscribed Monument Historique on 1 April 1963. Iconic view of the medieval town.",
+    "links": [
+      {
+        "url": "https://www.pop.culture.gouv.fr/notice/merimee/PA00099910",
+        "label": "Mérimée (Monument Historique)"
+      }
+    ],
     "nearest_km": 121.99,
     "nearest_distance_m": 81
   },
@@ -679,16 +684,6 @@
     "links": [],
     "nearest_km": 143.64,
     "nearest_distance_m": 448
-  },
-  {
-    "name": "Pont de la Tourmente",
-    "category": "bridge",
-    "lat": 45.534,
-    "lng": 1.795,
-    "description": "Medieval fortified bridge in Treignac over the Vezere. Site of Hundred Years' War skirmishes when English forces raided the Bas-Limousin.",
-    "links": [],
-    "nearest_km": 121.91,
-    "nearest_distance_m": 319
   },
   {
     "name": "La Table de Jean",

--- a/data/attractions.json
+++ b/data/attractions.json
@@ -615,20 +615,20 @@
     "category": "church",
     "lat": 45.42442,
     "lng": 1.83625,
-    "description": "13th-century parish church at the centre of the Saint-Augustin bourg, the village the Stage 9 route runs through at km 94.5. Inscribed Monument Historique on 28 December 1929. Houses a 17th-century retable carved by Pierre Duhamel of Tulle. The Tourondel hamlet (1.3 km off-route, also in seg 14) is associated with an old wooden chapel that locally is said to have inspired the church's nave vault.",
+    "description": "13th-century parish church at the centre of the Saint-Augustin bourg, the village the Stage 9 route runs through at km 94.5. Inscribed Monument Historique on 25 September 1929. The Tourondel hamlet (1.3 km off-route, also in seg 14) is associated with an old wooden chapel that locally is said to have inspired the church's nave vault.",
     "links": [
       {
         "url": "https://fr.wikipedia.org/wiki/%C3%89glise_Saint-Augustin_de_Saint-Augustin",
         "label": "Wikipédia"
       },
       {
-        "url": "https://www.pop.culture.gouv.fr/notice/merimee/PA00099811",
+        "url": "https://www.pop.culture.gouv.fr/notice/merimee/PA00099839",
         "label": "Mérimée (Monument Historique)"
       }
     ],
     "nearest_km": 94.52,
     "nearest_distance_m": 9,
-    "source": "https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) and Mérimée database PA00099811 (verified 2026-05-07). Coord = bourg centre per OSM place=village; the church sits in the bourg square."
+    "source": "https://fr.wikipedia.org/wiki/Saint-Augustin_(Corr%C3%A8ze) and Mérimée database PA00099839 (corrected from PA00099811, which is the Château de Ventadour ruins at Moustier-Ventadour; verified 2026-05-29 for #547). Coord = bourg centre per OSM place=village; the church sits in the bourg square. The previously asserted 17th-century Pierre Duhamel retable was removed as unsourced (#547); neither PA00099839 nor the Wikipédia article documents it."
   },
   {
     "name": "Suc au May Table d'orientation",


### PR DESCRIPTION
First of the two **data-state correction** PRs (sibling: route/data PR for #506/#549/#603/#624). Per `strand-data-state-506-547-549-602-603-624.md`, this PR takes the `attractions.json` corrections; both merge before the geometry-drift strand rebases.

## #547 — Saint-Augustin church: wrong Mérimée notice, wrong date, unsourced retable
- Mérimée notice corrected **PA00099811 → PA00099839** in both `links[1].url` and the `source` field. PA00099811 is the Château de Ventadour ruins at Moustier-Ventadour, a different building in a different commune.
- Inscription date corrected **28 December 1929 → 25 September 1929**.
- Removed the unsourced sentence "Houses a 17th-century retable carved by Pierre Duhamel of Tulle." Neither PA00099839 nor the Wikipédia article documents it (likely a confusion with the Retable de Naves).

**Deciding source:** POP/culture.gouv Mérimée base, verified 2026-05-29 — PA00099839 = Église Saint-Augustin (inscribed 25 Sept 1929); PA00099811 = Ruines du château de Ventadour, Moustier-Ventadour.

## #602 — "Pont de la Tourmente" is not a documented bridge name (decision)
**Checkpoint decided: remove the entry and source the real bridge.** No Treignac heritage source documents a "Pont de la Tourmente"; the structure it describes is the documented Vieux Pont (Mérimée PA00099910, "Pont ancien sur la Vézère"), which already has its own `Pont Medieval de Treignac` entry 80 m away. Renaming would have duplicated that entry, so the redundant unsourced entry was removed and the existing one strengthened with the PA00099910 link + 1 April 1963 inscription date.

**Deciding source:** POP/culture.gouv Mérimée PA00099910 = three-broken-arch granite bridge over the Vézère at Treignac, inscribed 1 April 1963.

## Verification
- `npm test` — 28 files, 209 passed, 3 skipped (the 3 skips are the geometry strand's `climb-summit-km` KNOWN_FAILING).
- `nuxt generate` — 57 routes prerendered clean, no errors (attraction surfaces render).
- `git diff` touches only `data/attractions.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)