### PR TITLE
Move Poulidor Country special to 2026-07-03

### DIFF
--- a/content/entries/special-poulidor-country.md
+++ b/content/entries/special-poulidor-country.md
@@ -3,7 +3,7 @@ special: tour-history
 issue: 502
 title: "Poulidor Country"
 subtitle: "A cycling corridor that has never made a champion, and the finish line it waited a century for"
-publishDate: 2026-07-02
+publishDate: 2026-07-03
 images: []
 imagesOptional: true
 weather: null


### PR DESCRIPTION
Publisher reschedule of the Stage 9 closing publication run:

- seg 26 (Saint-Angel) — **July 1** (PR #712)
- tour-history special (*Poulidor Country*) — **July 3** (this PR)
- seg 27 (Ussel, the finish) — **July 5**, the Tour's opening day (PR #714)

Frontmatter `publishDate` only (2026-07-02 → 2026-07-03); no content change. Entry stays `draft: true`. `validate_entries` green.

Opened as a sibling PR off main rather than mixed into the seg-26/27 strand PRs, since `special-poulidor-country.md` is outside the drafting strand's write-set.

Refs #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)