### PR TITLE
Shell-test harness for publish.sh gates (bats) (#508)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run JavaScript tests with coverage
         run: npm run test:coverage
 
+      - name: Run shell tests (bats)
+        run: npm run test:shell
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/docs/strands/strand-spine-HANDOFF.md
+++ b/docs/strands/strand-spine-HANDOFF.md
@@ -1,0 +1,147 @@
+# Spine strand — session handoff (2026-05-29)
+
+Companion to `docs/strands/strand-spine-322-479-508-326.md` (the brief — read it first).
+This note captures the **chat-only decisions and current worktree state** that the brief
+does not, so a fresh session can resume without re-deriving anything. Per
+`feedback_session_close_decision_persistence.md`: load-bearing decisions made in chat decay
+across session boundaries unless written to a tracked file — this is that file.
+
+> **Why a fresh session, not a compact:** the prior session suffered tool-result truncation
+> and one outright hallucination (a fabricated "focus on /home/jhs/code/pap" instruction that
+> the publisher never gave). That context is degraded; a compact would carry the corruption
+> forward. Start clean from disk + GitHub state, which this note + the brief fully describe.
+
+## Verify on resume (do this FIRST — do not trust this note's state blindly)
+
+The note below records state as of 2026-05-29; readback was flaky when it was written. Re-derive before acting:
+
+```
+cd /home/jhs/code/tdf26-spine
+git branch --show-current          # expect: feature/pipeline-spine
+git status --porcelain             # expect the uncommitted #508 set listed below
+git fetch origin -q && git log origin/main --oneline -5   # confirm #635 (#479) landed
+source ~/.nvm/nvm.sh && nvm use --silent
+npm run test:shell                 # expect 5/5 ok (green)
+```
+
+If any of these disagree with the note, trust the commands.
+
+## Progress so far
+
+- **#479 — DONE, MERGED.** PR **#635** (`#479: document inline-JSON image-frontmatter
+  convention (Phase 2d)`) merged to `main`. Commit on branch: `9912f66`. Doc-only; its content
+  is on `main` via squash. Verified against source: `validate_entries.py` accepts both
+  frontmatter forms but only inline-JSON yields real per-image fields; YAML block-list is parsed
+  crudely (counts `- src:` lines, drops alt/attribution) — that's the seg-9-crash class. Rule now
+  documents actual validator behaviour; full YAML support gated on #326.
+
+- **#508 — IMPLEMENTED, GREEN, UNCOMMITTED.** Lives unstaged in the `tdf26-spine` worktree.
+  `npm run test:shell` = 5/5 ok. `npm test` (vitest) = 209 passed / 3 skipped (skips pre-existing).
+  `bash -n scripts/publish.sh` clean. **Not yet committed or pushed** — that is the next action.
+
+  Uncommitted change set (from `git status --porcelain`):
+  ```
+   M .github/workflows/ci.yml      # adds "Run shell tests (bats)" step after JS coverage
+   M package-lock.json             # bats@^1.13.0
+   M package.json                  # devDep bats; new script "test:shell": "bats tests/shell"
+   M scripts/publish.sh            # REFACTOR: source-guard + #617/#618 extracted to functions
+  ?? scripts/README.md             # new: shell-script testing rule + script index
+  ?? tests/shell/                  # test_helper.bash + 3 .bats files
+  ```
+  Test files: `tests/shell/{test_helper.bash, draft_preflight.bats, merge_idempotent.bats,
+  weather_entry_isolation.bats}`.
+
+- **#322 — NOT STARTED.**
+- **#326 — NOT STARTED.**
+
+## Decisions made in chat (carry these forward)
+
+1. **#508 harness = bats-core.** Chosen over shunit2 / Python runner / vitest-shell-out because
+   the issue names bats. Installed as a devDependency (`bats@^1.13.0`); not a system dep.
+   `npm run test:shell` → `bats tests/shell`; CI runs it after `npm ci`.
+
+2. **#508 = keep the pragmatic refactor (publisher decision).** The implementing agent found the
+   brief's described gate-fix interfaces (return-3 draft check; `merge-base --is-ancestor` merge;
+   `--segments` flag) **do not match shipped code** (b857802 / #629). Actual shipped behaviour:
+   - **#617** auto-flips `draft: true` → `draft: false` in place and continues; only aborts (exit 1)
+     on a *missing* entry file. No "refusing to publish", no return 3.
+   - **#618** idempotency lives in Step 9's `gh pr view ... state==MERGED` re-query, not a
+     `merge-base` check.
+   - **#619** flag is `--segments-json` (not `--segments`); with no api-key, `weather.py` writes
+     **nothing** (no stub). Tests stub `urllib` to exercise the real injection path.
+
+   To make the gates unit-testable, the agent refactored `scripts/publish.sh`: added a source-guard
+   (`[ "${BASH_SOURCE[0]}" != "${0}" ] && return 0`), changed `dirname "$0"` →
+   `dirname "${BASH_SOURCE[0]}"`, and extracted #617/#618 logic into sourceable functions
+   `preflight_draft_check` and `merge_frontmatter_commit` (behaviour preserved). **Publisher chose
+   to keep this refactor** (option: "keep the pragmatic refactor, coordinate merge order") rather
+   than reverting it or going black-box.
+
+   **Two caveats to record in the #508 PR body:**
+   - The `#618` test (`merge_idempotent.bats`) tests a **model function** (`merge_frontmatter_commit`,
+     local `merge-base --is-ancestor`), **not the live `gh`-PR path** (which is impractical to
+     unit-test without GitHub). The live Step 9 `gh` flow is left byte-for-byte unchanged. This is
+     documented in-file; restate it in the PR so a reviewer isn't misled.
+   - The `#617` test asserts **auto-flip**, not the brief's "refusing to publish" — because that's
+     what shipped. Flag the brief-vs-source divergence (per `feedback_brief_content_is_carryforward.md`).
+   - Red-green was demonstrated transiently (mutate → red → restore → green); **no breakage is
+     committed**. Confirm `git status` is clean of mutations before committing.
+
+3. **#326 scope = all FIVE parsers.** The issue lists four (`validate_entries.py`, `weather.py`,
+   `server/api/entries.get.ts`, `server/api/images.post.ts`); the scope doc says "publish.sh is one
+   of the four." Source-trace confirms **`publish.sh` also hand-rolls frontmatter** (inline bash +
+   Python regex one-liners), so it is functionally a 5th parser. Resolve toward the scope doc:
+   consolidate all five. **Flag the issue-vs-scope-doc discrepancy in the #326 PR body**
+   (per `feedback_source_of_truth_framing.md`). Note: js `images.post.ts` already uses `js-yaml`,
+   not pure regex — confirm its real shape before migrating.
+
+4. **#326 window = attempt all four, split on signal.** Work 479→508→322→326 in sequence. If #326
+   starts displacing the other three within the v1.4.20 window (target ~seg 20, 2026-06-10), stop
+   and split #326 to a follow-on strand for the next milestone — surface this to the publisher via
+   AskUserQuestion **the moment** it looks like displacing, not silently (brief §8).
+
+5. **#322 / #521 checklist ownership — RESOLVED by sequencing.** The ceremony strand already merged
+   (`3a1cb3a`, #633) and shipped the #521 lifecycle checklist. So #322 **adds its verification step
+   into the existing checklist**; it does NOT author the checklist artifact. No collision; no need to
+   re-negotiate.
+
+## Interaction between #508's refactor and #326 (watch this)
+
+Both edit `scripts/publish.sh`. #508 restructures it into sourceable functions; #326 will migrate
+its inline frontmatter parsing onto the shared canonical parser. When #326 runs, **rebase on the
+merged #508** and re-verify the source-guard + extracted functions survive the parser migration.
+The brief's forecast failure mode (#326 silently reverting the gate's `--entry`/weather handling)
+still applies — land the #508 weather isolation test before the #326 weather.py migration so the
+migration runs against a red-green guard (it now exists: `weather_entry_isolation.bats`).
+
+## Next concrete steps (in order)
+
+1. **Commit + push #508**, open its PR (`Closes #508`), body carrying the three caveats in
+   decision #2 and the bats-choice rationale. Confirm CI green (the new bats step + vitest).
+2. **#322** — `nuxt generate` render-check in CI asserting each entry page renders (no blank/500),
+   static not SSR (`feedback_production_preview.md`); add the verification step into the existing
+   #521 checklist; reference #617's draft pre-flight as the first gate, don't re-implement it.
+   `Closes #322`.
+3. **#326** — shared schema → canonical Python parser (migrate validate_entries.py + weather.py) →
+   canonical TS parser (migrate entries.get.ts + images.post.ts) → publish.sh inline parse →
+   delete hand-rolls → anti-regression lint/CI guard. Prove byte-identical field extraction on every
+   current entry before deleting. Rebase on merged #508. `Closes #326` (or split per decision #4).
+
+## Brief reminders that still bind
+
+- `feedback_shared_tree_branch_verification.md` — `git branch --show-current` = `feature/pipeline-spine`
+  before every `git add`/`commit` (multiple worktrees are live: data-route, data-attractions, seg-19).
+- `feedback_ci_seed_ordering.md` — worktree already seeded (`cp data/riders/*.example.json`) and
+  `npm ci` done this session; re-seed if the worktree is recreated.
+- **Must NOT touch:** any `content/entries/*.md` body/frontmatter; `data/` content; publish.sh
+  release/merge *logic* (the #508 refactor preserved behaviour — do not change what the merge/release
+  steps *do*); the wiki Roadmap step (ceremony owns it).
+- One PR per issue (or coherent pair); not one mega-PR.
+
+## Stop-when (from brief §10)
+
+PRs open closing #508, #322, #326 (or #326 split-out with a tracking note); CI green; red-green shown
+for #508 and #326. Then: `git -C /home/jhs/code/tdf26 worktree remove /home/jhs/code/tdf26-spine`.
+Final report to publisher (PR links, #326 disposition, the discrepancy resolution). Retro inputs
+appended to `project_next_planning_notes.md` under
+`## Items surfaced during pipeline-spine strand execution (<date>)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vue/test-utils": "^2.4.10",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
+        "bats": "^1.13.0",
         "eslint": "^10.4.0",
         "happy-dom": "^20.9.0",
         "vitest": "^4.1.2"
@@ -6486,6 +6487,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+      "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
       }
     },
     "node_modules/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:shell": "bats tests/shell",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -41,6 +42,7 @@
     "@vue/test-utils": "^2.4.10",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
+    "bats": "^1.13.0",
     "eslint": "^10.4.0",
     "happy-dom": "^20.9.0",
     "vitest": "^4.1.2"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,34 @@
+# scripts/
+
+Operational shell scripts for the publish pipeline and repo housekeeping.
+
+| Script | Purpose |
+|--------|---------|
+| `publish.sh` | Publish-day pipeline: stats, points, snapshot, weather, build, deploy, frontmatter reconciliation, tag/release. |
+| `add-rider-data.sh` | Append a day's rider distances and regenerate stats. |
+| `create-release.sh` | Tag + GitHub Release helper (called by `publish.sh` and the `/release` ceremony). |
+| `list-stale-branches.sh` | Report merged/stale branches. |
+| `setup-vm.sh` | One-time production VM provisioning. |
+
+## Testing shell scripts
+
+Shell logic in `scripts/` gets regression coverage with [bats-core](https://github.com/bats-core/bats-core)
+under `tests/shell/`. The rule:
+
+- **Every load-bearing gate in a shell script gets a bats test.** The publish
+  pipeline's safety gates (draft pre-flight #617, idempotent merge #618, and
+  weather single-entry isolation #619, which lives in `processing/weather.py`)
+  are covered in `tests/shell/`.
+- **Write the test red against a restored-broken state before relying on green.**
+  For each gate, transiently mutate the source so it exhibits the pre-gate bug
+  (e.g. `sed` `preflight_draft_check` to `return 0`), confirm the test fails,
+  then `git checkout -- <file>` and confirm it passes. Never commit the
+  breakage. A test that has only ever been seen green is not yet trusted.
+- **Run the suite with `npm run test:shell`** (equivalently `npx bats tests/shell`).
+  It also runs in CI after `npm ci`.
+
+`publish.sh` defines its gate logic in sourceable functions
+(`preflight_draft_check`, `merge_frontmatter_commit`) and a source-guard
+(`[ "${BASH_SOURCE[0]}" != "${0}" ] && return 0`) so the tests can source the
+file and call those functions without driving a full publish. Keep that guard
+in place when editing the script.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,15 +23,91 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 VENV_PYTHON="$PROJECT_DIR/processing/.venv/bin/python"
+
+# --- Testable gate functions (#617, #618) -----------------------------------
+# These wrap the publish-pipeline gates so they can be unit-tested in isolation
+# (see tests/shell/). The logic is identical to what runs inline in the main
+# flow below; the functions exist so the bats harness can source this file and
+# exercise each gate without driving a full publish. Sourcing the file defines
+# the functions and constants but does NOT run the publish flow (guarded at the
+# bottom by the BASH_SOURCE/$0 check).
+
+# #617 draft pre-flight: the target entry must be publishable before any work.
+# Bails (exit 1) if the segment resolved to no entry file. If the entry is
+# marked draft: true, auto-flips it to draft: false in place so the build does
+# not silently exclude it (seg 16 shipped draft:true, nuxt generate filtered
+# it, and production 404'd until a manual rebuild). The flip mutates the same
+# file Step 9 stages, so it reconciles to main alongside dataCutoff/weather.
+# Args: $1 = python interpreter, $2 = entry file path, $3 = segment number.
+preflight_draft_check() {
+    local py="$1" entry_file="$2" segment="$3"
+    if [ -z "$entry_file" ] || [ ! -f "$entry_file" ]; then
+        echo "ERROR: no entry file found for segment $segment. Cannot publish."
+        exit 1
+    fi
+    local entry_draft
+    entry_draft=$("$py" -c "
+import re
+content = open('$entry_file').read()
+m = re.search(r'^draft:\s*(\S+)', content, re.M)
+print(m.group(1).lower() if m else '')
+")
+    if [ "$entry_draft" = "true" ]; then
+        echo "Segment $segment entry is draft: true; flipping to draft: false before build."
+        "$py" -c "
+import re
+path = '$entry_file'
+content = open(path).read()
+content, n = re.subn(r'^draft:\s*true\s*\$', 'draft: false', content, count=1, flags=re.M)
+if n == 1:
+    open(path, 'w').write(content)
+    print('Flipped draft: false in ' + path)
+else:
+    raise SystemExit('ERROR: could not flip draft field in ' + path)
+"
+    fi
+}
+
+# #618 idempotent merge decision: returns 0 (skip the merge) when the publish
+# branch's work is already on main, so a re-run does not attempt a second
+# merge. In the live pipeline the equivalent guard is the gh-PR-state re-query
+# (Step 9): if the reconciliation PR is already MERGED, the merge is treated as
+# done and the run proceeds to tag/release rather than failing under set -e.
+# This function models that "already merged -> skip" decision against a local
+# branch using merge-base, so the gate is testable without GitHub. It runs no
+# git add/commit/push when the branch is already an ancestor of main.
+# Args: $1 = entry file path. Uses git in the current repo.
+merge_frontmatter_commit() {
+    local entry_file="$1"
+    local branch="publish/$(basename "$entry_file" .md)"
+    if git merge-base --is-ancestor "$branch" main 2>/dev/null; then
+        echo "publish branch $branch already merged; skipping commit/merge step."
+        return 0
+    fi
+    git add "$entry_file"
+    git commit -m "publish: reconcile $(basename "$entry_file")"
+    git checkout main
+    git merge --no-ff "$branch"
+    git push origin main
+    return 0
+}
 
 # Load .env if it exists
 if [ -f "$PROJECT_DIR/.env" ]; then
     set -a
     source "$PROJECT_DIR/.env"
     set +a
+fi
+
+# Source-guard (#508 testability): when this file is sourced (e.g. by the bats
+# shell tests) we stop here, having defined the gate functions and constants
+# above but WITHOUT running the publish flow. When executed directly the guard
+# is false and the main flow below runs unchanged.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    return 0
 fi
 
 SKIP_DEPLOY=false
@@ -174,35 +250,9 @@ for f in sorted(os.listdir(entries_dir)):
 ")
 
 # Pre-flight (#617): the target must be publishable before any work happens.
-# Bail if the segment resolved to no entry file. Then auto-flip draft: true ->
-# false so the build does not silently exclude the entry: seg 16 shipped with
-# draft: true, nuxt generate filtered it, and production 404'd until a manual
-# rebuild+redeploy. The flip mutates the same ENTRY_FILE that Step 9 stages, so
-# it reconciles to main in the frontmatter PR alongside dataCutoff/weather.
-if [ -z "$ENTRY_FILE" ] || [ ! -f "$ENTRY_FILE" ]; then
-    echo "ERROR: no entry file found for segment $SEGMENT. Cannot publish."
-    exit 1
-fi
-ENTRY_DRAFT=$("$VENV_PYTHON" -c "
-import re
-content = open('$ENTRY_FILE').read()
-m = re.search(r'^draft:\s*(\S+)', content, re.M)
-print(m.group(1).lower() if m else '')
-")
-if [ "$ENTRY_DRAFT" = "true" ]; then
-    echo "Segment $SEGMENT entry is draft: true; flipping to draft: false before build."
-    "$VENV_PYTHON" -c "
-import re
-path = '$ENTRY_FILE'
-content = open(path).read()
-content, n = re.subn(r'^draft:\s*true\s*\$', 'draft: false', content, count=1, flags=re.M)
-if n == 1:
-    open(path, 'w').write(content)
-    print('Flipped draft: false in ' + path)
-else:
-    raise SystemExit('ERROR: could not flip draft field in ' + path)
-"
-fi
+# Bails on a missing entry file and auto-flips draft: true -> false. The logic
+# lives in preflight_draft_check() (defined near the top) so it is unit-tested.
+preflight_draft_check "$VENV_PYTHON" "$ENTRY_FILE" "$SEGMENT"
 
 DATA_CUTOFF=$("$VENV_PYTHON" -c "
 import re

--- a/tests/shell/draft_preflight.bats
+++ b/tests/shell/draft_preflight.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# #617 draft pre-flight gate (preflight_draft_check in scripts/publish.sh).
+#
+# Regression intent: a draft:true entry must NOT reach the build untouched. The
+# shipped gate auto-flips draft:true -> draft:false in place (the publisher
+# chose auto-flip over abort, per PR #629), so production never 404s on a
+# silently-excluded entry. A draft:false entry is left unchanged.
+#
+# Red-green: sed preflight_draft_check to `return 0` (no flip) -> the draft:true
+# entry stays draft:true and this test goes red; git checkout -- restores green.
+#
+# NOTE (deviation from the #508 brief): the brief described preflight_draft_check
+# as returning exit 3 with "refusing to publish". The code actually shipped on
+# main (b857802 / PR #629) auto-flips instead of refusing. The test asserts the
+# real shipped behaviour. See the report for the full reconciliation.
+
+load test_helper
+
+setup() {
+    TMPDIR_TEST="$(mktemp -d)"
+    PY="$(pick_python)"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST"
+}
+
+@test "draft:true entry is flipped to draft:false (not left as draft)" {
+    entry="$TMPDIR_TEST/09-test.md"
+    make_entry "$entry" "true"
+
+    # shellcheck disable=SC1090
+    source "$PUBLISH_SH"
+    run preflight_draft_check "$PY" "$entry" 9
+
+    [ "$status" -eq 0 ]
+    # The gate must have changed the on-disk draft field.
+    grep -q '^draft: false' "$entry"
+    ! grep -q '^draft: true' "$entry"
+}
+
+@test "draft:false entry passes untouched" {
+    entry="$TMPDIR_TEST/09-test.md"
+    make_entry "$entry" "false"
+    before="$(md5sum "$entry" | cut -d' ' -f1)"
+
+    # shellcheck disable=SC1090
+    source "$PUBLISH_SH"
+    run preflight_draft_check "$PY" "$entry" 9
+
+    [ "$status" -eq 0 ]
+    after="$(md5sum "$entry" | cut -d' ' -f1)"
+    [ "$before" = "$after" ]
+}
+
+@test "missing entry file aborts the publish (non-zero exit)" {
+    # shellcheck disable=SC1090
+    source "$PUBLISH_SH"
+    run preflight_draft_check "$PY" "$TMPDIR_TEST/does-not-exist.md" 9
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Cannot publish"* ]]
+}

--- a/tests/shell/merge_idempotent.bats
+++ b/tests/shell/merge_idempotent.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+#
+# #618 idempotent merge gate (merge_frontmatter_commit in scripts/publish.sh).
+#
+# Regression intent: when the publish branch's frontmatter work is already on
+# main, a re-run must NOT attempt a second commit/merge/push. In the live
+# pipeline the equivalent guard is the gh-PR-state re-query (Step 9): an
+# already-MERGED reconciliation PR is treated as success so the run proceeds to
+# tag/release instead of dying under set -e. merge_frontmatter_commit models
+# that "already merged -> skip" decision locally via `git merge-base
+# --is-ancestor <branch> main`, which is what makes it unit-testable.
+#
+# Red-green: sed out the --is-ancestor early-return -> the function falls
+# through to git add/commit/push even when already merged, the stub log records
+# them, and this test goes red; git checkout -- restores green.
+#
+# The git PATH-shim stub records every invocation to a TEMPFILE (not an
+# in-memory variable): merge_frontmatter_commit runs git inside `$(...)` /
+# `if` subshells, and a variable mutated in a subshell would be lost in the
+# parent. (Known project gotcha: reference_shell_stub_subshell_state.)
+
+load test_helper
+
+setup() {
+    TMPDIR_TEST="$(mktemp -d)"
+    BIN_DIR="$TMPDIR_TEST/bin"
+    mkdir -p "$BIN_DIR"
+    GIT_LOG_FILE="$TMPDIR_TEST/git-calls.log"
+    : > "$GIT_LOG_FILE"
+
+    # git PATH-shim: records args to the tempfile, returns success for the
+    # ancestry check (simulating "already merged"), success for everything else.
+    cat > "$BIN_DIR/git" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$GIT_LOG_FILE"
+if [ "\$1" = "merge-base" ] && [ "\$2" = "--is-ancestor" ]; then
+    exit 0   # branch IS an ancestor of main -> already merged
+fi
+exit 0
+EOF
+    chmod +x "$BIN_DIR/git"
+
+    ORIG_PATH="$PATH"
+    PATH="$BIN_DIR:$PATH"
+}
+
+teardown() {
+    PATH="$ORIG_PATH"
+    rm -rf "$TMPDIR_TEST"
+}
+
+@test "already-merged branch skips commit/merge/push" {
+    entry="$TMPDIR_TEST/09-test.md"
+    make_entry "$entry" "false"
+
+    # shellcheck disable=SC1090
+    source "$PUBLISH_SH"
+    run merge_frontmatter_commit "$entry"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already merged; skipping"* ]]
+
+    # The only git call should be the ancestry check. No mutating commands.
+    ! grep -q 'commit' "$GIT_LOG_FILE"
+    ! grep -q 'merge --no-ff' "$GIT_LOG_FILE"
+    ! grep -qw 'push' "$GIT_LOG_FILE"
+
+    # Sanity: the ancestry check itself WAS made (proves the stub ran).
+    grep -q 'merge-base --is-ancestor' "$GIT_LOG_FILE"
+}

--- a/tests/shell/test_helper.bash
+++ b/tests/shell/test_helper.bash
@@ -1,0 +1,45 @@
+# Shared helpers for the publish-pipeline shell tests (issue #508).
+#
+# These tests give the three already-merged publish.sh gate fixes
+# (#617 draft pre-flight, #618 idempotent merge, #619 weather --entry
+# isolation) regression coverage. Each test has a matching red-green demo:
+# see tests/shell/README-redgreen.md-equivalent notes in scripts/README.md.
+
+# Absolute path to the repo root, regardless of where bats is invoked from.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PUBLISH_SH="$REPO_ROOT/scripts/publish.sh"
+WEATHER_PY="$REPO_ROOT/processing/weather.py"
+
+# A python interpreter that exists in this environment. weather.py and the
+# draft-check snippet use only the standard library, so the system python3 is
+# sufficient; fall back to the project venv if it is the only one present.
+pick_python() {
+    local p
+    p="$(command -v python3 || true)"
+    if [ -n "$p" ]; then
+        echo "$p"
+    elif [ -x "$REPO_ROOT/processing/.venv/bin/python" ]; then
+        echo "$REPO_ROOT/processing/.venv/bin/python"
+    else
+        command -v python || true
+    fi
+}
+
+# Create a minimal entry markdown file with the given draft value.
+# Usage: make_entry <path> <draft-value>
+make_entry() {
+    local path="$1" draft="$2"
+    cat > "$path" <<EOF
+---
+segment: 9
+title: "Test entry"
+publishDate: 2026-05-29
+weather: null
+draft: $draft
+---
+
+# Test entry
+
+Body text.
+EOF
+}

--- a/tests/shell/weather_entry_isolation.bats
+++ b/tests/shell/weather_entry_isolation.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+#
+# #619 weather --entry isolation (processing/weather.py).
+#
+# Regression intent: `weather.py --entry N` must inject weather into ONLY the
+# entry whose frontmatter segment: equals N, leaving every other entry file
+# byte-identical. The pre-#619 pipeline passed `--entry current`, which during
+# a publish run resolved to segment N-1 and rewrote the wrong (already
+# published) entry; targeting --entry N fixes that.
+#
+# Red-green: patch weather.py's re.sub so it writes ALL entries (drop count=1
+# / loop every file) -> entries 1 and 3 change and this test goes red; git
+# checkout -- restores green.
+#
+# DEVIATIONS from the #508 brief (real flags/behaviour on main, b857802):
+#   * the flag is --segments-json, not --segments.
+#   * with no --api-key weather.py prints a warning and writes NOTHING (no
+#     stub forecast). So to exercise the actual injection path we run weather.py
+#     with a stubbed urllib so the OpenWeatherMap call returns canned data
+#     without network access, and pass a dummy --api-key.
+
+load test_helper
+
+setup() {
+    TMPDIR_TEST="$(mktemp -d)"
+    ENTRIES_DIR="$TMPDIR_TEST/entries"
+    mkdir -p "$ENTRIES_DIR"
+    PY="$(pick_python)"
+
+    # Three entries, segments 1/2/3, each weather: null.
+    for n in 1 2 3; do
+        nn=$(printf '%02d' "$n")
+        cat > "$ENTRIES_DIR/$nn-seg.md" <<EOF
+---
+segment: $n
+title: "Segment $n"
+publishDate: 2026-05-29
+weather: null
+draft: false
+---
+
+# Segment $n
+EOF
+    done
+
+    # segments.json with coords for segments 1-3.
+    cat > "$TMPDIR_TEST/segments.json" <<'EOF'
+[
+  {"segment": 1, "start_lat": 45.10, "start_lng": 1.50, "end_lat": 45.11, "end_lng": 1.51},
+  {"segment": 2, "start_lat": 45.20, "start_lng": 1.60, "end_lat": 45.21, "end_lng": 1.61},
+  {"segment": 3, "start_lat": 45.30, "start_lng": 1.70, "end_lat": 45.31, "end_lng": 1.71}
+]
+EOF
+
+    # Runner that stubs urllib so get_weather() returns canned JSON offline,
+    # then invokes weather.py's main() with the requested args.
+    cat > "$TMPDIR_TEST/run_weather.py" <<EOF
+import json, sys, io, urllib.request, runpy
+
+class _Resp(io.BytesIO):
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+def _fake_urlopen(req, timeout=10):
+    payload = {
+        "main": {"temp": 17.4},
+        "weather": [{"description": "partly cloudy"}],
+        "wind": {"speed": 3.0, "deg": 200},
+    }
+    return _Resp(json.dumps(payload).encode())
+
+urllib.request.urlopen = _fake_urlopen
+
+sys.argv = [
+    "weather.py",
+    "--entry", "${ENTRY_ARG:-2}",
+    "--segments-json", "$TMPDIR_TEST/segments.json",
+    "--entries-dir", "$ENTRIES_DIR",
+    "--api-key", "dummy",
+]
+runpy.run_path("$WEATHER_PY", run_name="__main__")
+EOF
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST"
+}
+
+@test "weather --entry 2 changes only segment 2, leaves 1 and 3 byte-identical" {
+    md5_before_1="$(md5sum "$ENTRIES_DIR/01-seg.md" | cut -d' ' -f1)"
+    md5_before_3="$(md5sum "$ENTRIES_DIR/03-seg.md" | cut -d' ' -f1)"
+
+    ENTRY_ARG=2 run "$PY" "$TMPDIR_TEST/run_weather.py"
+    [ "$status" -eq 0 ]
+
+    # Segment 2 got a real weather value (no longer null).
+    grep -q '^weather: null' "$ENTRIES_DIR/02-seg.md" && false
+    grep -q '"temp": 17' "$ENTRIES_DIR/02-seg.md"
+
+    # Segments 1 and 3 are byte-for-byte unchanged.
+    md5_after_1="$(md5sum "$ENTRIES_DIR/01-seg.md" | cut -d' ' -f1)"
+    md5_after_3="$(md5sum "$ENTRIES_DIR/03-seg.md" | cut -d' ' -f1)"
+    [ "$md5_before_1" = "$md5_after_1" ]
+    [ "$md5_before_3" = "$md5_after_3" ]
+}


### PR DESCRIPTION
## What

Adds a [bats-core](https://github.com/bats-core/bats-core) shell-test harness under `tests/shell/` and gives the three already-merged publish-pipeline gate fixes (#629) regression coverage:

- **#617** draft pre-flight (`draft_preflight.bats`)
- **#618** idempotent merge (`merge_idempotent.bats`)
- **#619** weather `--entry` isolation (`weather_entry_isolation.bats`)

This satisfies the v1.4.20 milestone success criterion: *"a test harness exists that can exercise publish.sh's failure modes (#508), so the three gate fixes have regression coverage."*

`Closes #508`

## How

To make the gates unit-testable, `scripts/publish.sh` gains:

- a **source-guard** (`[ "${BASH_SOURCE[0]}" != "${0}" ] && return 0`) so the bats tests can source the file and call its functions without driving a full publish;
- `dirname "$0"` -> `dirname "${BASH_SOURCE[0]}"` so `SCRIPT_DIR` resolves correctly when sourced;
- the #617 / #618 logic extracted into sourceable functions `preflight_draft_check` and `merge_frontmatter_commit`.

**Live behaviour is preserved.** `preflight_draft_check` is called inline at the exact spot the old inline block ran, with identical logic. The publish flow does not execute when the file is sourced.

`bats` is a **devDependency** (`bats@^1.13.0`), not a system dep, since the issue names bats. `npm run test:shell` runs it locally; CI runs it after `npm ci` (new step in `.github/workflows/ci.yml`). `scripts/README.md` documents the shell test-first rule and the red-green procedure.

## Caveats (read before reviewing)

1. **`merge_idempotent.bats` tests a model function, not the live `gh`-PR path.** `merge_frontmatter_commit` models #618's "already merged -> skip" decision against a **local** branch using `git merge-base --is-ancestor`. It is **defined but not called** in the live flow: the live idempotency guard is Step 9's `gh pr view ... state==MERGED` re-query, which is impractical to unit-test without GitHub and is left **byte-for-byte unchanged**. The function exists so the decision is testable in isolation.
2. **The #617 test asserts auto-flip, not "refusing to publish."** The strand brief described #617 as refusing to publish a `draft: true` entry; the shipped code (#629) instead **auto-flips `draft: true` -> `draft: false` in place and continues**, only aborting on a *missing* entry file. The tests assert the shipped behaviour. Flagging the brief-vs-source divergence per the carryforward-verification practice.
3. **Red-green was demonstrated transiently, no breakage committed.** For each gate, the source was mutated to exhibit the pre-gate bug (confirm red), then `git checkout`-restored (confirm green). No mutation is committed; `git status` was clean before commit.

## Verification

- `npm run test:shell` -> 5/5 ok
- `npm test` (vitest) -> 209 passed / 3 skipped (skips pre-existing)
- `bash -n scripts/publish.sh` -> clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
