### PR TITLE
Add town-coords completeness assertion (#487)

### DIFF
--- a/tests/utils/town-coords-completeness.test.ts
+++ b/tests/utils/town-coords-completeness.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import townCoords from '~/data/town-coords.json'
+import segmentsJson from '~/data/segments.json'
+import pointsConfig from '~/data/competition/points-config.json'
+
+// Completeness assertion for #487.
+//
+// town-coords.json is the coordinate source the map/labels resolve town and
+// climb positions against. Every town named in segments.json[].towns[] and
+// every climb named in points-config.json#climbs[].name must therefore have a
+// key here — otherwise a declared place silently has no coordinate and cannot
+// be placed. This guard fires red the moment a new town/climb name is declared
+// without a matching coord (the parallel-source-of-truth detector pattern).
+
+const coordKeys = new Set(Object.keys(townCoords as Record<string, unknown>))
+
+// Documented allowlist: climbs declared in points-config that intentionally
+// have no town-coords entry. Each MUST reference an open issue tracking whether
+// it is an intended omission or a genuine gap — never patch town-coords.json
+// silently inside a test strand.
+//
+// - 'Côte de Malemort' (#655): km-5 cat-4 marker (aso:false). Disposition
+//   (add coord vs intended omission) tracked in #655.
+const CLIMB_COORD_ALLOWLIST = new Set<string>(['Côte de Malemort'])
+
+describe('town-coords completeness (#487)', () => {
+  it('every segments.json town has a town-coords entry', () => {
+    const towns = new Set<string>()
+    for (const seg of segmentsJson as Array<{ towns?: string[] }>) {
+      for (const t of seg.towns || []) towns.add(t)
+    }
+    const missing = [...towns].filter(t => !coordKeys.has(t)).sort()
+    expect(missing, `towns missing a town-coords entry: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('every points-config climb has a town-coords entry (except documented allowlist)', () => {
+    const missing = pointsConfig.climbs
+      .map(c => c.name)
+      .filter(name => !coordKeys.has(name) && !CLIMB_COORD_ALLOWLIST.has(name))
+      .sort()
+    expect(missing, `climbs missing a town-coords entry: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('allowlisted climbs are still genuinely absent (prune the allowlist once they gain a coord)', () => {
+    // Keeps the allowlist honest: if #655 adds the coord, this fails and forces
+    // removing the allowlist entry rather than leaving dead exceptions behind.
+    const stale = [...CLIMB_COORD_ALLOWLIST].filter(name => coordKeys.has(name)).sort()
+    expect(stale, `allowlisted climbs that now HAVE a coord — remove from allowlist: ${stale.join(', ')}`).toEqual([])
+  })
+})


### PR DESCRIPTION
## What & why

No guard existed that every town/climb name declared in the data layer has a coordinate to render against. A declared place with no `town-coords.json` entry silently has no position.

`tests/utils/town-coords-completeness.test.ts` asserts:
1. every `segments.json[].towns[]` name has a `town-coords.json` key;
2. every `points-config.json` climb name has a `town-coords.json` key (minus a documented allowlist);
3. the allowlist stays honest — fails if an allowlisted name later gains a coord.

Closes #487.

## Genuine gap surfaced → #655 (not silently patched)

The assertion flagged one real gap: the points-config climb **`Côte de Malemort`** (segment-1 km-5 cat-4 marker, `aso:false`) has no `town-coords.json` entry. Per scope discipline this is **not** patched inside the strand — it's filed as **#655** (decide: add coord vs intended omission) and allowlisted with that reference. Every town and every other climb is present.

## Verification

- `npm test` — town-coords-completeness green (3/3).
- Negative control: without the allowlist the climb check reports exactly `['Côte de Malemort']`, confirming the guard detects gaps rather than passing vacuously; any other missing name would fire red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)