### PR TITLE
Segment 23: track snapshot 23

### DIFF
--- a/data/riders/snapshots/snapshot-23.json
+++ b/data/riders/snapshots/snapshot-23.json
@@ -1,0 +1,1288 @@
+{
+  "segment": 23,
+  "stats": {
+    "asOf": "2026-06-20",
+    "entryNumber": 81,
+    "riders": {
+      "justin": {
+        "totalDistanceCapped": 162.0,
+        "dailyAverageActual": 4.71,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 11.0,
+        "shortestDay": 0.3,
+        "daysBelowThreeKm": 24,
+        "consistencyStdev": 2.54,
+        "bestThreeDayCombo": 28.5,
+        "recentFiveDayAverage": 4.91,
+        "distanceRemaining": 23.0,
+        "estimatedDaysToFinish": 11,
+        "estimatedFinishDate": "2026-07-01",
+        "place": 1
+      },
+      "marian": {
+        "totalDistanceCapped": 160.6,
+        "dailyAverageActual": 3.59,
+        "dailyAverageCapped": 1.98,
+        "longestDay": 9.1,
+        "shortestDay": 0.8,
+        "daysBelowThreeKm": 39,
+        "consistencyStdev": 1.97,
+        "bestThreeDayCombo": 20.8,
+        "recentFiveDayAverage": 2.2,
+        "distanceRemaining": 24.4,
+        "estimatedDaysToFinish": 12,
+        "estimatedFinishDate": "2026-07-02",
+        "place": 4
+      },
+      "nan": {
+        "totalDistanceCapped": 162.0,
+        "dailyAverageActual": 4.68,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 8.6,
+        "shortestDay": 1,
+        "daysBelowThreeKm": 24,
+        "consistencyStdev": 2.15,
+        "bestThreeDayCombo": 25.1,
+        "recentFiveDayAverage": 8.36,
+        "distanceRemaining": 23.0,
+        "estimatedDaysToFinish": 11,
+        "estimatedFinishDate": "2026-07-01",
+        "place": 2
+      },
+      "wally": {
+        "totalDistanceCapped": 162.0,
+        "dailyAverageActual": 2.51,
+        "dailyAverageCapped": 2.0,
+        "longestDay": 4.4,
+        "shortestDay": 0.1,
+        "daysBelowThreeKm": 55,
+        "consistencyStdev": 1.13,
+        "bestThreeDayCombo": 12.3,
+        "recentFiveDayAverage": 2.6,
+        "distanceRemaining": 23.0,
+        "estimatedDaysToFinish": 11,
+        "estimatedFinishDate": "2026-07-01",
+        "place": 3
+      }
+    }
+  },
+  "points": {
+    "riders": {
+      "justin": {
+        "sprintPoints": 51,
+        "climbPoints": 13,
+        "totalPoints": 64
+      },
+      "marian": {
+        "sprintPoints": 53,
+        "climbPoints": 17,
+        "totalPoints": 70
+      },
+      "nan": {
+        "sprintPoints": 53,
+        "climbPoints": 30,
+        "totalPoints": 83
+      },
+      "wally": {
+        "sprintPoints": 49,
+        "climbPoints": 11,
+        "totalPoints": 60
+      }
+    },
+    "locations": [
+      {
+        "name": "Sprint - Brive-la-Gaillarde",
+        "type": "sprint",
+        "segment": 1,
+        "km": 3,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-02",
+            "points": 5
+          },
+          {
+            "place": 2,
+            "rider": "justin",
+            "date": "2026-04-02",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-02",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Turenne",
+        "type": "sprint",
+        "segment": 3,
+        "km": 17,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-09",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-09",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-09",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-13",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Before Tulle",
+        "type": "sprint",
+        "segment": 9,
+        "km": 60,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "wally",
+            "date": "2026-04-30",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-30",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "nan",
+            "date": "2026-04-30",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "justin",
+            "date": "2026-05-01",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Lestards",
+        "type": "sprint",
+        "segment": 19,
+        "km": 130,
+        "category": null,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-06-04",
+            "points": 20
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-06-04",
+            "points": 17
+          },
+          {
+            "place": 3,
+            "rider": "wally",
+            "date": "2026-06-04",
+            "points": 15
+          },
+          {
+            "place": 4,
+            "rider": "nan",
+            "date": "2026-06-04",
+            "points": 13
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Sprint - Ussel Finish",
+        "type": "sprint",
+        "segment": 27,
+        "km": 183,
+        "category": null,
+        "awards": [],
+        "reached": false
+      },
+      {
+        "name": "C\u00f4te de Malemort",
+        "type": "climb",
+        "segment": 1,
+        "km": 5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-04-03",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-03",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-04-03",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-03",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy Boubou",
+        "type": "climb",
+        "segment": 5,
+        "km": 29.06,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-04-15",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-04-15",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-19",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Lagleygeolle",
+        "type": "climb",
+        "segment": 7,
+        "km": 44.99,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-23",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-23",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-23",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-24",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Miel",
+        "type": "climb",
+        "segment": 9,
+        "km": 56.5,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-04-29",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-04-29",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-04-29",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-04-29",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de Naves",
+        "type": "climb",
+        "segment": 11,
+        "km": 77.45,
+        "category": 2,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-05-09",
+            "points": 6
+          },
+          {
+            "place": 2,
+            "rider": "wally",
+            "date": "2026-05-09",
+            "points": 4
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-05-09",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "justin",
+            "date": "2026-05-10",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Puy de Lachaud",
+        "type": "climb",
+        "segment": 13,
+        "km": 87.54,
+        "category": 2,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-05-14",
+            "points": 6
+          },
+          {
+            "place": 2,
+            "rider": "wally",
+            "date": "2026-05-14",
+            "points": 4
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-05-15",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "marian",
+            "date": "2026-05-15",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Suc au May",
+        "type": "climb",
+        "segment": 15,
+        "km": 105.15,
+        "category": 2,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "nan",
+            "date": "2026-05-23",
+            "points": 6
+          },
+          {
+            "place": 2,
+            "rider": "marian",
+            "date": "2026-05-23",
+            "points": 4
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-05-23",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-05-23",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te de la Croix de Pey",
+        "type": "climb",
+        "segment": 19,
+        "km": 129.54,
+        "category": 3,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "justin",
+            "date": "2026-06-04",
+            "points": 4
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-06-04",
+            "points": 3
+          },
+          {
+            "place": 3,
+            "rider": "marian",
+            "date": "2026-06-04",
+            "points": 2
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-06-04",
+            "points": 1
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "Mont Bessou",
+        "type": "climb",
+        "segment": 22,
+        "km": 152.31,
+        "category": 4,
+        "awards": [
+          {
+            "place": 1,
+            "rider": "marian",
+            "date": "2026-06-16",
+            "points": 2
+          },
+          {
+            "place": 2,
+            "rider": "nan",
+            "date": "2026-06-16",
+            "points": 1
+          },
+          {
+            "place": 3,
+            "rider": "justin",
+            "date": "2026-06-16",
+            "points": 0
+          },
+          {
+            "place": 4,
+            "rider": "wally",
+            "date": "2026-06-16",
+            "points": 0
+          }
+        ],
+        "reached": true
+      },
+      {
+        "name": "C\u00f4te des Gardes",
+        "type": "climb",
+        "segment": 25,
+        "km": 170.73,
+        "category": 3,
+        "awards": [],
+        "reached": false
+      }
+    ]
+  },
+  "log": {
+    "entries": [
+      {
+        "date": "2026-04-01",
+        "distances": {
+          "justin": 7.45,
+          "marian": 1,
+          "nan": 1.9,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-04-02",
+        "distances": {
+          "justin": 4.72,
+          "marian": 2.5,
+          "nan": 3.4,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-04-03",
+        "distances": {
+          "justin": 3.42,
+          "marian": 1.8,
+          "nan": 4.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-04",
+        "distances": {
+          "justin": 2.91,
+          "marian": 2.7,
+          "nan": 3,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-05",
+        "distances": {
+          "justin": 2.7,
+          "marian": 1.5,
+          "nan": 4.2,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-06",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2,
+          "nan": 2.5,
+          "wally": 2
+        }
+      },
+      {
+        "date": "2026-04-07",
+        "distances": {
+          "justin": 7.9,
+          "marian": 3,
+          "nan": 5,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-04-08",
+        "distances": {
+          "justin": 5.82,
+          "marian": 0.9,
+          "nan": 2.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-04-09",
+        "distances": {
+          "justin": 1.08,
+          "marian": 2.7,
+          "nan": 2.4,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-04-10",
+        "distances": {
+          "justin": 3.57,
+          "marian": 2.3,
+          "nan": 3.5,
+          "wally": 0.2
+        }
+      },
+      {
+        "date": "2026-04-11",
+        "distances": {
+          "justin": 6.11,
+          "marian": 3.5,
+          "nan": 3.2,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-12",
+        "distances": {
+          "justin": 5.93,
+          "marian": 3.8,
+          "nan": 1.2,
+          "wally": 0.1
+        }
+      },
+      {
+        "date": "2026-04-13",
+        "distances": {
+          "justin": 6.05,
+          "marian": 1.9,
+          "nan": 2.7,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-04-14",
+        "distances": {
+          "justin": 8.53,
+          "marian": 9.1,
+          "nan": 2.7,
+          "wally": 1.7
+        }
+      },
+      {
+        "date": "2026-04-15",
+        "distances": {
+          "justin": 4.51,
+          "marian": 5.9,
+          "nan": 2.4,
+          "wally": 1.3
+        }
+      },
+      {
+        "date": "2026-04-16",
+        "distances": {
+          "justin": 8.01,
+          "marian": 4.1,
+          "nan": 4,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-04-17",
+        "distances": {
+          "justin": 5.01,
+          "marian": 1.5,
+          "nan": 4.7,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-18",
+        "distances": {
+          "justin": 7.75,
+          "marian": 7.75,
+          "nan": 1.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-19",
+        "distances": {
+          "justin": 2.6,
+          "marian": 2.6,
+          "nan": 4.1,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-04-20",
+        "distances": {
+          "justin": 1.35,
+          "marian": 4.95,
+          "nan": 2.8,
+          "wally": 1.8
+        }
+      },
+      {
+        "date": "2026-04-21",
+        "distances": {
+          "justin": 3.52,
+          "marian": 4.8,
+          "nan": 3.9,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-04-22",
+        "distances": {
+          "justin": 3.5,
+          "marian": 5.25,
+          "nan": 5,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-23",
+        "distances": {
+          "justin": 1.4,
+          "marian": 3.22,
+          "nan": 3.8,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-04-24",
+        "distances": {
+          "justin": 3.8,
+          "marian": 3.8,
+          "nan": 3.2,
+          "wally": 4.3
+        }
+      },
+      {
+        "date": "2026-04-25",
+        "distances": {
+          "justin": 7.2,
+          "marian": 5.16,
+          "nan": 2.5,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-04-26",
+        "distances": {
+          "justin": 4.95,
+          "marian": 3.3,
+          "nan": 5.1,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-04-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 2.85,
+          "nan": 6.1,
+          "wally": 2.3
+        }
+      },
+      {
+        "date": "2026-04-28",
+        "distances": {
+          "justin": 7.5,
+          "marian": 6,
+          "nan": 5.1,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-04-29",
+        "distances": {
+          "justin": 1.8,
+          "marian": 1.9,
+          "nan": 3.1,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-04-30",
+        "distances": {
+          "justin": 1.6,
+          "marian": 2.6,
+          "nan": 3.1,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-05-01",
+        "distances": {
+          "justin": 2.3,
+          "marian": 2.3,
+          "nan": 1,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-05-02",
+        "distances": {
+          "justin": 4.4,
+          "marian": 4.4,
+          "nan": 2.2,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-03",
+        "distances": {
+          "justin": 1.55,
+          "marian": 1.55,
+          "nan": 2.4,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-04",
+        "distances": {
+          "justin": 3.3,
+          "marian": 3.9,
+          "nan": 2.7,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-05-05",
+        "distances": {
+          "justin": 3.4,
+          "marian": 4.9,
+          "nan": 2.6,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-05-06",
+        "distances": {
+          "justin": 2.7,
+          "marian": 6.2,
+          "nan": 3.1,
+          "wally": 4
+        }
+      },
+      {
+        "date": "2026-05-07",
+        "distances": {
+          "justin": 3.8,
+          "marian": 7.7,
+          "nan": 3.9,
+          "wally": 3.9
+        }
+      },
+      {
+        "date": "2026-05-08",
+        "distances": {
+          "justin": 0.35,
+          "marian": 2,
+          "nan": 2.3,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-09",
+        "distances": {
+          "justin": 1.5,
+          "marian": 1.5,
+          "nan": 2.2,
+          "wally": 3
+        }
+      },
+      {
+        "date": "2026-05-10",
+        "distances": {
+          "justin": 7.36,
+          "marian": 7.35,
+          "nan": 4.1,
+          "wally": 0.5
+        }
+      },
+      {
+        "date": "2026-05-11",
+        "distances": {
+          "justin": 1.6,
+          "marian": 1.7,
+          "nan": 2,
+          "wally": 3.4
+        }
+      },
+      {
+        "date": "2026-05-12",
+        "distances": {
+          "justin": 5.94,
+          "marian": 5,
+          "nan": 5.4,
+          "wally": 2.4
+        }
+      },
+      {
+        "date": "2026-05-13",
+        "distances": {
+          "justin": 1.65,
+          "marian": 1,
+          "nan": 2.6,
+          "wally": 3.1
+        }
+      },
+      {
+        "date": "2026-05-14",
+        "distances": {
+          "justin": 0.6,
+          "marian": 1.6,
+          "nan": 4,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-05-15",
+        "distances": {
+          "justin": 3.2,
+          "marian": 2.8,
+          "nan": 5.2,
+          "wally": 4.4
+        }
+      },
+      {
+        "date": "2026-05-16",
+        "distances": {
+          "justin": 6.7,
+          "marian": 2,
+          "nan": 3.6,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-05-17",
+        "distances": {
+          "justin": 5.1,
+          "marian": 2.4,
+          "nan": 6.3,
+          "wally": 2.7
+        }
+      },
+      {
+        "date": "2026-05-18",
+        "distances": {
+          "justin": 3.2,
+          "marian": 0.8,
+          "nan": 6,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-05-19",
+        "distances": {
+          "justin": 5.25,
+          "marian": 4.5,
+          "nan": 7.4,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-05-20",
+        "distances": {
+          "justin": 10.5,
+          "marian": 3.65,
+          "nan": 7.9,
+          "wally": 1
+        }
+      },
+      {
+        "date": "2026-05-21",
+        "distances": {
+          "justin": 9.8,
+          "marian": 2.1,
+          "nan": 7.1,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-05-22",
+        "distances": {
+          "justin": 8.2,
+          "marian": 2.25,
+          "nan": 2.9,
+          "wally": 2.8
+        }
+      },
+      {
+        "date": "2026-05-23",
+        "distances": {
+          "justin": 9.1,
+          "marian": 8.5,
+          "nan": 2.2,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-05-24",
+        "distances": {
+          "justin": 5,
+          "marian": 4.6,
+          "nan": 6.5,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-05-25",
+        "distances": {
+          "justin": 5.7,
+          "marian": 5.7,
+          "nan": 5.9,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-05-26",
+        "distances": {
+          "justin": 4.3,
+          "marian": 9,
+          "nan": 7.9,
+          "wally": 3.7
+        }
+      },
+      {
+        "date": "2026-05-27",
+        "distances": {
+          "justin": 2.9,
+          "marian": 6.1,
+          "nan": 7.0,
+          "wally": 3.4
+        }
+      },
+      {
+        "date": "2026-05-28",
+        "distances": {
+          "justin": 6.05,
+          "marian": 2.7,
+          "nan": 6.5,
+          "wally": 2.8
+        }
+      },
+      {
+        "date": "2026-05-29",
+        "distances": {
+          "justin": 2.3,
+          "marian": 2.4,
+          "nan": 6.3,
+          "wally": 3.6
+        }
+      },
+      {
+        "date": "2026-05-30",
+        "distances": {
+          "justin": 3.5,
+          "marian": 6.05,
+          "nan": 6.5,
+          "wally": 3.7
+        }
+      },
+      {
+        "date": "2026-05-31",
+        "distances": {
+          "justin": 2.1,
+          "marian": 2.5,
+          "nan": 8.1,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-06-01",
+        "distances": {
+          "justin": 4.5,
+          "marian": 2.6,
+          "nan": 7.7,
+          "wally": 3.8
+        }
+      },
+      {
+        "date": "2026-06-02",
+        "distances": {
+          "justin": 10.75,
+          "marian": 4.1,
+          "nan": 5.0,
+          "wally": 3.8
+        }
+      },
+      {
+        "date": "2026-06-03",
+        "distances": {
+          "justin": 4.25,
+          "marian": 2.6,
+          "nan": 2.5,
+          "wally": 3.9
+        }
+      },
+      {
+        "date": "2026-06-04",
+        "distances": {
+          "justin": 5.57,
+          "marian": 4.2,
+          "nan": 6.9,
+          "wally": 4.0
+        }
+      },
+      {
+        "date": "2026-06-05",
+        "distances": {
+          "justin": 7.0,
+          "marian": 5.7,
+          "nan": 6.9,
+          "wally": 3.8
+        }
+      },
+      {
+        "date": "2026-06-06",
+        "distances": {
+          "justin": 5.5,
+          "marian": 1.3,
+          "nan": 4.8,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-06-07",
+        "distances": {
+          "justin": 3.2,
+          "marian": 3.3,
+          "nan": 5.8,
+          "wally": 4.0
+        }
+      },
+      {
+        "date": "2026-06-08",
+        "distances": {
+          "justin": 6.0,
+          "marian": 3.0,
+          "nan": 7.9,
+          "wally": 2.1
+        }
+      },
+      {
+        "date": "2026-06-09",
+        "distances": {
+          "justin": 7.9,
+          "marian": 4.2,
+          "nan": 5.0,
+          "wally": 0.8
+        }
+      },
+      {
+        "date": "2026-06-10",
+        "distances": {
+          "justin": 6.25,
+          "marian": 5.1,
+          "nan": 2.2,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-06-11",
+        "distances": {
+          "justin": 2.1,
+          "marian": 2.5,
+          "nan": 7.1,
+          "wally": 1.6
+        }
+      },
+      {
+        "date": "2026-06-12",
+        "distances": {
+          "justin": 6.1,
+          "marian": 6,
+          "nan": 7.0,
+          "wally": 4.1
+        }
+      },
+      {
+        "date": "2026-06-13",
+        "distances": {
+          "justin": 5.0,
+          "marian": 4,
+          "nan": 7.9,
+          "wally": 3.5
+        }
+      },
+      {
+        "date": "2026-06-14",
+        "distances": {
+          "justin": 7.0,
+          "marian": 5.0,
+          "nan": 7.2,
+          "wally": 2.6
+        }
+      },
+      {
+        "date": "2026-06-15",
+        "distances": {
+          "justin": 6.05,
+          "marian": 3.0,
+          "nan": 6.3,
+          "wally": 0.4
+        }
+      },
+      {
+        "date": "2026-06-16",
+        "distances": {
+          "justin": 7.1,
+          "marian": 4.0,
+          "nan": 8.6,
+          "wally": 2.2
+        }
+      },
+      {
+        "date": "2026-06-17",
+        "distances": {
+          "justin": 4.2,
+          "marian": 2.0,
+          "nan": 8.3,
+          "wally": 2.5
+        }
+      },
+      {
+        "date": "2026-06-18",
+        "distances": {
+          "justin": 1.55,
+          "marian": 2.4,
+          "nan": 8.2,
+          "wally": 1.5
+        }
+      },
+      {
+        "date": "2026-06-19",
+        "distances": {
+          "justin": 0.7,
+          "marian": 1.6,
+          "nan": 8.1,
+          "wally": 2.8
+        }
+      },
+      {
+        "date": "2026-06-20",
+        "distances": {
+          "justin": 11.0,
+          "marian": 1.0,
+          "nan": 8.6,
+          "wally": 4.0
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Stats snapshot for the segment 23 publication, generated by `publish.sh` Step 3 (dataCutoff `2026-06-20`). Mirrors the seg-22 snapshot PR (#685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)