### PR TITLE
Pre-publish render verification: assert every entry page renders (#322)

### DIFF
--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -75,7 +75,7 @@ v1.4.19 (8-strand blitz).
 ## 5. Review, verify, merge
 
 - [ ] CI green. `npm test`; `bash -n` for any touched shell script; the shell-test harness once #508 lands.
-- [ ] **Rendered-page verification** (the build-and-preview step). The *automated* render-check (CI generates the site and asserts each entry page renders, no blank/500) is owned by **#322**. Until #322 lands, do this manually: `npm run build` + a `nuxt generate` static preview — **not** the SSR runtime (`feedback_production_preview`). *(Ownership split with #322: #322 implements the verification step; this checklist only references it.)*
+- [ ] **Rendered-page verification** (the build-and-preview step). The *automated* render-check now runs in CI (#322): `nuxt generate` then `tests/e2e/build-verify.sh`, which asserts every non-draft entry page renders — substantive size, no error boundary, and its **own title** present (catches the v1.3.4 frontmatter-corruption class where a page built but rendered blank), plus that the rendered entry count matches the non-draft entries on disk. CI failing this step blocks the merge. A manual `nuxt generate` static preview (**not** the SSR runtime, `feedback_production_preview`) remains the recommended final human look before deploy for anything CI can't judge (layout, imagery, prose).
 - [ ] Visible / blast-radius actions (push, deploy, force) confirmed with the publisher unless pre-authorised for a defined scope.
 - [ ] Merge to `main` via PR (squash). Verify the merge via the GitHub API before post-merge steps (`feedback_pr_polling`). Never push directly to `main`.
 

--- a/tests/e2e/build-verify.sh
+++ b/tests/e2e/build-verify.sh
@@ -60,6 +60,33 @@ check_not_contains() {
   fi
 }
 
+# Fixed-string variant of check_contains (no regex). Used for entry titles,
+# which can carry punctuation that would otherwise be read as regex.
+check_contains_fixed() {
+  local file="$OUTPUT_DIR/$1"
+  local pattern="$2"
+  local label="${3:-$2}"
+  if [ -f "$file" ] && grep -Fq "$pattern" "$file"; then
+    pass "$1 contains: $label"
+  else
+    fail "$1 missing: $label"
+  fi
+}
+
+# Assert a generated file is at least min bytes. A blank/error stub is tiny;
+# every real entry page is tens of KB (smallest observed ~53 KB).
+check_min_size() {
+  local file="$OUTPUT_DIR/$1"
+  local min="$2"
+  local size=0
+  [ -f "$file" ] && size=$(wc -c < "$file")
+  if [ "$size" -ge "$min" ]; then
+    pass "$1 substantive ($size bytes)"
+  else
+    fail "$1 too small ($size bytes < $min) - possible blank/error page"
+  fi
+}
+
 echo ""
 echo "Build verification: $OUTPUT_DIR"
 echo "================================"
@@ -144,6 +171,46 @@ check_file "admin/index.html"
 echo ""
 echo "Content data:"
 check_dir "__nuxt_content"
+
+# --- Per-entry render check (#322): every non-draft entry page renders ---
+# Targets the v1.3.4 bug class: a frontmatter-injection bug (dataCutoff) shipped
+# a page that built fine but rendered blank / without its content. The page
+# shell ("Corrèze" in the layout) survives such a failure, so the load-bearing
+# assertion is that each entry renders its OWN title - proof the frontmatter
+# parsed and the body rendered, not just the chrome. We also assert the page is
+# substantive and carries no error boundary, and that the count of rendered
+# non-draft entries matches the count on disk (catches a silently dropped entry,
+# the seg-16 draft-filtering class).
+echo ""
+echo "Per-entry render check (#322):"
+MIN_ENTRY_BYTES=20000
+EXPECTED=0
+RENDERED=0
+for entry_file in "$PROJECT_DIR"/content/entries/*.md; do
+  grep -q "^draft: true" "$entry_file" && continue
+  EXPECTED=$((EXPECTED + 1))
+  slug=$(basename "$entry_file" .md)
+  rel="entries/$slug/index.html"
+  if [ ! -f "$OUTPUT_DIR/$rel" ]; then
+    fail "non-draft entry not rendered: $slug"
+    continue
+  fi
+  RENDERED=$((RENDERED + 1))
+  check_min_size "$rel" "$MIN_ENTRY_BYTES"
+  check_not_contains "$rel" "__nuxt_error" "no Nuxt error boundary ($slug)"
+  check_not_contains "$rel" "Page not found" "no 404 body ($slug)"
+  title=$(grep -m1 '^title:' "$entry_file" | sed -E 's/^title:[[:space:]]*//; s/^"//; s/"$//')
+  if [ -n "$title" ]; then
+    check_contains_fixed "$rel" "$title" "own title rendered ($slug)"
+  else
+    fail "$slug has no title in frontmatter"
+  fi
+done
+if [ "$EXPECTED" -gt 0 ] && [ "$RENDERED" -eq "$EXPECTED" ]; then
+  pass "all $EXPECTED non-draft entries rendered"
+else
+  fail "rendered $RENDERED of $EXPECTED non-draft entries"
+fi
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## What

Adds an automated pre-publish render-check so the site can no longer deploy with broken/blank entry pages, and finalizes the release-checklist step.

`Closes #322`

## Why

The v1.3.4 `dataCutoff` injection bug shipped to production because nothing verified the site rendered before deploy. A frontmatter-corruption bug produces a page that **builds fine but renders blank** — the layout shell still renders, so a naive "did the file get generated" check passes. The gap is asserting each entry actually rendered *its own content*.

## How

### Automated (the gap #322 names)

CI already runs `npx nuxt generate` then `bash tests/e2e/build-verify.sh`. This PR extends `build-verify.sh` with a per-entry render check over **every non-draft entry** (currently 17). For each:

- the page exists at `entries/<slug>/index.html`;
- it is **substantive** (>= 20 KB; smallest real page is ~53 KB, a blank stub is bytes);
- it carries **no error boundary** (`__nuxt_error`) and no 404 body (`Page not found`);
- it renders its **own frontmatter title** — the load-bearing assertion. The page shell survives a frontmatter failure; the entry's own title does not, so a title match proves the frontmatter parsed and the body rendered.

Plus a count cross-check: rendered non-draft entries must equal the non-draft entries on disk — catches a **silently dropped entry** (the seg-16 draft-filtering class). CI failing any of this blocks the merge.

Notes on marker choice: bare `500` is **not** usable as an error signature (it appears in healthy pages, e.g. "500m" elevation); `404.html` itself contains the layout token "Corrèze", so generic shell markers can't distinguish a good page from an error page. Hence the per-entry **title** assertion.

### Process / checklist (#322 ↔ #521 ownership)

`docs/RELEASE-CHECKLIST.md` §5 already referenced #322 as the owner of the automated step (the #521 checklist shipped first, in #633). Updated that line: the automated render-check now runs in CI; the manual `nuxt generate` static preview (not SSR, per `feedback_production_preview`) becomes the recommended final human look for what CI can't judge (layout, imagery, prose). No new checklist authored — ownership resolved by sequencing.

`#617`'s draft pre-flight (shipped in #629) remains the first publish-time gate; this PR does not re-implement it.

## Verification / test plan

- `npx nuxt generate && bash tests/e2e/build-verify.sh` -> **90 passed, 0 failed**, all 17 non-draft entries covered.
- `bash -n tests/e2e/build-verify.sh` -> clean.
- **Red-green** (against a throwaway copy of the generated output; nothing committed, `.output` is gitignored):
  - stripped a page to a blank stub -> `min-size` and `own title` checks fire;
  - removed a non-draft entry dir -> "rendered 16 of 17" count check fires;
  - exit code 1 on any failure; real output passes with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
