### PR TITLE
docs/planning: NEXT.md → project wind-down state

### DIFF
--- a/docs/planning/NEXT.md
+++ b/docs/planning/NEXT.md
@@ -8,16 +8,19 @@
 
 Segs 1–24 are published (`W26-seg24`, 2026-06-27). The infrastructure chapter closed two retros ago; the project is in **run-mode** and **closes after the real Stage 9 on 2026-07-12**. See the [W23-seg18 retro](https://github.com/gneeek/tdf26/wiki/Retro-W23-seg18-W26-seg24).
 
-**Remaining content (drafting today / in flight):**
+**Done since the triage opened (merged to main, fast — parallel sessions):**
+- **Seg 25 — Meymac** drafted and merged as `content/entries/25-meymac-and-the-cote-des-gardes.md` (#704/#705); re-slugged off the stub; tracking issue #703 closed.
+- **#502 — Tour-history essay** "Poulidor Country" shipped (#702); the umbrella issue #502 stays open.
+- **Dependabot** npm group landed via #707; #689 closed (superseded); the `strand-deps-689.md` brief is spent.
+- **Strand briefs merged** (#701, #706).
 
-| Work | Strand brief | PR | Notes |
-|------|--------------|----|-------|
-| Seg 25 — Meymac (saintsbury, the set-piece) | `docs/strands/strand-seg-25-drafting.md` | #701 | Tracking issue #703; plants the Ventadour + abbey threads for 26/27 |
-| #502 — Tour-history surface (pre-stage launch) | `docs/strands/strand-502-tour-history.md` | #701 | Parallel-safe (data + route, not entries) |
-| Segs 26 → 27 (Saint-Angel, then the Ussel finish) | `docs/strands/strand-segs-26-27-drafting.md` | #706 | **Parked behind seg 25 + #502** — reviews their merged output first |
-| Dependabot #689 (npm minor-and-patch group) | `docs/strands/strand-deps-689.md` | #706 | Independent; rebase then merge-on-green |
+**Remaining content (unblocked, ready to run):**
 
-**Dependency order:** seg 25 + #502 merge before segs 26–27 run. Dependabot anytime.
+| Work | Strand brief | Status |
+|------|--------------|--------|
+| Segs 26 → 27 (Saint-Angel, then the Ussel finish) | `docs/strands/strand-segs-26-27-drafting.md` | **Unblocked** — its Phase-0 prerequisite (merged seg 25 + #502) is satisfied; segs 26/27 are still stubs |
+
+Segs 26 and 27 are the only remaining content. Seg 27 closes the 27-segment arc.
 
 ## Decisions made (2026-06-28 endgame triage)
 
@@ -28,7 +31,7 @@ Segs 1–24 are published (`W26-seg24`, 2026-06-27). The infrastructure chapter 
 
 ## Sequenced execution (what is left)
 
-1. **Finish the content** (this week): run seg 25 + #502, merge; then run segs 26–27; land the dependabot bump anytime.
+1. **Finish the content** (this week): seg 25 + #502 + the dependabot bump are done; run the segs 26–27 strand to draft the last two entries.
 2. **Land the finish** (through 2026-07-03): seg 27 closes the 27-segment arc; the Tour-history surface goes live for the stage-week reader peak.
 3. **Close the project** (after the 2026-07-12 stage): execute the three endgame issues — closing retro (#708), archive/handoff (#709), unfold harvest ([unfold#46](https://github.com/gneeek/unfold/issues/46)).
 

--- a/docs/planning/NEXT.md
+++ b/docs/planning/NEXT.md
@@ -2,84 +2,45 @@
 
 > **Singleton convention:** at most one open planning continuation lives at this path. When a planning session closes that this note tracked, rename to a date-stamped archive (e.g. `docs/planning/2026-06-XX-archive.md`) or delete. New sessions overwrite this file.
 
-> **NEXT ACTION (flagged 2026-06-03): run a full planning session once segment 18 ships today.** The 2026-06-03 session was scoped to the seg-18 publication process *only* (publisher's call — publish day, fresh rider stats in hand). Much of v1.4.20 has drained since the 2026-05-28 handoff (gate fixes, spine #508/#322/#479, geometry-drift, data corrections, release ceremony, segs 17/18/19 drafted), and the carryforward list in `project_next_planning_notes.md` has grown well past the ~15-item trigger noted below — so the planning session is due. Read those close-outs as the primary input.
+> **This note supersedes the 2026-05-28 → seg-18 run-in continuation** (preserved in git history). That note's flagged "run a full planning session once seg 18 ships" action is now done: the **2026-06-28 endgame triage** retired the backlog, wound down the milestones, and put the project into its finish-and-close stretch.
 
-## Status at handoff (2026-05-28 planning session close)
+## Status (2026-06-28) — the project is finishing
 
-Segs 1–16 are published (seg 16 shipped 2026-05-28). **v1.4.19 is closed** (drained, 23 issues). **v1.4.20 is themed: "Publish-pipeline hardening"** and trimmed to a 10-issue set. The next planning session has no fixed trigger — it fires when v1.4.20 drains, or sooner if the carryforward list (below) grows past ~15 items.
+Segs 1–24 are published (`W26-seg24`, 2026-06-27). The infrastructure chapter closed two retros ago; the project is in **run-mode** and **closes after the real Stage 9 on 2026-07-12**. See the [W23-seg18 retro](https://github.com/gneeek/tdf26/wiki/Retro-W23-seg18-W26-seg24).
 
-## Decisions made this session
+**Remaining content (drafting today / in flight):**
 
-- **v1.4.20 spine = publish-pipeline hardening.** Chosen over data-to-display reconciliation because seg 16 404'd in production; an unsafe publish.sh is the top reader-reliability risk with 11 segments left. Scope file: `docs/planning/v1.4.20-scope.md`.
-- **Three publish-day fixes are a hard gate before seg 17 (Sun 2026-05-31):** #617 (draft pre-flight), #618 (gh-merge idempotency), #619 (weather --entry). Weekend strand brief written: `docs/strands/strand-publish-safety-617-618-619.md`. **Publisher to spawn it this weekend.**
-- **#502 tour-history → v1.5.0, shape = standalone July-2 essay entry.** Publishes between seg 26 (07-01) and seg 27 (07-03, already moved via #616). Design now, schedule into the July milestone. Seg 16's closing line already foreshadows it date-free.
-- **Data-to-display reconciliation is the candidate spine for the *next* milestone.** Cluster seeded in backlog: #517, #588, #486, #476, #487. Climb data fixes don't reach readers because StageDetails.vue/ElevationChart.vue hardcode parallel values.
+| Work | Strand brief | PR | Notes |
+|------|--------------|----|-------|
+| Seg 25 — Meymac (saintsbury, the set-piece) | `docs/strands/strand-seg-25-drafting.md` | #701 | Tracking issue #703; plants the Ventadour + abbey threads for 26/27 |
+| #502 — Tour-history surface (pre-stage launch) | `docs/strands/strand-502-tour-history.md` | #701 | Parallel-safe (data + route, not entries) |
+| Segs 26 → 27 (Saint-Angel, then the Ussel finish) | `docs/strands/strand-segs-26-27-drafting.md` | #706 | **Parked behind seg 25 + #502** — reviews their merged output first |
+| Dependabot #689 (npm minor-and-patch group) | `docs/strands/strand-deps-689.md` | #706 | Independent; rebase then merge-on-green |
 
-## Content production line (the critical path — binding constraint on the run-in)
+**Dependency order:** seg 25 + #502 merge before segs 26–27 run. Dependabot anytime.
 
-The entries are the deliverable; this line gates the schedule, the pipeline milestone runs alongside it.
+## Decisions made (2026-06-28 endgame triage)
 
-**Drafting:** segs 1–16 published. **Segs 17–27 are all stubs** (`draft: true`, title-only) — 11 entries to write, twice-weekly, with no schedule slack:
+- **Backlog retired.** 17 open issues closed not-planned + `wontfix` (developer-experience, admin tooling, process-mechanism, deferred features, and the data-correctness items judged out of runway). Only #502 carried.
+- **Milestones wound down.** v1.4.20 + v1.4.21 closed (drained, moved to the Roadmap "Completed" list). v1.6.0 renamed *"Admin tooling (retired, not shipped)"* and closed. v1.5.0 renamed **"Finish line and project close"** — the only open milestone — holding #502, #703, #708, #709.
+- **Endgame issues filed.** [#708](https://github.com/gneeek/tdf26/issues/708) closing retrospective; [#709](https://github.com/gneeek/tdf26/issues/709) archive/handoff of final state; [unfold#46](https://github.com/gneeek/unfold/issues/46) portable-learnings harvest (filed on unfold per the ownership split).
+- **Wiki Roadmap updated** to the wind-down shape (Now = finish line → After the stage = project close → Later = retired feature milestones).
 
-| Seg | Publish | Research ready? |
-|-----|---------|-----------------|
-| 17 | 2026-05-31 | ✅ 17-19 dossier |
-| 18 | 2026-06-03 | ✅ 17-19 dossier |
-| 19 | 2026-06-07 | ✅ 17-19 dossier |
-| 20 | 2026-06-10 | ❌ **needs 20-22 dossier** |
-| 21 | 2026-06-14 | ❌ needs 20-22 dossier |
-| 22 | 2026-06-17 | ❌ needs 20-22 dossier |
-| 23 | 2026-06-21 | ❌ **needs 23-27 dossier** |
-| 24 | 2026-06-24 | ❌ needs 23-27 dossier |
-| 25 | 2026-06-28 | ❌ needs 23-27 dossier — **Meymac, saintsbury voice reservation** (`project_meymac_voice.md`) |
-| 26 | 2026-07-01 | ❌ needs 23-27 dossier |
-| — July special | 2026-07-02 | ✅ `tour-history-research.md` |
-| 27 | 2026-07-03 | ❌ needs 23-27 dossier — Ussel finish line |
+## Sequenced execution (what is left)
 
-**Research gaps to spawn (block-research-then-N-drafts shape, the stable dossier pattern):**
-- **Segs 20–22 dossier** — must land before seg 20 drafts (~2026-06-10). Spawn ~first week of June.
-- **Segs 23–27 dossier** — must land before seg 23 drafts (~2026-06-21). Larger block (finish-line stretch); settle the seg-25 Meymac voice at the same time.
+1. **Finish the content** (this week): run seg 25 + #502, merge; then run segs 26–27; land the dependabot bump anytime.
+2. **Land the finish** (through 2026-07-03): seg 27 closes the 27-segment arc; the Tour-history surface goes live for the stage-week reader peak.
+3. **Close the project** (after the 2026-07-12 stage): execute the three endgame issues — closing retro (#708), archive/handoff (#709), unfold harvest ([unfold#46](https://github.com/gneeek/unfold/issues/46)).
 
-**Committed strands this cycle.** Three briefs are written and scheduled to run within the v1.4.20 cycle — they are this-cycle work, not deferred:
-- `docs/strands/strand-seg-17-drafting.md` — run now, for the 2026-05-31 slot.
-- `docs/strands/strand-segs-20-22-content-research.md` — run before seg 20 (~06-10).
-- `docs/strands/strand-segs-23-27-content-research.md` — run before seg 23 (~06-21).
+## Open carryforwards
 
-## Sequenced execution
-
-1. **This weekend:** spawn the publish-safety strand; merge #617/#618/#619 before seg 17.
-2. **Seg 17 cycle (Sun 2026-05-31):** draft + publish on the hardened pipeline. Brief ready: `docs/strands/strand-seg-17-drafting.md` (note: seg 17 = **Madranges + the Treignac approach**; the stub is mis-titled "treignac-granite-and-water" — that's seg 18 — re-title at the anchor checkpoint).
-3. **Segs 17–19 drafting cadence:** publisher-paced, one strand per segment; handle dossier-flagged data corrections (#549, #551, #602, #603) inline. Briefs for segs 18/19 to scaffold from the same 17-19 dossier.
-4. **Spawn the 20–22 research dossier** before seg 20 (~06-10): `docs/strands/strand-segs-20-22-content-research.md`. **Spawn the 23–27 dossier** before seg 23 (~06-21): `docs/strands/strand-segs-23-27-content-research.md` (settles the seg-25 Meymac voice + corrects the segs 24/25/26 stub-title drift).
-5. **July-2 tour-history essay (#502):** design now, draft from `tour-history-research.md` ahead of 07-02.
-6. **Pipeline spine + ceremony (#322/#479/#508/#326/#480/#521/#339):** across the seg 17–20 cycles, alongside (not gating) drafting.
-
-## Open carryforwards (not decision-pending; carry unless cleared)
-
-- **Data-to-display reconciliation cluster** (#517/#588/#486/#476/#487) — next-milestone candidate spine.
-- **Summit-km data backlog** (#589/#590/#591) — opportunistic; clears the #518 assertion skip-list. Not milestone-gated.
-- **Off-theme backlog** (#483 instrumentation, #481 planning shape, #466 map perf, #409 rider-stats, #509 worktree bootstrap) — reassess next planning.
-- **Tour-history July-2 essay design** — v1.5.0; decide drafting cadence and voice closer to July.
-- **Recommended-option calibration** — monitor for rubber-stamping. (Note: this session hit one option-set-too-binary signal on the pipeline-timing question; re-fired cleanly.)
-- **Tully/Piers explainer pages** — unfold#44 blocks tdf26#529.
-- **Voices design session** — `docs/strands/strand-voices-design-session.md`; spawn when scheduled.
-- **Strand-as-first-class unfold candidate** — re-evaluate after the v1.4.20 multi-strand cycle.
-- **Doc drift:** `data/riders/rider-config.json` `startDate` is `2026-04-01`; CLAUDE.md says `2026-04-02`. Reconcile (file a small issue or fix in a data-hygiene pass). Walker arithmetic in the seg-16 notes assumes 04-01.
-
-## Reading order for the next session
-
-1. This note.
-2. `project_next_planning_notes.md` (agent memory) — strand close-out inputs since this session.
-3. `docs/planning/v1.4.20-scope.md` — what we said we would do.
-4. The next Retro's "What we lack" section.
-5. `docs/planning/2026-05-28-archive.md` — this session's archived inputs.
+The carryforward backlog is **cleared** — everything not retired is now one of the four open issues above. The only forward work is finishing the content and executing the three close issues. `project_next_planning_notes.md` (agent memory) holds the per-strand close-out detail and the W23-seg18 retro-handoff block.
 
 ## Pointers
 
-- v1.4.20 scope: `docs/planning/v1.4.20-scope.md`
-- Milestone-scope template: `docs/planning/MILESTONE-SCOPE-TEMPLATE.md`
-- Strand briefs: `docs/strands/`
-- Planning-notes memory: `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/project_next_planning_notes.md`
-- v1.4.20 milestone: https://github.com/gneeek/tdf26/milestone/53
+- Open milestone: https://github.com/gneeek/tdf26/milestone/26 (Finish line and project close)
+- Strand briefs: `docs/strands/` (seg-25, segs-26-27, 502, deps-689)
+- Latest retro: https://github.com/gneeek/tdf26/wiki/Retro-W23-seg18-W26-seg24
 - Roadmap (wiki): https://github.com/gneeek/tdf26/wiki/Roadmap
-- Slip-rate tally (wiki): https://github.com/gneeek/tdf26/wiki/Slip-rate-tally
+- Planning-notes memory: `/home/jhs/.claude/projects/-home-jhs-code-tdf26/memory/project_next_planning_notes.md`
+- Prior planning archives: `docs/planning/2026-05-28-archive.md` (and 05-12, 05-07)


### PR DESCRIPTION
Brings the repo-side plan in line with the wiki Roadmap and the milestone/issue state after the 2026-06-28 endgame triage.

- Supersedes the 2026-05-28 → seg-18 run-in continuation (its flagged 'run a full planning session' action is now done).
- Records: backlog retired (17 issues), milestones wound down to a single open 'Finish line and project close' milestone, endgame issues filed (#708/#709/unfold#46), Roadmap updated.
- Forward work table: seg 25 + #502 (PR #701), segs 26-27 + dependabot #689 (PR #706), with the 25+502 → 26-27 dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)