### PR TITLE
Frontmatter parser consolidation, Stage B: canonical TS parser + CI guard (Closes #326)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Lint JavaScript
         run: npx eslint .
 
+      - name: Guard against hand-rolled frontmatter parsers (#326)
+        run: bash scripts/check-frontmatter-parsers.sh
+
       - name: Run JavaScript tests with coverage
         run: npm run test:coverage
 

--- a/scripts/check-frontmatter-parsers.sh
+++ b/scripts/check-frontmatter-parsers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Anti-regression guard for issue #326.
+#
+# Every consumer must read and write entry frontmatter through the two
+# canonical parsers -- processing/frontmatter.py and
+# server/utils/frontmatter.ts -- never a new hand-rolled regex. Before #326 the
+# same parser was reimplemented in ~10 places, each drifting independently (the
+# class of bug behind the seg-9 publish crash and the v1.3.4 date corruption).
+#
+# This guard fails CI when production code outside the two canonical modules
+# contains a frontmatter fence regex (`^---\n`) or a per-field frontmatter-key
+# regex (`^segment:`, `^weather:`, ...). Test files are exempt: the byte-
+# identical parity proofs intentionally embed the old patterns.
+#
+# Red-green: add e.g. `re.search(r'^weather:', s)` to any processing/*.py and
+# this guard fails; remove it and it passes.
+set -euo pipefail
+
+KEYS='segment|title|subtitle|publishDate|kmStart|kmEnd|gpxFile|elevationData|images|weather|draft|dataCutoff|imagesOptional'
+
+# A regex/string literal opening with the fence (^---\n) or a field line
+# (^<key>:). The trailing \n on the fence avoids matching markdown rules
+# (-----) and PEM headers in vendored code.
+PATTERN="[\"'/]\\^(---\\\\n|(${KEYS}):)"
+
+# The canonical parsers legitimately contain the fence regex; this guard
+# documents the forbidden patterns in its own comments.
+ALLOW='processing/frontmatter\.py|server/utils/frontmatter\.ts|scripts/check-frontmatter-parsers\.sh'
+
+hits="$(
+  grep -rnE "$PATTERN" processing scripts server \
+    --include='*.py' --include='*.sh' --include='*.ts' --include='*.mjs' 2>/dev/null \
+    | grep -vE '\.venv/|node_modules/|/tests/|\.test\.(ts|js)' \
+    | grep -vE "$ALLOW" \
+    || true
+)"
+
+if [ -n "$hits" ]; then
+  echo "ERROR: hand-rolled frontmatter parsing found outside the canonical parsers (issue #326)." >&2
+  echo "Use processing/frontmatter.py or server/utils/frontmatter.ts instead:" >&2
+  echo "$hits" >&2
+  exit 1
+fi
+
+echo "OK: no hand-rolled frontmatter parsing outside the canonical parsers."

--- a/server/api/entries.get.ts
+++ b/server/api/entries.get.ts
@@ -1,34 +1,17 @@
 import { readFileSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { parseFrontmatter } from '~/server/utils/frontmatter'
+
 export default defineEventHandler(() => {
   const entriesDir = resolve('content/entries')
   const files = readdirSync(entriesDir).filter(f => f.endsWith('.md')).sort()
 
   const entries = files.map(filename => {
     const content = readFileSync(join(entriesDir, filename), 'utf8')
-    const frontmatter: Record<string, any> = {}
-
-    const match = content.match(/^---\n([\s\S]*?)\n---/)
-    if (match) {
-      for (const line of match[1].split('\n')) {
-        const colonIdx = line.indexOf(':')
-        if (colonIdx > 0) {
-          const key = line.slice(0, colonIdx).trim()
-          let value: any = line.slice(colonIdx + 1).trim()
-          if (value === 'true') value = true
-          else if (value === 'false') value = false
-          else if (value === 'null') value = null
-          else if (/^\d+(\.\d+)?$/.test(value)) value = parseFloat(value)
-          else if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1)
-          frontmatter[key] = value
-        }
-      }
-    }
-
     return {
       filename,
-      ...frontmatter
+      ...parseFrontmatter(content)
     }
   })
 

--- a/server/api/entry-content.get.ts
+++ b/server/api/entry-content.get.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { splitFrontmatter } from '~/server/utils/frontmatter'
+
 export default defineEventHandler((event) => {
   const query = getQuery(event)
   const filename = query.filename as string
@@ -12,14 +14,5 @@ export default defineEventHandler((event) => {
   const filePath = join(resolve('content/entries'), filename)
   const content = readFileSync(filePath, 'utf8')
 
-  // Split frontmatter and body
-  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
-  if (!match) {
-    return { frontmatter: '', body: content }
-  }
-
-  return {
-    frontmatter: match[1],
-    body: match[2]
-  }
+  return splitFrontmatter(content)
 })

--- a/server/api/entry-content.post.ts
+++ b/server/api/entry-content.post.ts
@@ -1,6 +1,8 @@
 import { writeFileSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { joinFrontmatter } from '~/server/utils/frontmatter'
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { filename, frontmatter, content: markdownBody } = body
@@ -11,8 +13,7 @@ export default defineEventHandler(async (event) => {
 
   const filePath = join(resolve('content/entries'), filename)
 
-  const fileContent = `---\n${frontmatter.trim()}\n---\n${markdownBody}`
-  writeFileSync(filePath, fileContent)
+  writeFileSync(filePath, joinFrontmatter(frontmatter, markdownBody))
 
   return { success: true, filename }
 })

--- a/server/api/entry-status.post.ts
+++ b/server/api/entry-status.post.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { setField } from '~/server/utils/frontmatter'
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { filename, draft, publishDate } = body
@@ -13,17 +15,11 @@ export default defineEventHandler(async (event) => {
   let content = readFileSync(filePath, 'utf8')
 
   if (draft !== undefined) {
-    content = content.replace(
-      /^draft:\s*(true|false)$/m,
-      `draft: ${draft}`
-    )
+    content = setField(content, 'draft', String(draft))
   }
 
   if (publishDate) {
-    content = content.replace(
-      /^publishDate:\s*\S+$/m,
-      `publishDate: ${publishDate}`
-    )
+    content = setField(content, 'publishDate', publishDate)
   }
 
   writeFileSync(filePath, content)

--- a/server/api/images.get.ts
+++ b/server/api/images.get.ts
@@ -1,6 +1,8 @@
 import { readFileSync, existsSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { parseFrontmatter } from '~/server/utils/frontmatter'
+
 export default defineEventHandler((event) => {
   const query = getQuery(event)
   const segment = parseInt(query.segment as string)
@@ -27,14 +29,11 @@ export default defineEventHandler((event) => {
 
   for (const filename of files) {
     const content = readFileSync(join(entriesDir, filename), 'utf8')
-    const segMatch = content.match(/^segment:\s*(\d+)/m)
-    if (segMatch && parseInt(segMatch[1]) === segment) {
+    const fm = parseFrontmatter(content)
+    if (fm.segment === segment) {
       entryFilename = filename
-      const imagesMatch = content.match(/^images:\s*(\[[\s\S]*?\])\s*$/m)
-      if (imagesMatch) {
-        try {
-          entryImages = JSON.parse(imagesMatch[1])
-        } catch {}
+      if (Array.isArray(fm.images)) {
+        entryImages = fm.images
       }
       break
     }

--- a/server/api/images.post.ts
+++ b/server/api/images.post.ts
@@ -1,8 +1,7 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve, join } from 'path'
-import yaml from 'js-yaml'
 
-const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---(\r?\n?)/
+import { hasFrontmatter, setField } from '~/server/utils/frontmatter'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -15,30 +14,16 @@ export default defineEventHandler(async (event) => {
   const filePath = join(resolve('content/entries'), filename)
   const content = readFileSync(filePath, 'utf8')
 
-  const match = content.match(FRONTMATTER_RE)
-  if (!match || match[1] === undefined) {
+  if (!hasFrontmatter(content)) {
     throw createError({ statusCode: 422, message: `Entry ${filename} has no frontmatter block` })
   }
 
-  const rawFrontmatter = match[1]
-  const parsed = yaml.load(rawFrontmatter)
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw createError({ statusCode: 422, message: `Entry ${filename} frontmatter is not a mapping` })
-  }
-
-  const frontmatter = parsed as Record<string, unknown>
-  frontmatter.images = images
-
-  const dumped = yaml.dump(frontmatter, {
-    lineWidth: -1,
-    flowLevel: 1,
-    noRefs: true,
-    quotingType: '"',
-  })
-
-  const body_ = content.slice(match[0].length)
-  const rebuilt = `---\n${dumped}---\n${body_}`
-  writeFileSync(filePath, rebuilt)
+  // setField replaces the images line (and any indented block-list
+  // continuation) with the inline JSON array, leaving every other field byte
+  // for byte -- no whole-block re-dump, so a bare ISO publishDate is not
+  // reserialised (the old route's js-yaml round-trip corrupted dates into
+  // full timestamps).
+  writeFileSync(filePath, setField(content, 'images', JSON.stringify(images)))
 
   return { success: true, filename, count: images.length }
 })

--- a/server/api/weather-inject.post.ts
+++ b/server/api/weather-inject.post.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { setField } from '~/server/utils/frontmatter'
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { filename, weather } = body
@@ -10,15 +12,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const filePath = join(resolve('content/entries'), filename)
-  let content = readFileSync(filePath, 'utf8')
+  const content = readFileSync(filePath, 'utf8')
 
   const weatherValue = weather ? JSON.stringify(weather) : 'null'
-  content = content.replace(
-    /^weather:.*$/m,
-    `weather: ${weatherValue}`
-  )
-
-  writeFileSync(filePath, content)
+  writeFileSync(filePath, setField(content, 'weather', weatherValue))
 
   return { success: true, filename }
 })

--- a/server/api/weather.get.ts
+++ b/server/api/weather.get.ts
@@ -1,27 +1,22 @@
 import { readFileSync, readdirSync } from 'fs'
 import { resolve, join } from 'path'
 
+import { parseFrontmatter } from '~/server/utils/frontmatter'
+
 export default defineEventHandler(() => {
   const entriesDir = resolve('content/entries')
   const files = readdirSync(entriesDir).filter(f => f.endsWith('.md')).sort()
 
   const entries = files.map(filename => {
     const content = readFileSync(join(entriesDir, filename), 'utf8')
+    const fm = parseFrontmatter(content)
 
-    const segMatch = content.match(/^segment:\s*(\d+)/m)
-    const titleMatch = content.match(/^title:\s*"?(.+?)"?\s*$/m)
-    const weatherMatch = content.match(/^weather:\s*(.+)$/m)
-
-    const segment = segMatch ? parseInt(segMatch[1]) : null
-    const title = titleMatch ? titleMatch[1] : filename
-    let weather = null
-    if (weatherMatch && weatherMatch[1] !== 'null') {
-      try {
-        weather = JSON.parse(weatherMatch[1])
-      } catch {}
+    return {
+      filename,
+      segment: fm.segment ?? null,
+      title: fm.title ?? filename,
+      weather: fm.weather ?? null
     }
-
-    return { filename, segment, title, weather }
   })
 
   return { entries }

--- a/server/utils/frontmatter.ts
+++ b/server/utils/frontmatter.ts
@@ -1,0 +1,110 @@
+/**
+ * Canonical frontmatter parser for content/entries/*.md (issue #326).
+ *
+ * The single source of read/write logic for every server route that touches
+ * entry frontmatter (entries.get, weather.get, images.get/post,
+ * entry-status.post, weather-inject.post, entry-content.get/post). Replaces the
+ * per-route hand-rolled regex parsers those files used to carry.
+ *
+ * This is the TypeScript twin of processing/frontmatter.py and shares
+ * schemas/frontmatter.schema.json with it. Like the Python module it loads YAML
+ * with js-yaml's JSON_SCHEMA so a bare ISO date (publishDate, dataCutoff) stays
+ * a string instead of becoming a Date -- downstream code compares those as
+ * strings.
+ */
+import yaml from 'js-yaml'
+
+import schema from '~/schemas/frontmatter.schema.json'
+
+// The frontmatter fence: group 1 the opening `---\n`, group 2 the YAML body
+// (non-greedy, stops at the first closing fence), group 3 the `\n---`.
+const FENCE_RE = /^(---\n)([\s\S]*?)(\n---)/
+const HEAD_RE = /^---\n([\s\S]*?)\n---/
+
+/** Frontmatter field names declared by the shared schema. */
+export const FIELDS = Object.keys((schema as { properties: Record<string, unknown> }).properties)
+/** Required frontmatter field names declared by the shared schema. */
+export const REQUIRED = (schema as { required: string[] }).required
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Parse the YAML frontmatter of a markdown string into an object.
+ * Returns {} when there is no frontmatter block or it is not a mapping.
+ * Bare ISO dates stay strings (see module docstring).
+ */
+export function parseFrontmatter(content: string): Record<string, any> {
+  const m = content.match(HEAD_RE)
+  if (!m) return {}
+  const data = yaml.load(m[1], { schema: yaml.JSON_SCHEMA })
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) return {}
+  return data as Record<string, any>
+}
+
+/**
+ * Split a markdown string into raw frontmatter text and body. Returns
+ * { frontmatter: '', body: content } when there is no frontmatter block. The
+ * frontmatter is the unparsed text between the fences; the body is everything
+ * after the closing `---\n`. This is the shared primitive the entry-content
+ * editor round-trip relies on (paired with joinFrontmatter).
+ */
+export function splitFrontmatter(content: string): { frontmatter: string, body: string } {
+  const m = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+  if (!m) return { frontmatter: '', body: content }
+  return { frontmatter: m[1], body: m[2] }
+}
+
+/** Reassemble a markdown file from raw frontmatter text and body. */
+export function joinFrontmatter(frontmatter: string, body: string): string {
+  return `---\n${frontmatter.trim()}\n---\n${body}`
+}
+
+/** True when content has a leading `---` frontmatter block. */
+export function hasFrontmatter(content: string): boolean {
+  return HEAD_RE.test(content)
+}
+
+/**
+ * Return content with frontmatter field `key` set to the literal `value`.
+ *
+ * Surgical and byte-preserving: replaces the `key:` line in the frontmatter
+ * block in place, or appends the field as the last frontmatter line (before the
+ * closing `---`) when absent. `value` is inserted verbatim -- already formatted
+ * by the caller (`true`, an ISO date, or a compact JSON string).
+ *
+ * If the existing value spans multiple YAML lines -- a block-style list such as
+ *   images:
+ *     - src: ...
+ * -- the indented continuation lines are consumed too, so replacing a block
+ * `images:` with an inline JSON array leaves no orphan `- src:` lines. For the
+ * single-line fields every other route writes (weather, draft, publishDate,
+ * dataCutoff) there are no continuation lines, so the result is byte-identical
+ * to the regex replacers this consolidates. Unlike the old images.post it never
+ * re-dumps the whole block, so sibling fields (and their exact bytes -- e.g. a
+ * bare ISO `publishDate`) are preserved rather than reserialised.
+ *
+ * Content with no frontmatter block is returned unchanged.
+ */
+export function setField(content: string, key: string, value: string): string {
+  const m = content.match(FENCE_RE)
+  if (!m) return content
+  const [, head, fmBody, tail] = m
+  const rest = content.slice(m[0].length)
+  const newLine = `${key}: ${value}`
+  const keyRe = new RegExp(`^${escapeRegExp(key)}:`)
+
+  const lines = fmBody.split('\n')
+  const idx = lines.findIndex(line => keyRe.test(line))
+  if (idx === -1) {
+    return `${head}${fmBody}\n${newLine}${tail}${rest}`
+  }
+  // Consume any indented continuation lines belonging to a block-style value.
+  let end = idx + 1
+  while (end < lines.length && /^\s/.test(lines[end])) {
+    end++
+  }
+  const newLines = [...lines.slice(0, idx), newLine, ...lines.slice(end)]
+  return `${head}${newLines.join('\n')}${tail}${rest}`
+}

--- a/tests/api/frontmatter-parity.test.ts
+++ b/tests/api/frontmatter-parity.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Byte-identical migration proof for the #326 parser consolidation (TS side).
+ *
+ * Mirrors processing/tests/test_frontmatter_parity.py for the server routes.
+ * It reads every real content/entries/*.md (NOT mocked fs), embeds the frozen
+ * pre-#326 extraction/write logic each route carried, and asserts the canonical
+ * server/utils/frontmatter helpers produce identical observable output -- with
+ * two documented, intentional improvements:
+ *   1. entries.get now returns real arrays/objects for images/weather instead of
+ *      raw strings (the old regex had no array branch). No consumer depended on
+ *      the string form (pages/admin/entries.vue reads only scalar fields).
+ *   2. images.post no longer corrupts dates. The old route round-tripped the
+ *      whole block through default-schema js-yaml, turning a bare ISO
+ *      `publishDate: 2026-04-12` into `2026-04-12T00:00:00.000Z`. The canonical
+ *      surgical setField leaves sibling fields byte-for-byte untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import yaml from 'js-yaml'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+import {
+  parseFrontmatter,
+  setField,
+  splitFrontmatter,
+} from '~/server/utils/frontmatter'
+
+const dir = resolve('content/entries')
+const files = readdirSync(dir).filter(f => f.endsWith('.md')).sort()
+const read = (f: string) => readFileSync(join(dir, f), 'utf8')
+
+// --- frozen pre-#326 implementations ---------------------------------------
+
+function oldEntriesParse(content: string): Record<string, any> {
+  const fm: Record<string, any> = {}
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (match) {
+    for (const line of match[1].split('\n')) {
+      const colonIdx = line.indexOf(':')
+      if (colonIdx > 0) {
+        const key = line.slice(0, colonIdx).trim()
+        let value: any = line.slice(colonIdx + 1).trim()
+        if (value === 'true') value = true
+        else if (value === 'false') value = false
+        else if (value === 'null') value = null
+        else if (/^\d+(\.\d+)?$/.test(value)) value = parseFloat(value)
+        else if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1)
+        fm[key] = value
+      }
+    }
+  }
+  return fm
+}
+
+function oldWeatherGet(content: string, filename: string) {
+  const segMatch = content.match(/^segment:\s*(\d+)/m)
+  const titleMatch = content.match(/^title:\s*"?(.+?)"?\s*$/m)
+  const weatherMatch = content.match(/^weather:\s*(.+)$/m)
+  const segment = segMatch ? parseInt(segMatch[1]) : null
+  const title = titleMatch ? titleMatch[1] : filename
+  let weather: any = null
+  if (weatherMatch && weatherMatch[1] !== 'null') {
+    try { weather = JSON.parse(weatherMatch[1]) } catch { /* ignore */ }
+  }
+  return { filename, segment, title, weather }
+}
+
+function oldImagesGet(content: string): any[] {
+  let entryImages: any[] = []
+  const imagesMatch = content.match(/^images:\s*(\[[\s\S]*?\])\s*$/m)
+  if (imagesMatch) {
+    try { entryImages = JSON.parse(imagesMatch[1]) } catch { /* ignore */ }
+  }
+  return entryImages
+}
+
+function oldStatusSet(content: string, draft?: boolean, publishDate?: string) {
+  let out = content
+  if (draft !== undefined) out = out.replace(/^draft:\s*(true|false)$/m, `draft: ${draft}`)
+  if (publishDate) out = out.replace(/^publishDate:\s*\S+$/m, `publishDate: ${publishDate}`)
+  return out
+}
+
+function oldWeatherInject(content: string, weather: any) {
+  const weatherValue = weather ? JSON.stringify(weather) : 'null'
+  return content.replace(/^weather:.*$/m, `weather: ${weatherValue}`)
+}
+
+function oldEntryContentSplit(content: string) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/)
+  if (!match) return { frontmatter: '', body: content }
+  return { frontmatter: match[1], body: match[2] }
+}
+
+function oldImagesPostCorrupting(content: string, images: any) {
+  const match = content.match(/^---\n([\s\S]*?)\n---(\r?\n?)/)!
+  const parsed: any = yaml.load(match[1])
+  parsed.images = images
+  const dumped = yaml.dump(parsed, { lineWidth: -1, flowLevel: 1, noRefs: true, quotingType: '"' })
+  return `---\n${dumped}---\n${content.slice(match[0].length)}`
+}
+
+// --- read parity -----------------------------------------------------------
+
+describe('frontmatter read parity (#326)', () => {
+  it('entries.get scalar fields identical; images/weather upgraded to parsed', () => {
+    for (const f of files) {
+      const c = read(f)
+      const neu = parseFrontmatter(c)
+      const old = oldEntriesParse(c)
+      for (const key of Object.keys(old)) {
+        if (key === 'images' || key === 'weather') {
+          // Old returned a raw string; new returns the parsed value.
+          const oldVal = old[key]
+          const expected = (oldVal === null || oldVal === undefined) ? null : JSON.parse(oldVal)
+          expect(neu[key] ?? null, `${f}:${key}`).toEqual(expected)
+        } else {
+          expect(neu[key], `${f}:${key}`).toEqual(old[key])
+        }
+      }
+    }
+  })
+
+  it('weather.get extraction identical on every entry', () => {
+    for (const f of files) {
+      expect(
+        {
+          filename: f,
+          segment: parseFrontmatter(read(f)).segment ?? null,
+          title: parseFrontmatter(read(f)).title ?? f,
+          weather: parseFrontmatter(read(f)).weather ?? null,
+        },
+        f,
+      ).toEqual(oldWeatherGet(read(f), f))
+    }
+  })
+
+  it('images.get entryImages identical on every entry', () => {
+    for (const f of files) {
+      const fm = parseFrontmatter(read(f))
+      const neu = Array.isArray(fm.images) ? fm.images : []
+      expect(neu, f).toEqual(oldImagesGet(read(f)))
+    }
+  })
+})
+
+// --- write parity ----------------------------------------------------------
+
+describe('frontmatter write parity (#326)', () => {
+  it('entry-status draft/publishDate writes byte-identical', () => {
+    for (const f of files) {
+      const c = read(f)
+      expect(setField(c, 'draft', 'true'), f).toBe(oldStatusSet(c, true))
+      expect(setField(c, 'publishDate', '2026-06-01'), f).toBe(oldStatusSet(c, undefined, '2026-06-01'))
+    }
+  })
+
+  it('weather-inject write byte-identical', () => {
+    const weather = { current: { temp: 20, conditions: 'Clear', wind: '5 km/h' } }
+    for (const f of files) {
+      const c = read(f)
+      expect(setField(c, 'weather', JSON.stringify(weather)), f).toBe(oldWeatherInject(c, weather))
+      expect(setField(c, 'weather', 'null'), f).toBe(oldWeatherInject(c, null))
+    }
+  })
+
+  it('entry-content split identical on every entry', () => {
+    for (const f of files) {
+      expect(splitFrontmatter(read(f)), f).toEqual(oldEntryContentSplit(read(f)))
+    }
+  })
+})
+
+// --- images.post date-corruption fix ---------------------------------------
+
+describe('images.post no longer corrupts dates (#326)', () => {
+  const newImages = [{ src: '/img/x.jpg', alt: 'x' }]
+
+  it('the old route corrupted bare ISO dates into full timestamps', () => {
+    const dated = files.find(f => /^publishDate: \d{4}-\d{2}-\d{2}\s*$/m.test(read(f)))!
+    const corrupted = oldImagesPostCorrupting(read(dated), newImages)
+    expect(corrupted).toMatch(/publishDate: \d{4}-\d{2}-\d{2}T00:00:00/)
+  })
+
+  it('the canonical setField preserves every sibling field byte-for-byte', () => {
+    for (const f of files) {
+      const c = read(f)
+      const out = setField(c, 'images', JSON.stringify(newImages))
+      // Every non-images frontmatter line is unchanged.
+      const before = splitFrontmatter(c).frontmatter.split('\n').filter(l => !/^images:/.test(l))
+      const after = splitFrontmatter(out).frontmatter.split('\n').filter(l => !/^images:/.test(l))
+      expect(after, f).toEqual(before)
+      // images is the new inline array.
+      expect(parseFrontmatter(out).images, f).toEqual(newImages)
+    }
+  })
+})

--- a/tests/data/frontmatter-schema.test.ts
+++ b/tests/data/frontmatter-schema.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Validates every content/entries/*.md frontmatter against the shared schema
+ * (schemas/frontmatter.schema.json) using the canonical TypeScript parser and
+ * ajv -- the TS-side drift guard for #326, mirroring the schema-conformance
+ * test in processing/tests/test_frontmatter.py. The schema is the single field
+ * definition both languages read.
+ */
+import { describe, it, expect } from 'vitest'
+import Ajv from 'ajv'
+import addFormats from 'ajv-formats'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+import { parseFrontmatter } from '~/server/utils/frontmatter'
+import schema from '~/schemas/frontmatter.schema.json'
+
+const ajv = new Ajv({ allErrors: true, strict: false })
+addFormats(ajv)
+const validate = ajv.compile(schema)
+
+const dir = resolve('content/entries')
+const files = readdirSync(dir).filter(f => f.endsWith('.md')).sort()
+
+describe('content/entries frontmatter schema validation', () => {
+  for (const filename of files) {
+    it(`${filename} conforms to frontmatter.schema.json`, () => {
+      const fm = parseFrontmatter(readFileSync(join(dir, filename), 'utf8'))
+      const ok = validate(fm)
+      expect(ok, ajv.errorsText(validate.errors, { separator: '\n  ' })).toBe(true)
+    })
+  }
+
+  it('discovers every entry', () => {
+    expect(files.length).toBeGreaterThanOrEqual(28)
+  })
+})


### PR DESCRIPTION
## Stage B of #326 — canonical **TypeScript** parser + anti-regression guard

Completes the consolidation started in #649 (Stage A, Python). With this PR
every entry-frontmatter parser in the repo reads/writes through one of two
canonical modules, and a CI guard stops new hand-rolled ones from regrowing.
**`Closes #326`.**

### What this PR delivers

- **`server/utils/frontmatter.ts`** — the TypeScript twin of
  `processing/frontmatter.py`: js-yaml `JSON_SCHEMA` reader (bare ISO dates stay
  strings), a surgical byte-preserving `setField` (consuming block-list
  continuation lines), and `splitFrontmatter`/`joinFrontmatter` fence helpers.
  Reads the same `schemas/frontmatter.schema.json`.
- **All 8 server routes migrated**, hand-rolled regex removed:
  `entries.get`, `weather.get`, `images.get` (reads); `entry-status.post`,
  `weather-inject.post` (surgical writes); `images.post` (was a full js-yaml
  re-dump); `entry-content.get`/`post` (shared fence split/join).
- **`scripts/check-frontmatter-parsers.sh`** — CI guard that fails on any new
  frontmatter fence/field regex outside the two canonical modules. Red-green
  verified.

### Two intentional, consumer-safe improvements (proven, not assumed)

`tests/api/frontmatter-parity.test.ts` embeds the frozen pre-#326 logic for each
route and asserts the canonical parser is byte-identical over **every real
entry**, except two deliberate upgrades:

1. **`/api/entries` returns real arrays/objects for `images`/`weather`** instead
   of the old raw strings (its regex had no array branch). Verified no consumer
   depends on the string form — `pages/admin/entries.vue` reads only scalar
   fields.
2. **`images.post` no longer corrupts dates.** The old route round-tripped the
   whole block through *default-schema* js-yaml, turning a bare
   `publishDate: 2026-04-12` into `2026-04-12T00:00:00.000Z` — the v1.3.4
   corruption class #326 cites. The canonical surgical `setField` leaves every
   sibling field byte-for-byte intact. The parity test demonstrates both the old
   corruption and the fix.

### Scope note (carried from #649)

#326's title says "four" parsers; the real surface was ~10. Per the
full-consolidation decision, this PR migrates the 6 TypeScript field parsers
plus the `entry-content` fence pair. The anti-regression guard can now go green
tree-wide — the property that required consolidating all of them.

### Verification

- `npm test` (vitest) — **246 passed** / 3 skipped (was 209; +37: 9 parity, 28
  schema-conformance)
- `bash scripts/check-frontmatter-parsers.sh` — green; red on a planted parser
- `npx eslint .` — clean · `npm run build` — OK
- `pytest` — 242 · `ruff` — clean · `npm run test:shell` — 5/5 (Stage A intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
