### PR TITLE
Route-geometry corrections: climb summit-km, gradient, KOM-line exemption, segments.json regen

### DIFF
--- a/data/competition/points-config.json
+++ b/data/competition/points-config.json
@@ -61,7 +61,8 @@
       "category": 4,
       "gradient": 3.2,
       "points": [2, 1, 0, 0],
-      "aso": false
+      "aso": false,
+      "summit_is_kom_line": true
     },
     {
       "name": "Côte de Miel",
@@ -91,7 +92,8 @@
       "category": 2,
       "gradient": 3.2,
       "points": [6, 4, 2, 1],
-      "aso": false
+      "aso": false,
+      "summit_is_kom_line": true
     },
     {
       "name": "Suc au May",
@@ -106,10 +108,10 @@
     {
       "name": "Côte de la Croix de Pey",
       "segment": 19,
-      "km": 128.99,
+      "km": 129.54,
       "length_km": 7,
       "category": 3,
-      "gradient": 4.4,
+      "gradient": 4.9,
       "points": [4, 3, 2, 1],
       "aso": true
     },
@@ -126,7 +128,7 @@
     {
       "name": "Côte des Gardes",
       "segment": 25,
-      "km": 170.98,
+      "km": 170.73,
       "length_km": 2.2,
       "category": 3,
       "gradient": 4.3,

--- a/data/segments.json
+++ b/data/segments.json
@@ -15,6 +15,9 @@
     "towns": [
       "Malemort"
     ],
+    "town_positions": {
+      "Malemort": 0.0
+    },
     "climbs": [
       "Côte de Malemort"
     ]
@@ -35,6 +38,9 @@
     "towns": [
       "Turenne"
     ],
+    "town_positions": {
+      "Turenne": 11.85
+    },
     "climbs": []
   },
   {
@@ -54,6 +60,10 @@
       "Ligneyrac",
       "Collonges-la-Rouge"
     ],
+    "town_positions": {
+      "Ligneyrac": 17.49,
+      "Collonges-la-Rouge": 21.79
+    },
     "climbs": []
   },
   {
@@ -72,6 +82,9 @@
     "towns": [
       "Meyssac"
     ],
+    "town_positions": {
+      "Meyssac": 23.57
+    },
     "climbs": [
       "Puy Boubou"
     ]
@@ -90,6 +103,7 @@
     "max_elevation": 404,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": [
       "Puy Boubou"
     ]
@@ -110,6 +124,9 @@
     "towns": [
       "Lanteuil"
     ],
+    "town_positions": {
+      "Lanteuil": 37.93
+    },
     "climbs": [
       "Côte de Lagleygeolle"
     ]
@@ -130,6 +147,9 @@
     "towns": [
       "Beynat"
     ],
+    "town_positions": {
+      "Beynat": 46.22
+    },
     "climbs": [
       "Côte de Lagleygeolle"
     ]
@@ -148,6 +168,7 @@
     "max_elevation": 568,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": [
       "Côte de Miel"
     ]
@@ -168,6 +189,9 @@
     "towns": [
       "Sainte-Fortunade"
     ],
+    "town_positions": {
+      "Sainte-Fortunade": 60.0
+    },
     "climbs": [
       "Côte de Miel"
     ]
@@ -188,6 +212,9 @@
     "towns": [
       "Tulle"
     ],
+    "town_positions": {
+      "Tulle": 68.69
+    },
     "climbs": []
   },
   {
@@ -204,6 +231,7 @@
     "max_elevation": 424,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": [
       "Côte de Naves"
     ]
@@ -224,6 +252,9 @@
     "towns": [
       "Naves"
     ],
+    "town_positions": {
+      "Naves": 78.17
+    },
     "climbs": [
       "Puy de Lachaud"
     ]
@@ -242,6 +273,7 @@
     "max_elevation": 532,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": [
       "Puy de Lachaud"
     ]
@@ -262,6 +294,9 @@
     "towns": [
       "Saint-Augustin"
     ],
+    "town_positions": {
+      "Saint-Augustin": 94.52
+    },
     "climbs": []
   },
   {
@@ -280,6 +315,9 @@
     "towns": [
       "Chaumeil"
     ],
+    "town_positions": {
+      "Chaumeil": 100.27
+    },
     "climbs": [
       "Suc au May"
     ]
@@ -298,6 +336,7 @@
     "max_elevation": 853,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": []
   },
   {
@@ -316,6 +355,9 @@
     "towns": [
       "Madranges"
     ],
+    "town_positions": {
+      "Madranges": 113.5
+    },
     "climbs": []
   },
   {
@@ -334,6 +376,9 @@
     "towns": [
       "Treignac"
     ],
+    "town_positions": {
+      "Treignac": 121.92
+    },
     "climbs": [
       "Côte de la Croix de Pey"
     ]
@@ -354,6 +399,9 @@
     "towns": [
       "Lestards"
     ],
+    "town_positions": {
+      "Lestards": 130.52
+    },
     "climbs": [
       "Côte de la Croix de Pey"
     ]
@@ -372,6 +420,7 @@
     "max_elevation": 827,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": []
   },
   {
@@ -390,6 +439,9 @@
     "towns": [
       "Bugeat"
     ],
+    "town_positions": {
+      "Bugeat": 143.65
+    },
     "climbs": [
       "Mont Bessou"
     ]
@@ -408,6 +460,7 @@
     "max_elevation": 892,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": [
       "Mont Bessou"
     ]
@@ -426,6 +479,7 @@
     "max_elevation": 973,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": []
   },
   {
@@ -442,6 +496,7 @@
     "max_elevation": 940,
     "notable_points": [],
     "towns": [],
+    "town_positions": {},
     "climbs": []
   },
   {
@@ -460,6 +515,9 @@
     "towns": [
       "Meymac"
     ],
+    "town_positions": {
+      "Meymac": 168.1
+    },
     "climbs": [
       "Côte des Gardes"
     ]
@@ -480,6 +538,9 @@
     "towns": [
       "Saint-Angel"
     ],
+    "town_positions": {
+      "Saint-Angel": 176.53
+    },
     "climbs": []
   },
   {
@@ -498,6 +559,9 @@
     "towns": [
       "Ussel"
     ],
+    "town_positions": {
+      "Ussel": 184.84
+    },
     "climbs": []
   }
 ]

--- a/processing/split_gpx.py
+++ b/processing/split_gpx.py
@@ -243,15 +243,23 @@ def split_into_segments(
         )
 
         # Find towns in this segment via route-proximity (#341).
-        # Half-open [km_start, km_end) so a town landing exactly on a boundary
-        # only appears once.
+        # Half-open [km_start, km_end) so a town landing exactly on an interior
+        # boundary only appears once. The final segment's interval is closed at
+        # both ends (#639): Ussel's closest-approach km sits at the route's
+        # total km (km_end), which the half-open rule would otherwise drop. The
+        # inclusive end is restricted to the last segment so interior boundaries
+        # keep their dedup, and the lower bound (km_start) is still enforced so
+        # the final segment only claims towns within its own span. (The
+        # proximity km is rounded to 2dp and can land just past the unrounded
+        # km_end, so the upper comparison uses a small epsilon.)
+        is_last_segment = seg_num == actual_segments
         towns = []
         town_positions = {}
         for name, prox in town_proximity.items():
             if prox["distance_m"] > town_max_distance_m:
                 continue
             km = prox["km"]
-            if km_start <= km < km_end:
+            if km_start <= km < km_end or (is_last_segment and km_start <= km <= km_end + 0.01):
                 towns.append(name)
                 town_positions[name] = km
 

--- a/tests/utils/climb-summit-km.test.ts
+++ b/tests/utils/climb-summit-km.test.ts
@@ -37,22 +37,26 @@ interface Climb {
   km: number
   length_km: number | null
   gradient: number
+  summit_is_kom_line?: boolean
 }
 
 const TOLERANCE_KM = 0.35
 const TOLERANCE_M = 10
 const UPPER_PAD_KM = 1.5
 
-// Climbs whose declared summit km is known to drift from the GPX argmax.
-// Each maps to the follow-up issue tracking the data fix. The assertion
-// is asserted-but-skipped for these; remove from the map when the data
-// fix lands (see PR that closes the referenced issue).
-const KNOWN_FAILING: Record<string, number> = {
-  'Côte de Lagleygeolle': 589,
-  'Puy de Lachaud': 590,
-  'Côte de la Croix de Pey': 591,
-}
-
+// Permanent by-design exemption: a climb flagged `summit_is_kom_line` declares
+// its summit km as a scoring / KOM line that is intentionally placed below the
+// GPX elevation peak (an ASO-style categorised summit on a continuously rising
+// flank, where the road keeps climbing — uncounted — past the points line).
+// For such climbs the declared km is NOT meant to be the argmax, so this
+// placement assertion does not apply. This replaces the former ad-hoc
+// KNOWN_FAILING skip-list (#589 Côte de Lagleygeolle, #590 Puy de Lachaud):
+// those were never data bugs to be "fixed" — the published entries
+// 07-road-through-beynat.md and 13-puy-de-lachaud-uncounted.md deliberately
+// anchor the scored summit below the true crest. The flag is the typed,
+// self-documenting source of truth for the exemption; relocating the km to the
+// GPX crest would contradict that fixed content (and, for Lagleygeolle, move
+// the climb into a different segment). See also #492 (ASO 2026 categorisation).
 describe('points-config climb summit km vs GPX argmax', () => {
   const track = buildTrack()
 
@@ -60,9 +64,11 @@ describe('points-config climb summit km vs GPX argmax', () => {
     if (climb.length_km == null) continue
     const winLow = climb.km - climb.length_km
     const winHigh = climb.km + UPPER_PAD_KM
-    const knownFailIssue = KNOWN_FAILING[climb.name]
-    const testFn = knownFailIssue ? it.skip : it
-    const titleSuffix = knownFailIssue ? ` [skipped: #${knownFailIssue}]` : ''
+    const exempt = climb.summit_is_kom_line === true
+    const testFn = exempt ? it.skip : it
+    const titleSuffix = exempt
+      ? ' [exempt: summit km is a KOM/scoring line below the GPX peak, by design]'
+      : ''
     testFn(`${climb.name}: declared summit km ${climb.km} matches GPX argmax in [${winLow.toFixed(2)}, ${winHigh.toFixed(2)}] within ±${TOLERANCE_KM} km / ±${TOLERANCE_M} m${titleSuffix}`, () => {
       let argmaxKm = climb.km
       let argmaxElev = -Infinity


### PR DESCRIPTION
## Summary

Reconciles climb summit-km and route-geometry drift surfaced by the GPX cross-checks, and brings `data/segments.json` back in sync with the generator that owns it. Single PR per the agreed scope (the finish-line gap #554 is resolved separately as an issue comment, see below).

## Climb data (`data/competition/points-config.json`)

- **#591 Cote de la Croix de Pey** summit km `128.99 -> 129.54` (the GPX elevation argmax in the climb window, +0.55 km / +31.6 m). The summit-km regression assertion now runs and passes.
- **#551 Croix de Pey length/gradient** resolved as: keep the 7.0 km span, re-measure the gradient to the GPX. Correcting the summit shifted the gradient test's `[km-length, km]` window, so the declared gradient was re-derived from the GPX over the retained span: **4.4% -> 4.9%** (GPX-derived 4.86%, gain 340.2 m / 7 km). 4.9% sits between the prior points-config 4.4% and the community mycols/climbfinder 5.1%, corroborating both. Category 3 unchanged. **Provisional pending the 2026 ASO categorisation (#492)** — basis recorded there.
- **#555 Cote des Gardes** summit km `170.98 -> 170.73`, moving the declared summit back onto the GPX crest (it sat ~0.25 km past the peak, on the descent). Length 2.2 km / gradient 4.3% already within tolerance.

## KOM-line exemption (#589, #590)

GPX investigation found these are **not data bugs**. The declared summit km is an intentional scoring / KOM line placed *below* the GPX elevation peak: the road keeps climbing, uncounted, past the points line.

- **#589 Cote de Lagleygeolle** — true GPX crest is at km ~51.42 (568 m), **6.4 km past** the declared KOM line and in a different segment (8, not 7).
- **#590 Puy de Lachaud** — deliberately uncounted by ASO; the declared point is a project-internal Cat-2 marker, not an elevation peak.
- The published entries `07-road-through-beynat.md` and `13-puy-de-lachaud-uncounted.md` deliberately anchor the scored summit below the true crest, and quote the declared figures. Relocating the km would contradict fixed content (and, for Lagleygeolle, move the climb into the wrong segment).

Mechanism: replaced the ad-hoc `KNOWN_FAILING` skip-list in `tests/utils/climb-summit-km.test.ts` with a typed, self-documenting `summit_is_kom_line` flag on the climb object. The placement assertion is exempt for flagged climbs **by design, not pending a fix**. The points-config schema is permissive (`additionalProperties: true`), so no schema change was needed. Croix de Pey was removed from the old skip-list entirely (its summit-km is now correct and the assertion runs green).

## `segments.json` regeneration (#639)

- Regenerated from `split_gpx.py`. The committed file was stale w.r.t. the generator: it lacked the per-segment `town_positions` blocks the generator emits. The regen syncs them across all 27 segments.
- Fixed the half-open town-assignment boundary so the **final segment** uses an inclusive end (final-segment-only, to preserve interior-boundary dedup). Without it, a town whose closest-approach km lands exactly on the route's final km is dropped: **Ussel** (Place Voltaire, km == total_km) was falling out of seg 27. Ussel is restored; no interior segment's towns changed.

## #554 (finish-line gap) — resolved separately, no code change

The seg-27 polyline ends 216 m short of the Place Voltaire judge line. Decision: **document, don't fabricate** — the GPX is bedrock and no authoritative finish-line geometry exists (only a Nominatim point, which is not authority to rewrite the recorded track). Recorded as an issue comment on #554; no track points invented.

## Verification

- `npm test`: **210 passed, 2 skipped (by-design KOM-line exemptions), 0 failed**
- `python3 processing/validate_points.py`: **exit 0**
- `npm run build`: **clean**

Refs #591 #551 #555 #589 #590 #639 #492 #554