### PR TITLE
Data-state corrections: route/competition/historical data (#506, #549, #603, #624)

### DIFF
--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -20,7 +20,7 @@
       "points": [20, 17, 15, 13]
     },
     {
-      "name": "Sprint - Bugeat",
+      "name": "Sprint - Lestards",
       "segment": 19,
       "km": 130,
       "points": [20, 17, 15, 13]

--- a/data/historical-tdf.json
+++ b/data/historical-tdf.json
@@ -159,12 +159,6 @@
         "description": "72.5 km finish at Chaumeil on Saturday 11 July 1987, the same day as the men's stage. Roberta Bonanomi (Italy) won the stage ahead of Maria Canins and Jeannie Longo, taking the yellow jersey. Longo went on to win the overall race (8–26 July 1987). The Tour de France Féminin ran in parallel with the men's race from 1984 to 1989."
       },
       {
-        "year": 2017,
-        "stage": "Tour du Limousin Stage 3 (50th edition)",
-        "route": "Saint-Pantaléon-de-Larche to Chaumeil",
-        "description": "184.7 km Chaumeil finish on Thursday 17 August 2017, the queen stage of the 50th-anniversary Tour du Limousin. Won by Cyril Gautier (AG2R-La Mondiale). The stage climbed Côte de la Vaysse and Côte de Lestards before three finishing circuits over the Côte des Géants in Chaumeil."
-      },
-      {
         "year": 2020,
         "stage": "Stage 12",
         "route": "Chauvigny to Sarran",
@@ -186,6 +180,17 @@
         "stage": "Paris-Corrèze",
         "route": "Final stages closing at Chaumeil",
         "description": "UCI 2.1 stage race created in 2001 by 1983/1984 Tour de France winner Laurent Fignon with Corrézien motorsport champion Max Mamers and the Conseil général de la Corrèze. From the 2005 edition onward, the final stage closed with five laps of the historic Bol d'Or des Monédières circuit at Chaumeil, explicitly preserving the legacy of the post-Tour criterium. Six confirmed Chaumeil finishes: 2007 (Vigeois → Chaumeil, won by Edvald Boasson Hagen at age 20), 2008 (Brive → Chaumeil), 2009 (Tulle → Chaumeil), 2010, 2011 (Objat → Chaumeil), 2012 (Objat → Chaumeil, final edition). The race did not run in 2013 and has not been organised since."
+      }
+    ]
+  },
+  {
+    "segments": [15, 18, 19],
+    "events": [
+      {
+        "year": 2017,
+        "stage": "Tour du Limousin Stage 3 (50th edition)",
+        "route": "Saint-Pantaléon-de-Larche to Chaumeil",
+        "description": "184.7 km Chaumeil finish on Thursday 17 August 2017, the queen stage of the 50th-anniversary Tour du Limousin. Won by Cyril Gautier (AG2R-La Mondiale). The stage climbed Côte de la Vaysse and Côte de Lestards before three finishing circuits over the Côte des Géants in Chaumeil. The Côte de Lestards is the same crest as 2026 Stage 9's Côte de la Croix de Pey (segs 18-19, climbed from the Treignac side), so the stage's corridor footprint spans seg 15 (the Chaumeil finish) and segs 18-19 (the Lestards crossing); keyed to all three for #603."
       }
     ]
   },

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -70,7 +70,7 @@
     "type": "town",
     "lat": 45.4756,
     "lng": 1.7911,
-    "source": "https://en.wikipedia.org/wiki/Madranges (verified 2026-05-12). Plateau de Millevaches gateway commune (pop ~166, area 12.88 km²); bourg sits 102 m off the polyline at km 113.31 (seg 17). Added during seg 17-19 verification (#498) — previously absent from town-coords.json and segments.json towns array."
+    "source": "https://en.wikipedia.org/wiki/Madranges (verified 2026-05-12). Plateau de Millevaches gateway commune (pop ~166, area 12.88 km²); bourg sits 65.5 m off the polyline at km 113.48 (seg 17; recomputed against segment-17.gpx for #624). Added during seg 17-19 verification (#498) — previously absent from town-coords.json and segments.json towns array."
   },
   "Treignac": {
     "type": "town",

--- a/data/town-coords.json
+++ b/data/town-coords.json
@@ -7,7 +7,8 @@
   "Brive-la-Gaillarde": {
     "type": "town",
     "lat": 45.1584982,
-    "lng": 1.5332389
+    "lng": 1.5332389,
+    "note": "Town centre sits ~2.6 km off the route polyline, beyond split_gpx.py's 1000 m town-proximity threshold, so Brive is deliberately absent from every segment's generated towns array in segments.json (the route skirts Brive rather than passing through its centre). This is by design, not an omission (#506): split_gpx.py's module docstring cites Brive as the canonical example of correct off-route exclusion. Brive's relationship to the route is instead captured as 'Sprint - Brive-la-Gaillarde' (seg 1, km 3) in data/competition/points-config.json."
   },
   "Turenne": {
     "type": "town",


### PR DESCRIPTION
Second of the two **data-state correction** PRs (sibling: attractions PR #637). Per `strand-data-state-506-547-549-602-603-624.md`, this PR takes the route/competition/historical-data corrections. **Both this and #637 should merge before the geometry-drift strand (`strand-geometry-drift-551-554-555-589-590-591.md`) rebases** — that strand also touches `points-config.json` and regenerates `segments.json`.

## #624 — Madranges off-route note disagreed with the GPX (clear)
`town-coords.json` recorded the bourg at 102 m off the polyline at km 113.31. Recomputing the nearest-point offset from the file's own coordinate (45.4756, 1.7911) against `data/segments/segment-17.gpx` gives **65.5 m at km 113.48** (index 91/442). Corrected the note's figures; the coordinate is unchanged.

## #506 — Brive missing from seg-1 towns (decision)
**Checkpoint decided: document the deliberate exclusion (not force Brive into the array).** The `towns` array is **generated** by `split_gpx.py` route-proximity (1000 m threshold). Brive's town centre sits ~2.6 km off the route, and `split_gpx.py`'s own module docstring cites Brive as the canonical example of correct off-route exclusion. Forcing it in would contradict the design and risk pulling other off-route centres in. Added a `note` on Brive in `town-coords.json` recording that the exclusion is by design and that Brive's route relationship is already captured as the seg-1 sprint in `points-config.json`. This is the issue's own offered alternative ("a deliberate reason… documented somewhere readable").

## #549 — "Sprint - Bugeat" mis-keyed (decision)
**Checkpoint decided: rename to its location (Lestards), keep km/segment.** The sprint was keyed km 130 / seg 19, but Bugeat town is km 143.67 / seg 21; km 130 / seg 19 sits at **Lestards**. The official ASO Stage 9 sprint location is not publicly verifiable, so rather than relocate the point on a guess, the name was corrected to the data's own geometry: `Sprint - Bugeat → Sprint - Lestards`. `validate_points.py` stays green (sprint km still within its segment range).

## #603 — 2017 Tour du Limousin Stage 3 corridor footprint (decision)
**Checkpoint decided: split into its own [15, 18, 19] group.** `historical-tdf.json` groups events by a shared `segments` array; the 2017 event sat in the seg-15 Chaumeil group with five other events. Extending that group's array would have mis-keyed all six. Instead the 2017 event was split into its own group keyed `[15, 18, 19]` — preserving the Chaumeil finish (seg 15) and adding the Côte de Lestards crossing (= Côte de la Croix de Pey, segs 18-19) that seg 18-19 drafters need. The other five Chaumeil events stay keyed to seg 15.

## Verification
- `npm test` — 28 files, 209 passed, 3 skipped (geometry strand's `climb-summit-km` KNOWN_FAILING).
- `python3 processing/validate_points.py` — green after the #549 rename.
- `nuxt generate` — 57 routes prerendered clean (homepage HistoricalContext / UpcomingPoints / town-coords surfaces render).
- Re-ran `split_gpx.py` to confirm the #506/#549 generator-input edits produce **no** change to `segments.json`, then restored the committed file. The diff is intentionally absent.

## Finding surfaced (out of scope — see PR discussion)
Regenerating `segments.json` with the current `split_gpx.py` produces incidental churn unrelated to this work: it adds `town_positions` blocks the committed file lacks, and drops `Ussel` from seg-27 `towns` (closest-approach km falls on the half-open `km_end` boundary). The committed `segments.json` is stale w.r.t. the generator. Not fixed here (outside this strand's write-set); flagged for planning / a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)