### PR TITLE
Derive climb display values from points-config + drift assertion (#517 #588 #486)

### DIFF
--- a/components/ElevationChart.vue
+++ b/components/ElevationChart.vue
@@ -232,19 +232,10 @@ const chartData = computed(() => {
 
 // townKmPositions is imported from ~/data/town-positions (shared with StageDetails.vue)
 
-// Known climb summit positions (km_end from KNOWN_CLIMBS)
-const climbSummitKm = {
-  'Cote de Malemort': 5,
-  'Puy Boubou': 30.6,
-  'Cote de Lagleygeolle': 43.2, 'Côte de Lagleygeolle': 43.2,
-  'Cote de Miel': 51.1, 'Côte de Miel': 51.1,
-  'Côte de Naves': 74.8,
-  'Puy de Lachaud': 85.6,
-  'Suc au May': 104.8,
-  'Cote de la Croix de Pey': 127, 'Côte de la Croix de Pey': 127,
-  'Mont Bessou': 153,
-  'Cote des Gardes': 167.2, 'Côte des Gardes': 167.2,
-}
+// Climb summit km comes from CLIMB_DISPLAY (derived from points-config.json by
+// canonical climb name) — see utils/stage-totals.ts. Deriving by the canonical
+// name removes the former dual ASCII/accented key map, which drifted from
+// points-config and broke on the Naves rename (#517).
 
 function buildLabelItems() {
   if (!props.segments.length || !props.elevationData) return []
@@ -290,8 +281,8 @@ function buildLabelItems() {
       for (const climb of seg.climbs) {
         if (placed.has(climb)) continue
         placed.add(climb)
-        // Use known summit km if available, otherwise find peak in segment range
-        const summitKm = climbSummitKm[climb]
+        // Use canonical summit km if available, otherwise find peak in segment range
+        const summitKm = CLIMB_DISPLAY.get(climb)?.km
         let peakIdx = 0
         if (summitKm != null) {
           const targetKm = summitKm - kmOffset

--- a/components/StageDetails.vue
+++ b/components/StageDetails.vue
@@ -31,7 +31,7 @@
 <script setup>
 import segmentsJson from '~/data/segments.json'
 import { townKmPositions } from '~/data/town-positions'
-import { deriveTotals, CATEGORIZED_CLIMBS } from '~/utils/stage-totals'
+import { deriveTotals, CATEGORIZED_CLIMBS, CLIMB_DISPLAY } from '~/utils/stage-totals'
 
 const totals = deriveTotals(segmentsJson)
 
@@ -43,18 +43,9 @@ function isPassed(km) {
   return props.currentKm > 0 && Number(km) < props.currentKm
 }
 
-// Known climb details from CLAUDE.md
-const climbData = {
-  'Puy Boubou': { length: 2.8, gradient: 4.1 },
-  'Côte de Lagleygeolle': { length: 5.2, gradient: 3.9 },
-  'Côte de Miel': { length: 6.6, gradient: 3.9 },
-  'Côte de Naves': { length: 2.8, gradient: 6.7 },
-  'Puy de Lachaud': { length: 3.6, gradient: 5.3 },
-  'Suc au May': { length: 3.8, gradient: 7.7 },
-  'Côte de la Croix de Pey': { length: 7.0, gradient: 4.9 },
-  'Mont Bessou': { length: 5.0, gradient: 3.5 },
-  'Côte des Gardes': { length: 2.2, gradient: 4.8 },
-}
+// Climb gradient + summit km come from CLIMB_DISPLAY (derived from
+// points-config.json by canonical name) — no second copy to drift. See
+// utils/stage-totals.ts.
 
 // Extract towns with their approximate km and elevation
 const townSet = new Map()
@@ -81,12 +72,12 @@ for (const seg of segmentsJson) {
     for (const climb of seg.climbs) {
       if (!CATEGORIZED_CLIMBS.has(climb)) continue
       if (!climbSet.has(climb)) {
-        const data = climbData[climb] || {}
+        const data = CLIMB_DISPLAY.get(climb)
         climbSet.set(climb, {
           name: climb,
-          km: seg.km_start.toFixed(0),
-          gradient: data.gradient || '?',
-          length: data.length || '?'
+          km: data ? data.km.toFixed(0) : seg.km_start.toFixed(0),
+          gradient: data ? data.gradient : '?',
+          length: data?.length_km ?? '?'
         })
       }
     }

--- a/tests/utils/climb-display.test.ts
+++ b/tests/utils/climb-display.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { CLIMB_DISPLAY } from '~/utils/stage-totals'
+import pointsConfig from '~/data/competition/points-config.json'
+
+// Drift detector for the data-to-display consolidation (#517 #588 #486).
+//
+// StageDetails.vue (climb gradient + summit km) and ElevationChart.vue (summit
+// km label placement) used to carry hand-maintained literal maps that disagreed
+// with points-config.json on every gradient and on most summit km, and broke on
+// accent/rename of the lookup key. They now derive from CLIMB_DISPLAY, which is
+// built from points-config by the canonical climb name. These assertions fire
+// red if (a) CLIMB_DISPLAY stops matching points-config, or (b) a component
+// re-introduces a hardcoded climb literal — the two ways the old bug returns.
+
+const COMPONENTS_DIR = resolve(__dirname, '..', '..', 'components')
+const COMPONENTS = ['StageDetails.vue', 'ElevationChart.vue']
+
+describe('CLIMB_DISPLAY is faithful to points-config', () => {
+  it('exposes exactly the points-config climbs, keyed by canonical name', () => {
+    const pcNames = pointsConfig.climbs.map(c => c.name).sort()
+    const mapNames = [...CLIMB_DISPLAY.keys()].sort()
+    expect(mapNames).toEqual(pcNames)
+  })
+
+  it('reports km, length_km and gradient byte-equal to points-config', () => {
+    for (const c of pointsConfig.climbs) {
+      const d = CLIMB_DISPLAY.get(c.name)
+      expect(d, `${c.name} missing from CLIMB_DISPLAY`).toBeDefined()
+      expect(d!.km, `${c.name} km`).toBe(c.km)
+      expect(d!.length_km, `${c.name} length_km`).toBe(c.length_km)
+      expect(d!.gradient, `${c.name} gradient`).toBe(c.gradient)
+    }
+  })
+})
+
+describe('components carry no hardcoded climb literal (consume CLIMB_DISPLAY only)', () => {
+  for (const file of COMPONENTS) {
+    it(`${file} imports CLIMB_DISPLAY and holds no climb-keyed literal`, () => {
+      const src = readFileSync(resolve(COMPONENTS_DIR, file), 'utf-8')
+
+      // Must consume the single derivation.
+      expect(src, `${file} should import CLIMB_DISPLAY`).toMatch(/CLIMB_DISPLAY/)
+
+      // Must NOT re-introduce a literal that maps a climb name to a number or an
+      // object — the shape of the old climbData / climbSummitKm maps. Catches
+      // e.g.  'Suc au May': 104.8  or  'Puy Boubou': { gradient: 9.9 }.
+      const climbLiteral = /'(Côte|Puy|Suc|Mont)[^']*'\s*:\s*[{0-9]/
+      expect(
+        climbLiteral.test(src),
+        `${file} contains a hardcoded climb literal; derive from CLIMB_DISPLAY instead`,
+      ).toBe(false)
+
+      // The retired variable names must not come back either.
+      expect(src).not.toMatch(/\bclimbData\b/)
+      expect(src).not.toMatch(/\bclimbSummitKm\b/)
+    })
+  }
+})

--- a/utils/stage-totals.ts
+++ b/utils/stage-totals.ts
@@ -18,6 +18,32 @@ export const CATEGORIZED_CLIMBS: Set<string> = new Set(
   pointsConfig.climbs.map(c => c.name),
 )
 
+// Per-climb display values (summit km, length, gradient) derived directly from
+// points-config.json keyed by the canonical climb name. This is the single
+// derivation consumed by both StageDetails.vue (gradient + summit km) and
+// ElevationChart.vue (summit km label placement). It replaces the hand-kept
+// `climbData` / `climbSummitKm` literals those components used to carry, which
+// drifted from points-config (#517 #588 #486) and broke on accent/rename of the
+// lookup key. Deriving by the canonical name removes the key-drift surface
+// entirely. tests/utils/climb-display.test.ts asserts this map stays byte-equal
+// to points-config so a re-introduced literal would fire red.
+export interface ClimbDisplay {
+  name: string
+  /** Cumulative km of the scored summit along the full stage. */
+  km: number
+  /** Climb length in km; null where points-config leaves it unset. */
+  length_km: number | null
+  /** Average gradient, per cent. */
+  gradient: number
+}
+
+export const CLIMB_DISPLAY: Map<string, ClimbDisplay> = new Map(
+  pointsConfig.climbs.map(c => [
+    c.name,
+    { name: c.name, km: c.km, length_km: c.length_km, gradient: c.gradient },
+  ]),
+)
+
 export interface StageTotals {
   totalDistance: number
   totalElevationGain: number


### PR DESCRIPTION
## What & why

Climb-data corrections in `data/competition/points-config.json` (landed by geometry-drift, #650) were **not reaching readers**: `StageDetails.vue` and `ElevationChart.vue` each held hand-maintained literal climb maps that duplicated and disagreed with the canonical data — **8 of 9 gradients differed**, and most summit-km. The lookup keys were also accent/rename-fragile (dual ASCII+accented variants; broke on the Naves rename, #517).

Both components now derive climb **gradient** and **summit km** from a single new `CLIMB_DISPLAY` map in `utils/stage-totals.ts`, built from points-config by the canonical climb name. There is now exactly one derivation; the parallel copies are gone.

Closes #517 #588 #486.

## Design checkpoint (self-decided in auto mode, per publisher instruction)

**Helper shape: extended `utils/stage-totals.ts` rather than a new `utils/climb-display.ts`.** `stage-totals.ts` already imports points-config and is the climb-identity authority (`CATEGORIZED_CLIMBS`); extending it keeps one JSON import and one derivation point. A new file would re-import the same JSON for no benefit.

## Drift assertion (closes #486 durably)

`tests/utils/climb-display.test.ts` is the parallel-source-of-truth detector:
- asserts `CLIMB_DISPLAY` is byte-equal to points-config (km / length_km / gradient) for every climb;
- scans both component sources so a **re-introduced** gradient/km literal — or the retired `climbData`/`climbSummitKm` names — fires red.

**Red→green demonstrated:** against `main`'s literals the guard fails on all three structural checks and 8/9 gradients disagree; green on this branch. No artificial breakage committed.

## Reader-experience impact (verified against published prose)

This was checked entry-by-entry before implementing:
- **Published entries 13 (Puy de Lachaud) and 15 (Suc au May)** already quote the *corrected* figures in their prose and Sources — their homepage card was the laggard. This change makes the display **catch up** to what those entries already say.
- **Côte de Miel (entry 08)** is the one published entry whose prose quotes an old figure; per publisher instruction it is **left as-is, no note**.
- Remaining segments (17–27) are pure upside.

## Verification

- `npm test` — 167/167 green.
- `npm run build` (`nuxt generate`) — homepage stage card renders the corrected figures: **Suc au May 7.1%**, **Mont Bessou 2.7%**, **Croix de Pey km 130**; old literals (7.7%, 3.5%, km 127) gone. This is the strand's core proof: a geometry-drift correction now actually reaches the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)