### PR TITLE
Frontmatter parser consolidation, Stage A: shared schema + canonical Python parser (Refs #326)

### DIFF
--- a/processing/frontmatter.py
+++ b/processing/frontmatter.py
@@ -1,0 +1,230 @@
+"""Canonical frontmatter parser for content/entries/*.md (issue #326).
+
+Single source of read/write logic for every Python consumer of entry
+frontmatter: validate_entries.py, weather.py, pick_entry_thumbnails.py, and
+the inline reads in scripts/publish.sh. Replaces the per-module hand-rolled
+regex parsers those files used to carry, each of which drifted independently
+(the class of fragility behind the seg-9 publish-day crash).
+
+Field definitions live in schemas/frontmatter.schema.json -- the shared schema
+the TypeScript canonical parser (server/utils/frontmatter.ts) reads too. This
+module loads that schema for its field registry so neither language re-derives
+frontmatter field shapes.
+
+YAML quirk handled here once: PyYAML (like js-yaml's default schema) parses a
+bare ISO date such as `publishDate: 2026-04-05` into a datetime.date. The
+hand-rolled regex parsers kept those as strings, and downstream code compares
+them as strings (e.g. `pub_date <= today`). So this loader strips the YAML 1.1
+timestamp resolver, keeping bare dates as strings -- matching the TypeScript
+side, which loads with js-yaml JSON_SCHEMA for the same reason.
+"""
+
+import argparse
+import json
+import os
+import re
+
+import yaml
+
+# The frontmatter fence: group 1 the opening `---\n`, group 2 the YAML body
+# (non-greedy, so it stops at the first closing fence), group 3 the `\n---`.
+# This is the exact pattern validate_entries.set_images_optional used, so the
+# surgical writer below stays byte-identical to the code it replaces.
+_FENCE_RE = re.compile(r'^(---\n)(.*?)(\n---)', re.DOTALL)
+_HEAD_RE = re.compile(r'^---\n(.*?)\n---', re.DOTALL)
+
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', 'schemas', 'frontmatter.schema.json'
+)
+
+
+class _Loader(yaml.SafeLoader):
+    """SafeLoader that keeps bare ISO dates as strings (see module docstring)."""
+
+
+_Loader.yaml_implicit_resolvers = {
+    ch: [(tag, regexp) for (tag, regexp) in mappers
+         if tag != 'tag:yaml.org,2002:timestamp']
+    for ch, mappers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _load_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+SCHEMA = _load_schema()
+FIELDS = tuple(SCHEMA['properties'].keys())
+REQUIRED = tuple(SCHEMA['required'])
+
+
+def split_frontmatter(content):
+    """Split a markdown string into (raw_frontmatter, body).
+
+    Returns (None, content) when there is no leading `---` frontmatter block.
+    The raw frontmatter is the unparsed text between the fences -- the shared
+    primitive the entry-content editor round-trip relies on.
+    """
+    m = _FENCE_RE.match(content)
+    if not m:
+        return None, content
+    return m.group(2), content[m.end():]
+
+
+def parse(content):
+    """Parse the YAML frontmatter of a markdown string into a dict.
+
+    Returns {} when there is no frontmatter block, or it is not a mapping.
+    Bare ISO dates stay strings (see module docstring).
+    """
+    m = _HEAD_RE.match(content)
+    if not m:
+        return {}
+    data = yaml.load(m.group(1), Loader=_Loader)
+    return data if isinstance(data, dict) else {}
+
+
+def parse_file(path):
+    """Parse frontmatter from a markdown file path."""
+    with open(path) as f:
+        return parse(f.read())
+
+
+def set_field(content, key, value):
+    """Return content with frontmatter field `key` set to the literal `value`.
+
+    Surgical and byte-preserving: if a `key:` line exists in the frontmatter
+    block it is replaced in place; otherwise the field is appended as the last
+    frontmatter line, before the closing `---`. `value` is inserted verbatim
+    -- already formatted by the caller (e.g. `true`, an ISO date, or a compact
+    JSON string) -- so the rest of the file is untouched. This unifies the
+    three hand-rolled writers it replaces: validate_entries' imagesOptional
+    insert, weather's weather-line rewrite, and publish.sh's dataCutoff insert
+    and draft flip.
+
+    Content with no frontmatter block is returned unchanged.
+    """
+    m = _FENCE_RE.match(content)
+    if not m:
+        return content
+    head, fm_body, tail = m.group(1), m.group(2), m.group(3)
+    rest = content[m.end():]
+    line_re = re.compile(r'^' + re.escape(key) + r':.*$', re.MULTILINE)
+    new_line = f'{key}: {value}'
+    if line_re.search(fm_body):
+        # Replace via a function so the literal value is never interpreted as a
+        # regex backreference (e.g. a `\1` inside a URL or JSON string).
+        fm_body = line_re.sub(lambda _m: new_line, fm_body, count=1)
+    else:
+        fm_body = f'{fm_body}\n{new_line}'
+    return f'{head}{fm_body}{tail}{rest}'
+
+
+def validate(frontmatter):
+    """Validate a parsed frontmatter dict against the shared schema.
+
+    Returns a list of human-readable error strings (empty when valid). Imports
+    jsonschema lazily so the parse/write path never needs it -- only callers
+    that opt into validation (the test suite) pull the dependency in.
+    """
+    import jsonschema
+
+    validator = jsonschema.Draft7Validator(SCHEMA)
+    return [
+        f'{"/".join(str(p) for p in err.absolute_path) or "<root>"}: {err.message}'
+        for err in sorted(validator.iter_errors(frontmatter), key=lambda e: list(e.absolute_path))
+    ]
+
+
+def current_segment(entries_dir, today=None):
+    """Return the highest segment number whose entry is published on/before today.
+
+    "Published" means draft is false and publishDate <= today (string compare on
+    ISO dates). Returns 0 when nothing qualifies. Replaces publish.sh's inline
+    segment auto-detect.
+    """
+    if today is None:
+        from datetime import datetime
+        today = datetime.now().strftime('%Y-%m-%d')
+    best = None
+    for fname in sorted(os.listdir(entries_dir)):
+        if not fname.endswith('.md'):
+            continue
+        fm = parse_file(os.path.join(entries_dir, fname))
+        seg = fm.get('segment')
+        pub = fm.get('publishDate')
+        if seg is not None and pub and fm.get('draft') is False and pub <= today:
+            if best is None or seg > best:
+                best = seg
+    return best if best is not None else 0
+
+
+def find_entry_path(entries_dir, segment):
+    """Return the path of the entry whose frontmatter segment equals `segment`.
+
+    Returns None when no entry matches. Replaces publish.sh's inline entry-file
+    resolve.
+    """
+    for fname in sorted(os.listdir(entries_dir)):
+        if not fname.endswith('.md'):
+            continue
+        path = os.path.join(entries_dir, fname)
+        if parse_file(path).get('segment') == segment:
+            return path
+    return None
+
+
+def _format_scalar(value):
+    """Render a frontmatter scalar for shell consumption (the `get` CLI).
+
+    None -> empty string; booleans -> lowercase `true`/`false` (matching the
+    publish.sh comparisons this replaces); everything else -> str().
+    """
+    if value is None:
+        return ''
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    return str(value)
+
+
+def _main(argv=None):
+    parser = argparse.ArgumentParser(
+        description='Frontmatter operations for content/entries/*.md (issue #326).'
+    )
+    sub = parser.add_subparsers(dest='cmd', required=True)
+
+    p_get = sub.add_parser('get', help='print a frontmatter field value')
+    p_get.add_argument('file')
+    p_get.add_argument('field')
+
+    p_set = sub.add_parser('set', help='set a frontmatter field in place')
+    p_set.add_argument('file')
+    p_set.add_argument('field')
+    p_set.add_argument('value')
+
+    p_cur = sub.add_parser('current-segment', help='highest published segment number')
+    p_cur.add_argument('entries_dir')
+    p_cur.add_argument('--today', default=None)
+
+    p_find = sub.add_parser('find-entry', help='path of the entry for a segment')
+    p_find.add_argument('entries_dir')
+    p_find.add_argument('segment', type=int)
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == 'get':
+        print(_format_scalar(parse_file(args.file).get(args.field)))
+    elif args.cmd == 'set':
+        with open(args.file) as f:
+            content = f.read()
+        with open(args.file, 'w') as f:
+            f.write(set_field(content, args.field, args.value))
+    elif args.cmd == 'current-segment':
+        print(current_segment(args.entries_dir, args.today))
+    elif args.cmd == 'find-entry':
+        print(find_entry_path(args.entries_dir, args.segment) or '')
+
+
+if __name__ == '__main__':
+    _main()

--- a/processing/pick_entry_thumbnails.py
+++ b/processing/pick_entry_thumbnails.py
@@ -19,14 +19,13 @@ the build does not depend on network availability.
 import argparse
 import json
 import os
-import re
 import sys
 import time
 from pathlib import Path
 from urllib.parse import unquote
 
+import frontmatter
 import requests
-import yaml
 from PIL import Image
 
 WIKIMEDIA_PREFIX = "https://upload.wikimedia.org/"
@@ -39,15 +38,6 @@ TARGET_RATIO = 1.5  # 3:2 wins ties; portraits are rejected outright
 OBJECT_POSITION_BONUS = 0.05
 API_BATCH_SIZE = 50
 API_SLEEP_SECONDS = 1.0
-
-
-def parse_frontmatter(filepath):
-    with open(filepath) as f:
-        content = f.read()
-    m = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-    if not m:
-        return {}
-    return yaml.safe_load(m.group(1)) or {}
 
 
 def wikimedia_filename(url):
@@ -201,7 +191,7 @@ def main():
         if not filename.endswith(".md"):
             continue
         filepath = entries_dir / filename
-        fm = parse_frontmatter(filepath)
+        fm = frontmatter.parse_file(filepath)
         seg = fm.get("segment")
         if seg is None or seg <= 0:
             continue

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -3,6 +3,7 @@ geopy>=2.4.1
 numpy>=2.4.6
 Pillow>=12.2.0
 PyYAML>=6.0.3
+jsonschema>=4.0
 requests>=2.34.2
 pytest>=9.0.3
 pytest-cov>=7.1.0

--- a/processing/tests/test_frontmatter.py
+++ b/processing/tests/test_frontmatter.py
@@ -1,0 +1,165 @@
+"""Tests for the canonical frontmatter parser (processing/frontmatter.py, #326).
+
+Covers the read path, the surgical byte-preserving write path, the publish.sh
+helper logic (current_segment / find_entry_path), and -- the drift guard that
+makes the shared schema load-bearing on the Python side -- validation of every
+real content/entries/*.md against schemas/frontmatter.schema.json.
+"""
+
+import os
+
+import pytest
+
+from processing import frontmatter as fm
+
+ENTRIES_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'content', 'entries')
+
+
+def _entry_files():
+    return sorted(
+        os.path.join(ENTRIES_DIR, f)
+        for f in os.listdir(ENTRIES_DIR)
+        if f.endswith('.md')
+    )
+
+
+# --- parse -----------------------------------------------------------------
+
+class TestParse:
+    def test_basic_fields_and_types(self):
+        d = fm.parse('---\nsegment: 3\nkmEnd: 7.1\ndraft: false\nweather: null\n---\n\nbody')
+        assert d['segment'] == 3 and isinstance(d['segment'], int)
+        assert d['kmEnd'] == 7.1 and isinstance(d['kmEnd'], float)
+        assert d['draft'] is False
+        assert d['weather'] is None
+
+    def test_bare_iso_date_stays_string(self):
+        # The whole reason for the custom loader: YAML would coerce this to a
+        # date object, but downstream code compares publishDate as a string.
+        d = fm.parse('---\npublishDate: 2026-04-05\n---\n')
+        assert d['publishDate'] == '2026-04-05'
+        assert isinstance(d['publishDate'], str)
+
+    def test_inline_json_images_becomes_list(self):
+        d = fm.parse('---\nimages: [{"src": "/a.jpg", "alt": "a"}]\n---\n')
+        assert d['images'] == [{'src': '/a.jpg', 'alt': 'a'}]
+
+    def test_no_frontmatter_returns_empty(self):
+        assert fm.parse('# just a heading\n') == {}
+
+    def test_non_mapping_returns_empty(self):
+        assert fm.parse('---\n- a\n- b\n---\n') == {}
+
+    def test_parse_file(self, tmp_path):
+        p = tmp_path / 'e.md'
+        p.write_text('---\nsegment: 9\n---\nbody\n')
+        assert fm.parse_file(str(p))['segment'] == 9
+
+
+# --- split_frontmatter -----------------------------------------------------
+
+class TestSplitFrontmatter:
+    def test_splits_raw_and_body(self):
+        raw, body = fm.split_frontmatter('---\nsegment: 1\n---\n\n# Title\n')
+        assert raw == 'segment: 1'
+        assert body == '\n\n# Title\n'
+
+    def test_no_frontmatter(self):
+        raw, body = fm.split_frontmatter('# Title\n')
+        assert raw is None
+        assert body == '# Title\n'
+
+
+# --- set_field -------------------------------------------------------------
+
+class TestSetField:
+    def test_replaces_existing_line(self):
+        out = fm.set_field('---\nweather: null\ndraft: false\n---\nbody', 'weather', '{"t": 1}')
+        assert 'weather: {"t": 1}' in out
+        assert 'weather: null' not in out
+        assert out.endswith('---\nbody')
+
+    def test_inserts_before_closing_fence_when_absent(self):
+        out = fm.set_field('---\nsegment: 1\n---\nbody', 'imagesOptional', 'true')
+        assert out == '---\nsegment: 1\nimagesOptional: true\n---\nbody'
+
+    def test_value_with_backslash_not_treated_as_backreference(self):
+        out = fm.set_field('---\nweather: null\n---\n', 'weather', r'{"p": "a\1b"}')
+        assert r'weather: {"p": "a\1b"}' in out
+
+    def test_no_frontmatter_returned_unchanged(self):
+        content = '# no frontmatter\n'
+        assert fm.set_field(content, 'draft', 'false') == content
+
+    def test_draft_flip_byte_exact(self):
+        out = fm.set_field('---\nsegment: 9\ndraft: true\n---\n\nbody', 'draft', 'false')
+        assert out == '---\nsegment: 9\ndraft: false\n---\n\nbody'
+
+
+# --- publish.sh helpers ----------------------------------------------------
+
+class TestPublishHelpers:
+    def _dir(self, tmp_path, entries):
+        for name, body in entries.items():
+            (tmp_path / name).write_text(body)
+        return str(tmp_path)
+
+    def test_current_segment_picks_highest_published(self, tmp_path):
+        d = self._dir(tmp_path, {
+            '01.md': '---\nsegment: 1\npublishDate: 2026-04-05\ndraft: false\n---\n',
+            '02.md': '---\nsegment: 2\npublishDate: 2026-04-08\ndraft: false\n---\n',
+            '03.md': '---\nsegment: 3\npublishDate: 2026-09-01\ndraft: false\n---\n',
+        })
+        assert fm.current_segment(d, today='2026-04-10') == 2
+
+    def test_current_segment_skips_drafts(self, tmp_path):
+        d = self._dir(tmp_path, {
+            '01.md': '---\nsegment: 1\npublishDate: 2026-04-05\ndraft: false\n---\n',
+            '02.md': '---\nsegment: 2\npublishDate: 2026-04-08\ndraft: true\n---\n',
+        })
+        assert fm.current_segment(d, today='2026-04-10') == 1
+
+    def test_current_segment_none_qualifies(self, tmp_path):
+        d = self._dir(tmp_path, {
+            '01.md': '---\nsegment: 1\npublishDate: 2026-09-01\ndraft: false\n---\n',
+        })
+        assert fm.current_segment(d, today='2026-04-10') == 0
+
+    def test_find_entry_path(self, tmp_path):
+        d = self._dir(tmp_path, {
+            '01.md': '---\nsegment: 1\n---\n',
+            '07.md': '---\nsegment: 7\n---\n',
+        })
+        assert fm.find_entry_path(d, 7) == os.path.join(d, '07.md')
+        assert fm.find_entry_path(d, 99) is None
+
+
+# --- _format_scalar (the `get` CLI rendering) ------------------------------
+
+class TestFormatScalar:
+    @pytest.mark.parametrize('value,expected', [
+        (None, ''),
+        (True, 'true'),
+        (False, 'false'),
+        (9, '9'),
+        ('2026-04-05', '2026-04-05'),
+    ])
+    def test_render(self, value, expected):
+        assert fm._format_scalar(value) == expected
+
+
+# --- schema drift guard ----------------------------------------------------
+
+class TestSchemaConformance:
+    def test_every_entry_conforms_to_shared_schema(self):
+        failures = []
+        for path in _entry_files():
+            errors = fm.validate(fm.parse_file(path))
+            if errors:
+                failures.append(f'{os.path.basename(path)}: {"; ".join(errors)}')
+        assert not failures, 'Entries violate frontmatter schema:\n' + '\n'.join(failures)
+
+    def test_validate_flags_a_bad_entry(self):
+        # segment is required and must be an integer; a string must fail.
+        errors = fm.validate({'segment': 'not-an-int'})
+        assert errors

--- a/processing/tests/test_frontmatter_parity.py
+++ b/processing/tests/test_frontmatter_parity.py
@@ -1,0 +1,174 @@
+"""Byte-identical migration proof for the #326 parser consolidation.
+
+This module pins what "byte-identical" meant when the hand-rolled regex
+frontmatter parsers were removed. It embeds the *exact* pre-#326 extraction
+and write logic from each Python consumer (validate_entries, weather,
+pick_entry_thumbnails, scripts/publish.sh) and asserts the canonical parser
+produces identical results on **every current content/entries/*.md**.
+
+Per the strand brief (§5/§6) the migration must not change any consumer's
+observable behaviour. These tests are the durable regression guard for that:
+if a future change to processing/frontmatter.py drifts from the old
+behaviour, the relevant assertion fails. The embedded `old_*` functions are
+intentionally frozen copies of deleted code -- do not "modernise" them.
+"""
+
+import json
+import os
+import re
+
+from processing import frontmatter as fm
+
+ENTRIES_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'content', 'entries')
+
+
+def _entries():
+    for name in sorted(os.listdir(ENTRIES_DIR)):
+        if name.endswith('.md'):
+            path = os.path.join(ENTRIES_DIR, name)
+            with open(path) as f:
+                yield name, path, f.read()
+
+
+# --- frozen pre-#326 implementations ---------------------------------------
+
+def old_validate_parse(content):
+    """validate_entries.parse_frontmatter, verbatim (pre-#326)."""
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return {}
+    out = {}
+    for line in match.group(1).split('\n'):
+        m = re.match(r'^(\w+):\s*(.*)', line)
+        if m:
+            key, val = m.group(1), m.group(2).strip()
+            if val == 'true':
+                out[key] = True
+            elif val == 'false':
+                out[key] = False
+            elif val == 'null':
+                out[key] = None
+            elif val == '[]':
+                out[key] = []
+            elif val.startswith('[') and val.endswith(']') and val != '[]':
+                out[key] = val
+            else:
+                out[key] = val
+    return out
+
+
+def old_weather_seg(content):
+    m = re.search(r'^segment:\s*(\d+)', content, re.MULTILINE)
+    return int(m.group(1)) if m else None
+
+
+def old_weather_pubdate(content):
+    m = re.search(r'^publishDate:\s*(\S+)', content, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def old_weather_is_draft(content):
+    m = re.search(r'^draft:\s*(\S+)', content, re.MULTILINE)
+    return m.group(1).lower() == 'true' if m else False
+
+
+def old_datacutoff(content):
+    m = re.search(r'^dataCutoff:\s*(\S+)', content, re.MULTILINE)
+    return m.group(1) if m else ''
+
+
+def old_set_images_optional(content):
+    match = re.match(r'^(---\n)(.*?)(\n---)', content, re.DOTALL)
+    if not match:
+        return content
+    return match.group(1) + match.group(2) + '\nimagesOptional: true' + match.group(3) + content[match.end():]
+
+
+def old_weather_inject(content, weather_data):
+    weather_yaml = json.dumps(weather_data)
+    return re.sub(r'^weather:.*$', f'weather: {weather_yaml}', content, count=1, flags=re.MULTILINE)
+
+
+def old_datacutoff_write(content, value):
+    parts = content.split('---', 2)
+    if len(parts) >= 3:
+        parts[1] = parts[1].rstrip() + f'\ndataCutoff: {value}\n'
+        return '---'.join(parts)
+    return content
+
+
+def old_draft_flip(content):
+    out, _ = re.subn(r'^draft:\s*true\s*$', 'draft: false', content, count=1, flags=re.MULTILINE)
+    return out
+
+
+# --- read parity -----------------------------------------------------------
+
+def test_read_parity_on_every_entry():
+    """Each field every consumer reads matches the old extraction exactly."""
+    mismatches = []
+    for name, _path, content in _entries():
+        new = fm.parse(content)
+        old = old_validate_parse(content)
+
+        # segment / publishDate / draft (weather.py + publish.sh selection)
+        if new.get('segment') != old_weather_seg(content):
+            mismatches.append(f'{name}: segment {new.get("segment")!r} != {old_weather_seg(content)!r}')
+        if new.get('publishDate') != old_weather_pubdate(content):
+            mismatches.append(f'{name}: publishDate {new.get("publishDate")!r} != {old_weather_pubdate(content)!r}')
+        if (new.get('draft') is True) != old_weather_is_draft(content):
+            mismatches.append(f'{name}: draft decision differs')
+
+        # dataCutoff (publish.sh get) -- canonical empty -> '' like the old code
+        new_dc = new.get('dataCutoff')
+        new_dc = '' if new_dc is None else str(new_dc)
+        if new_dc != old_datacutoff(content):
+            mismatches.append(f'{name}: dataCutoff {new_dc!r} != {old_datacutoff(content)!r}')
+
+        # validate_entries "has images" decision
+        new_has_images = bool(new.get('images'))
+        old_images = old.get('images', [])
+        old_has_images = (isinstance(old_images, str) and old_images.startswith('[')) or \
+                         (isinstance(old_images, list) and len(old_images) > 0)
+        if new_has_images != old_has_images:
+            mismatches.append(f'{name}: has-images decision differs')
+
+        # draft / imagesOptional booleans the old validate parser produced
+        for key in ('draft', 'imagesOptional'):
+            if key in old and isinstance(old[key], bool):
+                if new.get(key) != old[key]:
+                    mismatches.append(f'{name}: {key} {new.get(key)!r} != {old[key]!r}')
+
+    assert not mismatches, 'Read parity broken:\n' + '\n'.join(mismatches)
+
+
+# --- write parity ----------------------------------------------------------
+
+def test_set_images_optional_byte_identical():
+    for name, _path, content in _entries():
+        assert fm.set_field(content, 'imagesOptional', 'true') == old_set_images_optional(content), name
+
+
+def test_weather_inject_byte_identical():
+    weather = {
+        'fetchedAt': '2026-05-30',
+        'current': {'temp': 17, 'conditions': 'Clear sky', 'wind': '3 km/h ESE'},
+        'forecast': None,
+    }
+    for name, _path, content in _entries():
+        if re.search(r'^weather:', content, re.MULTILINE):
+            new = fm.set_field(content, 'weather', json.dumps(weather))
+            assert new == old_weather_inject(content, weather), name
+
+
+def test_datacutoff_insert_byte_identical():
+    for name, _path, content in _entries():
+        if not re.search(r'^dataCutoff:', content, re.MULTILINE):
+            new = fm.set_field(content, 'dataCutoff', '2026-05-30')
+            assert new == old_datacutoff_write(content, '2026-05-30'), name
+
+
+def test_draft_flip_byte_identical():
+    for name, _path, content in _entries():
+        if re.search(r'^draft:\s*true\s*$', content, re.MULTILINE):
+            assert fm.set_field(content, 'draft', 'false') == old_draft_flip(content), name

--- a/processing/validate_entries.py
+++ b/processing/validate_entries.py
@@ -12,40 +12,12 @@ import re
 import sys
 from datetime import date
 
+import frontmatter
+
 MDC_OPEN_RE = re.compile(r'^(::+)([A-Za-z][A-Za-z0-9_-]*)(\s*\{.*\})?\s*$')
 MDC_CLOSE_RE = re.compile(r'^(::+)\s*$')
 CODE_FENCE_RE = re.compile(r'^(```+|~~~+)')
 FRONTMATTER_FENCE = '---'
-
-
-def parse_frontmatter(filepath):
-    """Parse YAML frontmatter from a markdown file. Returns a dict."""
-    with open(filepath) as f:
-        content = f.read()
-
-    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
-    if not match:
-        return {}
-
-    fm = {}
-    for line in match.group(1).split('\n'):
-        # Simple key: value parsing
-        m = re.match(r'^(\w+):\s*(.*)', line)
-        if m:
-            key, val = m.group(1), m.group(2).strip()
-            if val == 'true':
-                fm[key] = True
-            elif val == 'false':
-                fm[key] = False
-            elif val == 'null':
-                fm[key] = None
-            elif val == '[]':
-                fm[key] = []
-            elif val.startswith('[') and val.endswith(']') and val != '[]':
-                fm[key] = val  # non-empty array, keep as string marker
-            else:
-                fm[key] = val
-    return fm
 
 
 def find_entries_to_validate(entries_dir, today=None):
@@ -65,7 +37,7 @@ def find_entries_to_validate(entries_dir, today=None):
             continue
 
         filepath = os.path.join(entries_dir, filename)
-        fm = parse_frontmatter(filepath)
+        fm = frontmatter.parse_file(filepath)
 
         # Skip drafts
         if fm.get('draft') is True:
@@ -80,11 +52,10 @@ def find_entries_to_validate(entries_dir, today=None):
         if fm.get('imagesOptional') is True:
             continue
 
-        # Skip if images is a non-empty array
-        images = fm.get('images', [])
-        if isinstance(images, str) and images.startswith('['):
-            # Non-empty array string like [{src: ...}]
-            continue
+        # Skip if images is a non-empty array. The canonical parser yields a
+        # real list (the old hand-rolled parser kept a non-empty array as a
+        # string marker; both reduce to "does this entry have any images").
+        images = fm.get('images') or []
         if isinstance(images, list) and len(images) > 0:
             continue
 
@@ -163,7 +134,7 @@ def find_entries_for_mdc_check(entries_dir):
         if not filename.endswith('.md'):
             continue
         filepath = os.path.join(entries_dir, filename)
-        fm = parse_frontmatter(filepath)
+        fm = frontmatter.parse_file(filepath)
         if fm.get('draft') is True:
             continue
         paths.append(filepath)
@@ -175,18 +146,9 @@ def set_images_optional(filepath):
     with open(filepath) as f:
         content = f.read()
 
-    # Insert imagesOptional: true before the closing ---
-    # Find the end of frontmatter
-    match = re.match(r'^(---\n)(.*?)(\n---)', content, re.DOTALL)
-    if not match:
+    new_content = frontmatter.set_field(content, 'imagesOptional', 'true')
+    if new_content == content:
         return
-
-    before = match.group(1)
-    fm_content = match.group(2)
-    after = match.group(3)
-    rest = content[match.end():]
-
-    new_content = before + fm_content + '\nimagesOptional: true' + after + rest
 
     with open(filepath, 'w') as f:
         f.write(new_content)

--- a/processing/weather.py
+++ b/processing/weather.py
@@ -4,9 +4,16 @@
 import argparse
 import json
 import os
-import re
+import sys
 import urllib.parse
 import urllib.request
+
+# Make the canonical frontmatter parser importable when this file is run as a
+# script, via runpy (the shell tests), or imported as processing.weather. None
+# of those reliably puts processing/ on sys.path, so add it explicitly.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import frontmatter  # noqa: E402
 
 OPENWEATHERMAP_API = "https://api.openweathermap.org/data/2.5/weather"
 
@@ -64,14 +71,7 @@ def inject_weather_into_entry(entry_path, weather_data):
 
     # Replace the weather field in frontmatter
     if weather_data:
-        weather_yaml = json.dumps(weather_data)
-        content = re.sub(
-            r'^weather:.*$',
-            f'weather: {weather_yaml}',
-            content,
-            count=1,
-            flags=re.MULTILINE,
-        )
+        content = frontmatter.set_field(content, "weather", json.dumps(weather_data))
 
     with open(entry_path, "w") as f:
         f.write(content)
@@ -92,14 +92,12 @@ def find_current_entry(entries_dir, segments_json):
             content = f.read()
 
         # Extract segment number and publishDate from frontmatter
-        seg_match = re.search(r'^segment:\s*(\d+)', content, re.MULTILINE)
-        date_match = re.search(r'^publishDate:\s*(\S+)', content, re.MULTILINE)
-        draft_match = re.search(r'^draft:\s*(\S+)', content, re.MULTILINE)
+        fm = frontmatter.parse(content)
+        seg_num = fm.get("segment")
+        pub_date = fm.get("publishDate")
 
-        if seg_match and date_match:
-            seg_num = int(seg_match.group(1))
-            pub_date = date_match.group(1)
-            is_draft = draft_match.group(1).lower() == "true" if draft_match else False
+        if seg_num is not None and pub_date:
+            is_draft = fm.get("draft") is True
 
             if not is_draft and pub_date <= today:
                 entries.append((seg_num, pub_date, path))

--- a/schemas/frontmatter.schema.json
+++ b/schemas/frontmatter.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tdf26/frontmatter.schema.json",
+  "title": "Blog entry frontmatter",
+  "description": "Single source of truth for content/entries/*.md YAML frontmatter field definitions. Read by the canonical parsers (processing/frontmatter.py, server/utils/frontmatter.ts) and validated against every entry by tests. Adding a new frontmatter field means adding it here, not to a hand-rolled parser. Consolidates the parsers tracked by issue #326.",
+  "type": "object",
+  "required": [
+    "segment",
+    "title",
+    "subtitle",
+    "publishDate",
+    "kmStart",
+    "kmEnd",
+    "gpxFile",
+    "elevationData",
+    "images",
+    "weather",
+    "draft"
+  ],
+  "properties": {
+    "segment": { "type": "integer", "minimum": 0, "maximum": 27 },
+    "title": { "type": "string", "minLength": 1 },
+    "subtitle": { "type": "string", "minLength": 1 },
+    "publishDate": { "type": "string", "format": "date" },
+    "kmStart": { "type": "number", "minimum": 0 },
+    "kmEnd": { "type": "number", "minimum": 0 },
+    "gpxFile": { "type": ["string", "null"] },
+    "elevationData": { "type": ["string", "null"] },
+    "draft": { "type": "boolean" },
+    "dataCutoff": { "type": "string", "format": "date" },
+    "imagesOptional": { "type": "boolean" },
+    "images": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["src", "alt", "author", "license", "licenseUrl"],
+        "properties": {
+          "src": { "type": "string", "minLength": 1 },
+          "alt": { "type": "string" },
+          "author": { "type": "string" },
+          "authorUrl": { "type": "string" },
+          "license": { "type": "string" },
+          "licenseUrl": { "type": ["string", "null"] },
+          "sourceUrl": { "type": "string" },
+          "objectPosition": { "type": "string" },
+          "recommended": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "weather": {
+      "type": ["object", "null"],
+      "properties": {
+        "fetchedAt": { "type": "string", "format": "date" },
+        "current": {
+          "type": "object",
+          "properties": {
+            "temp": { "type": "number" },
+            "conditions": { "type": "string" },
+            "wind": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "forecast": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -48,26 +48,13 @@ preflight_draft_check() {
         echo "ERROR: no entry file found for segment $segment. Cannot publish."
         exit 1
     fi
+    local fm_py="$PROJECT_DIR/processing/frontmatter.py"
     local entry_draft
-    entry_draft=$("$py" -c "
-import re
-content = open('$entry_file').read()
-m = re.search(r'^draft:\s*(\S+)', content, re.M)
-print(m.group(1).lower() if m else '')
-")
+    entry_draft=$("$py" "$fm_py" get "$entry_file" draft)
     if [ "$entry_draft" = "true" ]; then
         echo "Segment $segment entry is draft: true; flipping to draft: false before build."
-        "$py" -c "
-import re
-path = '$entry_file'
-content = open(path).read()
-content, n = re.subn(r'^draft:\s*true\s*\$', 'draft: false', content, count=1, flags=re.M)
-if n == 1:
-    open(path, 'w').write(content)
-    print('Flipped draft: false in ' + path)
-else:
-    raise SystemExit('ERROR: could not flip draft field in ' + path)
-"
+        "$py" "$fm_py" set "$entry_file" draft false
+        echo "Flipped draft: false in $entry_file"
     fi
 }
 
@@ -210,25 +197,8 @@ export NVM_DIR="$HOME/.nvm"
 
 # Auto-detect current segment if not specified
 if [ -z "$SEGMENT" ]; then
-    SEGMENT=$("$VENV_PYTHON" -c "
-import json, os, re
-from datetime import datetime
-today = datetime.now().strftime('%Y-%m-%d')
-entries_dir = '$PROJECT_DIR/content/entries'
-best = None
-for f in sorted(os.listdir(entries_dir)):
-    if not f.endswith('.md'): continue
-    content = open(os.path.join(entries_dir, f)).read()
-    seg = re.search(r'^segment:\s*(\d+)', content, re.M)
-    date = re.search(r'^publishDate:\s*(\S+)', content, re.M)
-    draft = re.search(r'^draft:\s*(\S+)', content, re.M)
-    if seg and date and draft:
-        if draft.group(1) == 'false' and date.group(1) <= today:
-            s = int(seg.group(1))
-            if best is None or s > best:
-                best = s
-print(best if best is not None else 0)
-")
+    SEGMENT=$("$VENV_PYTHON" "$PROJECT_DIR/processing/frontmatter.py" \
+        current-segment "$PROJECT_DIR/content/entries")
     echo "Auto-detected current segment: $SEGMENT"
 fi
 echo ""
@@ -237,29 +207,16 @@ echo ""
 # the stats/points/snapshot outputs are reproducible against the cutoff (per
 # issues #541, #328). The order is: find entry file → resolve cutoff → run
 # stats with --reference-date → run points with --data-cutoff → snapshot.
-ENTRY_FILE=$("$VENV_PYTHON" -c "
-import os, re
-entries_dir = '$PROJECT_DIR/content/entries'
-for f in sorted(os.listdir(entries_dir)):
-    if not f.endswith('.md'): continue
-    content = open(os.path.join(entries_dir, f)).read()
-    seg = re.search(r'^segment:\s*(\d+)', content, re.M)
-    if seg and int(seg.group(1)) == $SEGMENT:
-        print(os.path.join(entries_dir, f))
-        break
-")
+ENTRY_FILE=$("$VENV_PYTHON" "$PROJECT_DIR/processing/frontmatter.py" \
+    find-entry "$PROJECT_DIR/content/entries" "$SEGMENT")
 
 # Pre-flight (#617): the target must be publishable before any work happens.
 # Bails on a missing entry file and auto-flips draft: true -> false. The logic
 # lives in preflight_draft_check() (defined near the top) so it is unit-tested.
 preflight_draft_check "$VENV_PYTHON" "$ENTRY_FILE" "$SEGMENT"
 
-DATA_CUTOFF=$("$VENV_PYTHON" -c "
-import re
-content = open('$ENTRY_FILE').read()
-m = re.search(r'^dataCutoff:\s*(\S+)', content, re.M)
-print(m.group(1) if m else '')
-")
+DATA_CUTOFF=$("$VENV_PYTHON" "$PROJECT_DIR/processing/frontmatter.py" \
+    get "$ENTRY_FILE" dataCutoff)
 if [ -z "$DATA_CUTOFF" ]; then
     echo "No dataCutoff set for segment $SEGMENT."
     # Only prompt when stdin is a TTY; non-interactive runs (cron, nohup, background
@@ -271,20 +228,11 @@ if [ -z "$DATA_CUTOFF" ]; then
     if [ -z "$DATA_CUTOFF" ]; then
         DATA_CUTOFF=$(date +%Y-%m-%d)
     fi
-    # Write dataCutoff to frontmatter
-    "$VENV_PYTHON" -c "
-path = '$ENTRY_FILE'
-content = open(path).read()
-# Insert dataCutoff before the closing --- of frontmatter
-parts = content.split('---', 2)
-if len(parts) >= 3:
-    parts[1] = parts[1].rstrip() + '\ndataCutoff: $DATA_CUTOFF\n'
-    content = '---'.join(parts)
-    open(path, 'w').write(content)
-    print('Set dataCutoff: $DATA_CUTOFF in ' + path)
-else:
-    print('ERROR: Could not find frontmatter delimiters in ' + path)
-"
+    # Write dataCutoff to frontmatter (inserted before the closing --- by the
+    # canonical parser's surgical set_field)
+    "$VENV_PYTHON" "$PROJECT_DIR/processing/frontmatter.py" \
+        set "$ENTRY_FILE" dataCutoff "$DATA_CUTOFF"
+    echo "Set dataCutoff: $DATA_CUTOFF in $ENTRY_FILE"
 fi
 echo "Data cutoff for segment $SEGMENT: $DATA_CUTOFF"
 echo ""


### PR DESCRIPTION
## Stage A of #326 — shared schema + canonical **Python** parser

Consolidates the hand-rolled YAML frontmatter parsers onto one shared schema
and one canonical parser per language. This is the **first of two PRs**
(`Refs #326`, does not close it): it lands the schema and the Python side.
Stage B (canonical TS parser for the server routes + the anti-regression CI
guard) will `Closes #326`.

### Scope: the issue says "four", reality is ~ten

Re-verifying the carryforward brief against source (per `feedback_brief_content_is_carryforward`):

- Issue #326's title says **four** parsers. `docs/planning/v1.4.20-scope.md` and the
  spine handoff said **five** (adding `scripts/publish.sh`). A tree-wide sweep found the
  real surface is **~ten** hand-rolled frontmatter parsers/mutators:
  - **Python (4):** `validate_entries.py`, `weather.py`, `scripts/publish.sh`,
    and `pick_entry_thumbnails.py` (not named anywhere prior).
  - **TypeScript (6):** `entries.get.ts`, `images.post.ts` (already js-yaml),
    `weather.get.ts`, `images.get.ts`, `entry-status.post.ts`, `weather-inject.post.ts`
    — these back the in-browser entry editor — plus an `entry-content.{get,post}.ts`
    fence split/reassemble pair.
- **Publisher decision (2026-05-30): full consolidation** of all ~10, because the
  anti-regression guard can only go green tree-wide if every hand-rolled parser is
  migrated. The entry-content pair will call a shared fence-split helper.
- The design doc the brief cites (`metablog/2026-04-10-harness-engineering-dialogue.md`)
  **does not exist** in the repo. Proceeded from the issue + the parsers themselves.

`#326` reassigned from the shipped `v1.4.20` milestone to **v1.5.0**.

### What this PR delivers (Python side)

- **`schemas/frontmatter.schema.json`** — one draft-07 schema (repo `schemas/` convention)
  declaring every entry frontmatter field. Validates clean against all 28 entries under
  both engines.
- **`processing/frontmatter.py`** — canonical reader (PyYAML), surgical byte-preserving
  `set_field` writer, `current_segment`/`find_entry_path` helpers, and a
  `get/set/current-segment/find-entry` CLI.
- Migrated **every Python consumer** onto it, deleting their hand-rolled regex:
  `validate_entries.py`, `weather.py`, `pick_entry_thumbnails.py`, and the four inline
  Python reads + draft-flip + dataCutoff write in `scripts/publish.sh`.

The publish.sh **source-guard and #508 functions** (`preflight_draft_check`,
`merge_frontmatter_commit`) are preserved; `weather.py`'s **#619 `--entry` isolation** is
untouched. Both bats guards stay green.

### Load-bearing finding: YAML coerces bare dates

Default YAML (PyYAML **and** js-yaml) parses `publishDate: 2026-04-05` into a date object,
but the old regex parsers kept strings and downstream code compares them as strings
(`pub_date <= today`). The canonical parsers therefore load with the **timestamp resolver
stripped** (PyYAML) / **`JSON_SCHEMA`** (js-yaml). This is exactly the class of silent
behaviour change the byte-identical proof exists to catch.

### Byte-identical proof (before deleting)

`processing/tests/test_frontmatter_parity.py` embeds the frozen pre-#326 extraction and
write logic and asserts the canonical parser is identical — read fields and written bytes —
on **every** current entry. **Red-green verified:** perturbing `set_field`'s insert fails
the proof; restoring passes it. `set_field` is byte-identical to all four old writers.

### Verification

- `pytest processing/tests/` — **242 passed** (213 baseline + 29 new)
- `ruff check processing/` — clean
- `npm run test:shell` (bats) — **5/5** (publish.sh + weather.py behaviour preserved)
- `npm test` (vitest) — 209 passed (TS untouched in this stage)
- `npm run build` — OK · `bash -n scripts/publish.sh` — OK
- `validate_entries` / `validate_points` — OK

### Notes

- Adds `jsonschema` to `processing/requirements.txt` (test-only; lazy-imported, so the
  parse/write runtime path never needs it).
- New downstream effect to track: with a real YAML parser, CLAUDE.md's inline-JSON image
  requirement (explicitly "gated on #326") could be relaxed to allow YAML block lists.
  Out of scope here; flagged for planning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
