### PR TITLE
Prune CLAUDE.md reference appendices to docs/reference/ + dossier pointers (Closes #627, Refs #309)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Corrèze Travelogue — Project Specification
 
+> **Keep this file to load-bearing every-session instruction.** Bulk reference appendices (cycling history, CC image sources, historical/cultural sources by area) were relocated under #627 to `docs/reference/` and the `content/research/` dossiers. Do not re-add large reference tables or source lists here; add a pointer instead. See the `## References` section near the end for the map.
+
 ## Project Overview
 
 A cycling travelogue blog following the 185km route of Stage 9 of the 2026 Tour de France, from Malemort to Ussel through the Corrèze department of France. The route is divided into 27 segments with alternating lengths (odd-numbered ~8km, even-numbered ~6km, per `processing/split_gpx.py`). One blog entry per segment is published twice weekly from early April to early July 2026, building anticipation toward the actual stage on Sunday, July 12, 2026.
@@ -421,116 +423,10 @@ ASO categorisation (HC, Cat 2, etc.) is on each climb in points-config. Whether 
 - Prioritize mobile-responsive design; entries will be shared on social media
 - New repositories in this ecosystem use Apache 2.0 for code repos and CC BY-SA 4.0 for content/text repos. The `gh repo create --license` default is Apache 2.0, which is wrong for content-centric repos such as `unfold`; pass the correct flag explicitly at creation time.
 
-## References: Cycling History Along the Route
+## References
 
-### Tour de France History in the Corridor
+The bulk reference appendices that used to live here were relocated under #627 to keep this file to load-bearing every-session instruction. Consult these surfaces when drafting; do not copy their contents back into this file.
 
-**Brive-la-Gaillarde (km 3–6)** — multiple Tour visits:
-- **1951 Tour, Stage 11 (Brive → Agen):** Hugo Koblet's legendary 135km solo breakaway, holding off Coppi, Bobet, Bartali, Magni, Géminiani, and Robic. One of the greatest solo rides in Tour history. Source: bikeraceinfo.com/tdf/tdf1951.html
-- **1996 Tour, Stage 15:** Departure from Brive to Villeneuve-sur-Lot.
-- **2012 Tour, Stage 18 (Blagnac → Brive):** Mark Cavendish sprint victory in the rainbow jersey. Bradley Wiggins in yellow. Source: cyclehistory.wordpress.com and procyclingstats.com
-
-**Tulle (km 63–68)** — the departmental capital has hosted Tour du Limousin stages and is the base for local cycling clubs (Tulle Cyclisme Compétition). The L'Agglomérée cyclosportive departs from Tulle annually and in 2026 covers 40km of the Stage 9 route including Suc au May.
-
-**Nearby/overlapping Tour stages:**
-- **2024 Tour, Stage 11 (Évaux-les-Bains → Le Lioran):** 211km through the Massif Central with 4,350m climbing. Vingegaard vs Pogačar battle. Terrain very similar to Stage 9's second half. Dailymotion highlights: dailymotion.com/video/x90ywby
-- **2024 Tour, Stage 12 (Aurillac → Villeneuve-sur-Lot):** Passed through the Cantal just south of the Stage 9 route.
-- **2026 Tour, Stage 10 (Aurillac → Le Lioran):** Takes place the day after Stage 9, using Cantal roads adjacent to the Corrèze route. Same finale as 2024 where Vingegaard beat Pogačar in a photo finish.
-
-### Regional Cycling Races
-
-**Tour du Limousin** — 4-day professional stage race (UCI 2.1), held annually since 1968. Routes through Corrèze, Haute-Vienne, Creuse, and Dordogne on many of the same roads. Now called Tour du Limousin-Périgord-Nouvelle-Aquitaine. Wikipedia: en.wikipedia.org/wiki/Tour_du_Limousin
-
-**Paris-Corrèze** — defunct professional race (UCI 2.1) that ran through the 2000s with stages finishing in Corrèze towns including Ussel. Archived results: autobus.cyclingnews.com
-
-**L'Agglomérée Cyclosportive (Tulle, April 5, 2026)** — amateur sportive riding 40km of the actual Stage 9 route including the Suc au May climb. 85km and 105km options. Organized by Tulle Cyclisme Compétition. This event falls during the blog's first week of publication — potential tie-in content. Source: lagglomeree.agglo-tulle.fr
-
-**La Corrézienne VTT** — mountain bike tour of the Corrèze department. Source: cyclotourisme-correze.fr
-
-### CycleBlaze Touring Journals
-
-CycleBlaze.com hosts touring journals with photos and ride reports through the exact towns on this route, including Turenne, Collonges-la-Rouge, and Curemonte. These provide ground-level cycling perspectives on the terrain. Example: cycleblaze.com/journals/pyreneesannsteve/turenne-collanges-la-rouge-and-curemonte/ — Check individual journal CC licenses before use.
-
-## References: Creative Commons Image Sources
-
-### Wikimedia Commons Categories (all CC BY-SA)
-
-Primary location categories to query for each segment:
-
-| Segment(s) | Wikimedia Commons Category | Notes |
-|------------|---------------------------|-------|
-| 1–2 | Category:Malemort, Category:Brive-la-Gaillarde | Town views, river Corrèze |
-| 3 | Category:Turenne (Corrèze) | Castle ruins, hilltop village, panoramic views |
-| 4 | Category:Collonges-la-Rouge | Extensive collection; red sandstone architecture |
-| 5–6 | Category:Beynat | Smaller collection |
-| 9–10 | Category:Tulle | River valley, cathedral, town views |
-| 11–12 | Category:Naves, Corrèze | Limited |
-| 15 | Category:Monédières | Suc au May area, heathland panoramas |
-| 17 | Category:Treignac | Medieval bridge, granite town |
-| 18–20 | Category:Plateau de Millevaches | Heathland, forests, remote landscapes |
-| 19–20 | Category:Bugeat | Small town, Millevaches gateway |
-| 22 | Category:Mont Bessou | Summit views (highest point in Corrèze) |
-| 25 | Category:Meymac | Benedictine abbey, medieval town |
-| 27 | Category:Ussel, Corrèze | Town centre, Place Voltaire |
-
-### Confirmed CC-Licensed Photographers on Commons
-
-These photographers have Corrèze-specific content confirmed as CC BY-SA:
-- **E gargadennec** — Collonges-la-Rouge header images
-- **Alertomalibu** — Collonges village streets, Castel de Vassinhac
-- **Accrochoc** — Collonges architectural details, tympanum
-- **Sail over** — Maison de la Sirène, Collonges
-
-### Other CC/Open Image Sources
-
-- **Unsplash** — search "Corrèze", "Limousin", "Dordogne valley" for landscape photography (Unsplash license, free for all uses)
-- **Flickr Creative Commons** — search by geographic coordinates for each segment; filter by CC BY or CC BY-SA
-- **Wikimedia Commons geosearch API** — `suggest_images.py` should query: `https://commons.wikimedia.org/w/api.php?action=query&list=geosearch&gscoord={lat}|{lng}&gsradius=5000&gsnamespace=6&gslimit=50`
-
-### Video Sources
-
-- **Dailymotion / Tour de France official channel** — ASO publishes stage highlight videos. Embeddable but check redistribution terms per video:
-  - 2024 TdF Stage 11 highlights (Massif Central): dailymotion.com/video/x90ywby
-  - 2024 TdF Stage 11 route preview: dailymotion.com/video/x9sik7s (check — may be 2026 stage 9 preview)
-  - 2025 TdF highlights reel: dailymotion.com/video/x9npbe4
-- **YouTube** — search "cycling Corrèze", "vélo Corrèze", "Suc au May cycling", "Plateau de Millevaches vélo" for amateur ride-along videos. Many cycling YouTubers post CC-licensed or embeddable content.
-- **Tour du Limousin** — official race footage may be available via France 3 Nouvelle-Aquitaine archives or the race's social media channels.
-
-## References: Historical and Cultural Sources for Entry Content
-
-### Key Historical Topics by Area
-
-**Malemort / Brive area (Segments 1–2):**
-- Malemort is primarily known for rugby (CA Brive), not cycling — first-ever Tour de France visit
-- Brive: Edmond Michelet museum (WWII Resistance), medieval old town
-- The 2012 Cavendish sprint finish provides strong cycling narrative content
-
-**Turenne (Segment 3):**
-- One of the most powerful viscounties in France; the Turenne viscounts controlled much of the Corrèze from the medieval period until 1738 when sold to Louis XV
-- Henri de La Tour d'Auvergne, Marshal of France, born in the castle
-- "Plus Beaux Villages de France" designation
-
-**Collonges-la-Rouge (Segment 4):**
-- Founded by monks of Charroux Abbey (8th century), pilgrimage stop on the Way of St. James to Santiago de Compostela via Rocamadour
-- Red sandstone colored by iron oxide — unique geological feature
-- Birthplace of the "Plus Beaux Villages de France" association (founded by mayor Charles Ceyrac)
-- Maison de la Sirène belonged to Henry de Jouvenel, husband of the writer Colette
-
-**Tulle (Segments 9–10):**
-- Historic lace-making and accordion-manufacturing centre
-- WWII: site of the Tulle massacre (June 9, 1944) — 99 men hanged by the SS Das Reich division
-- Departmental prefecture; François Hollande was mayor before becoming President of France
-
-**Plateau de Millevaches (Segments 18–20):**
-- Name derives from Celtic/Occitan roots meaning "thousand springs" (not "thousand cows")
-- One of the least populated areas of France; vast heathland and peat bogs
-- Regional Natural Park (Parc naturel régional de Millevaches en Limousin)
-
-**Meymac (Segment 25):**
-- Benedictine Abbaye Saint-André (founded 1085)
-- Centre d'Art Contemporain housed in the abbey
-
-**Ussel (Segment 27):**
-- Historical gateway between the Limousin lowlands and the Auvergne highlands
-- Jacques Chirac began his political career as a municipal councillor here
-- Stage finish on Avenue Thiers, sprint judged at Place Voltaire
+- **Cycling history along the route** (Tour de France in the corridor, Tour du Limousin, Paris-Corrèze, L'Agglomérée) → `content/research/tour-history-research.md`. Two items the dossier does not own (La Corrézienne VTT, CycleBlaze touring journals) → `docs/reference/cycling-history.md`.
+- **Creative Commons image sources** (per-segment Wikimedia categories, confirmed CC photographers, geosearch API, video sources) → `docs/reference/cc-image-sources.md`.
+- **Historical and cultural sources by area** (key topics per area; for segments with a research dossier, that dossier is the source of truth) → `docs/reference/historical-cultural-sources.md`.

--- a/docs/reference/cc-image-sources.md
+++ b/docs/reference/cc-image-sources.md
@@ -1,0 +1,46 @@
+# Reference: Creative Commons Image Sources
+
+Relocated from `CLAUDE.md` (issue #627 context-budget prune). This is cross-cutting operational reference for image sourcing across all segments; no per-segment research dossier owns it. Consult it when selecting images for an entry. `processing/suggest_images.py` automates the Wikimedia Commons geosearch query below.
+
+## Wikimedia Commons Categories (all CC BY-SA)
+
+Primary location categories to query for each segment:
+
+| Segment(s) | Wikimedia Commons Category | Notes |
+|------------|---------------------------|-------|
+| 1–2 | Category:Malemort, Category:Brive-la-Gaillarde | Town views, river Corrèze |
+| 3 | Category:Turenne (Corrèze) | Castle ruins, hilltop village, panoramic views |
+| 4 | Category:Collonges-la-Rouge | Extensive collection; red sandstone architecture |
+| 5–6 | Category:Beynat | Smaller collection |
+| 9–10 | Category:Tulle | River valley, cathedral, town views |
+| 11–12 | Category:Naves, Corrèze | Limited |
+| 15 | Category:Monédières | Suc au May area, heathland panoramas |
+| 17 | Category:Treignac | Medieval bridge, granite town |
+| 18–20 | Category:Plateau de Millevaches | Heathland, forests, remote landscapes |
+| 19–20 | Category:Bugeat | Small town, Millevaches gateway |
+| 22 | Category:Mont Bessou | Summit views (highest point in Corrèze) |
+| 25 | Category:Meymac | Benedictine abbey, medieval town |
+| 27 | Category:Ussel, Corrèze | Town centre, Place Voltaire |
+
+## Confirmed CC-Licensed Photographers on Commons
+
+These photographers have Corrèze-specific content confirmed as CC BY-SA:
+- **E gargadennec** — Collonges-la-Rouge header images
+- **Alertomalibu** — Collonges village streets, Castel de Vassinhac
+- **Accrochoc** — Collonges architectural details, tympanum
+- **Sail over** — Maison de la Sirène, Collonges
+
+## Other CC/Open Image Sources
+
+- **Unsplash** — search "Corrèze", "Limousin", "Dordogne valley" for landscape photography (Unsplash license, free for all uses)
+- **Flickr Creative Commons** — search by geographic coordinates for each segment; filter by CC BY or CC BY-SA
+- **Wikimedia Commons geosearch API** — `suggest_images.py` should query: `https://commons.wikimedia.org/w/api.php?action=query&list=geosearch&gscoord={lat}|{lng}&gsradius=5000&gsnamespace=6&gslimit=50`
+
+## Video Sources
+
+- **Dailymotion / Tour de France official channel** — ASO publishes stage highlight videos. Embeddable but check redistribution terms per video:
+  - 2024 TdF Stage 11 highlights (Massif Central): dailymotion.com/video/x90ywby
+  - 2024 TdF Stage 11 route preview: dailymotion.com/video/x9sik7s (check — may be 2026 stage 9 preview)
+  - 2025 TdF highlights reel: dailymotion.com/video/x9npbe4
+- **YouTube** — search "cycling Corrèze", "vélo Corrèze", "Suc au May cycling", "Plateau de Millevaches vélo" for amateur ride-along videos. Many cycling YouTubers post CC-licensed or embeddable content.
+- **Tour du Limousin** — official race footage may be available via France 3 Nouvelle-Aquitaine archives or the race's social media channels.

--- a/docs/reference/cycling-history.md
+++ b/docs/reference/cycling-history.md
@@ -1,0 +1,15 @@
+# Reference: Cycling History Along the Route
+
+Relocated from `CLAUDE.md` (issue #627 context-budget prune).
+
+**The main corpus lives in the dossier.** Tour de France history in the corridor (Brive, Tulle, the nearby/overlapping stages), the Tour du Limousin, Paris-Corrèze, and L'Agglomérée are all researched in depth in `content/research/tour-history-research.md` — that dossier is the source of truth; consult it rather than re-transcribing its facts here (this avoids the CLAUDE.md drift that motivated #627).
+
+This file keeps only the two items the dossier does **not** own:
+
+## La Corrézienne VTT
+
+- **La Corrézienne VTT** — mountain bike tour of the Corrèze department. Source: cyclotourisme-correze.fr
+
+## CycleBlaze Touring Journals
+
+CycleBlaze.com hosts touring journals with photos and ride reports through the exact towns on this route, including Turenne, Collonges-la-Rouge, and Curemonte. These provide ground-level cycling perspectives on the terrain. Example: cycleblaze.com/journals/pyreneesannsteve/turenne-collanges-la-rouge-and-curemonte/ — Check individual journal CC licenses before use.

--- a/docs/reference/historical-cultural-sources.md
+++ b/docs/reference/historical-cultural-sources.md
@@ -1,0 +1,34 @@
+# Reference: Historical and Cultural Sources for Entry Content
+
+Relocated from `CLAUDE.md` (issue #627 context-budget prune). A quick "key topics by area" index for drafting entry content.
+
+**Where the deep version lives.** For segments that have a per-block research dossier, that dossier — not this index — is the source of truth; the entries below point at it rather than re-transcribing the facts (this avoids the CLAUDE.md drift that motivated #627; see #491/#505/#553). The early-segment areas (1–10) predate the dossier practice and have no other home, so they are kept verbatim here.
+
+## Key Historical Topics by Area
+
+**Malemort / Brive area (Segments 1–2):**
+- Malemort is primarily known for rugby (CA Brive), not cycling — first-ever Tour de France visit
+- Brive: Edmond Michelet museum (WWII Resistance), medieval old town
+- The 2012 Cavendish sprint finish provides strong cycling narrative content
+
+**Turenne (Segment 3):**
+- One of the most powerful viscounties in France; the Turenne viscounts controlled much of the Corrèze from the medieval period until 1738 when sold to Louis XV
+- Henri de La Tour d'Auvergne, Marshal of France, born in the castle
+- "Plus Beaux Villages de France" designation
+
+**Collonges-la-Rouge (Segment 4):**
+- Founded by monks of Charroux Abbey (8th century), pilgrimage stop on the Way of St. James to Santiago de Compostela via Rocamadour
+- Red sandstone colored by iron oxide — unique geological feature
+- Birthplace of the "Plus Beaux Villages de France" association (founded by mayor Charles Ceyrac)
+- Maison de la Sirène belonged to Henry de Jouvenel, husband of the writer Colette
+
+**Tulle (Segments 9–10):**
+- Historic lace-making and accordion-manufacturing centre
+- WWII: site of the Tulle massacre (June 9, 1944) — 99 men hanged by the SS Das Reich division
+- Departmental prefecture; François Hollande was mayor before becoming President of France
+
+**Plateau de Millevaches (Segments 18–20):** see `content/research/segs-17-19-block-research.md` (Mille Vaches etymology — "thousand springs", not "thousand cows"; Parc naturel régional de Millevaches en Limousin). Also referenced in `content/research/segs-20-22-block-research.md`.
+
+**Meymac (Segment 25):** see `content/research/segs-23-27-block-research.md` (Abbaye Saint-André de Meymac, founded 1085; Centre d'Art Contemporain in the former abbey buildings).
+
+**Ussel (Segment 27):** see `content/research/segs-23-27-block-research.md` (Jacques Chirac's early Corrèze political career; Place Voltaire — stage-9 sprint judged here; Avenue Thiers finishing straight; historical gateway between the Limousin lowlands and the Auvergne highlands).


### PR DESCRIPTION
## What

`CLAUDE.md` is the largest persistent per-session context contributor in a tdf26 session (~10.7k tokens measured via `/context` on 2026-05-29) — loaded into every session and inherited by every context-taking subagent. It mixed two access patterns: **load-bearing every-session instruction** and **large reference appendices** consulted only during specific drafting work. This PR relocates the second class and leaves pointers — the same prune-by-pointer move the file already made when town/climb facts went out to `data/*.json`.

## Publisher decisions (Checkpoint 0)

Three things #627 deliberately left open were decided via `AskUserQuestion` before any edit (per `feedback_issues_describe_problems.md` — the issue is problem-only):

1. **Where reference content lands:** fold into `content/research/` where a dossier already owns it; orphans with no dossier home → `docs/reference/`.
2. **Stub style:** pointer-only one-liner per relocated block.
3. **Re-accumulation guard:** header note near the top of the file (not a CI byte check).

## What moved

| Block | New home |
|---|---|
| Cycling history corpus (TdF in the corridor, Tour du Limousin, Paris-Corrèze, L'Agglomérée) | → `content/research/tour-history-research.md` (dossier owns it) |
| La Corrézienne VTT + CycleBlaze touring journals | → `docs/reference/cycling-history.md` (dossier does **not** own these) |
| CC image sources (Wikimedia categories, confirmed CC photographers, geosearch API, video sources) | → `docs/reference/cc-image-sources.md` |
| Historical/cultural sources by area | → `docs/reference/historical-cultural-sources.md` |

The historical/cultural index points at the per-block research dossiers for segments that have one (Millevaches → segs-17-19/20-22; Meymac & Ussel → segs-23-27) rather than re-transcribing — the anti-drift move motivated by #491/#505/#553. Early segments 1–10 (pre-dossier) are kept verbatim since no other surface owns them.

## What stayed (load-bearing — explicitly retained)

- The data-source-of-truth pointers: `data/segments.json`, `data/town-coords.json`, `data/competition/points-config.json`.
- The **Known Waypoints and Climbs** section.
- Project overview, agent-ownership, directory structure, the four Phase specs, Publication Schedule, Content Topics, Development Notes.

## Portability (Refs #309 — not closed here)

`docs/reference/` is tool-agnostic plain markdown a future #309 generation step could consume. This PR makes a portability-*aware* layout choice but does **not** build the tool-agnostic context pipeline — that stays a planning item under #309. Per `feedback_pr_closure_keywords.md`, no closing keyword for the informing issue.

## Measurement

| | Lines | Bytes |
|---|---|---|
| Before | 536 | 27,420 |
| After | 432 | 20,983 |
| Delta | **-104 (-19%)** | **-6,437 (-23%)** |

(Token before/after via `/context` is not agent-accessible in this run; line/byte deltas are the proxy. The ~10.7k-token figure is the publisher's 2026-05-29 `/context` baseline for the whole file.)

## Verification

- `npm run build` — green (no component/server-route/script referenced the moved content).
- `python3 processing/validate_entries.py --entries-dir content/entries --non-interactive` — green (no entry frontmatter touched).

Closes #627
Refs #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)